### PR TITLE
fix(premium): /api/redirect bounce so sign-in lands on content, not /api/me JSON

### DIFF
--- a/.claude/skills/manage-cloudflare-access/cf_access.py
+++ b/.claude/skills/manage-cloudflare-access/cf_access.py
@@ -291,6 +291,50 @@ def cmd_create_gated_app(token, domain, args):
     print("        `wrangler secret put PREMIUM_PASSPHRASE`, then `wrangler deploy`.")
 
 
+def cmd_add_destination(token, domain, args):
+    """Add a path-scoped destination to an EXISTING gated app (by id), keeping its
+    AUD, policies, and existing paths intact. Idempotent: a path already present is a
+    no-op. Use to extend the '/api/*' gate when a new Worker endpoint is added (e.g.
+    /api/redirect) — the AUD is unchanged, so the Worker's POLICY_AUD stays valid.
+
+    Why a PATCH (not delete+recreate): recreating would mint a NEW AUD and break the
+    Worker until wrangler.toml is updated + redeployed. Appending preserves the AUD.
+    """
+    app_id = args.target
+    new_path = args.path
+    if "/" not in new_path:
+        sys.exit(f"{new_path!r} is not a path-scoped match (need e.g. 'blog.{domain}/api/redirect').")
+
+    full = api(token, "GET", f"/accounts/{ACCOUNT_ID}/access/apps/{app_id}")
+    domains = list(full.get("self_hosted_domains") or [])
+    if new_path in domains:
+        print(f"{new_path!r} already gated by {full.get('name')!r} (id={app_id}). No change.")
+        print(f"  AUD = {full.get('aud')}")
+        return
+
+    domains.append(new_path)
+    # CF derives `destinations` from self_hosted_domains on write; send both to be safe,
+    # preserving the existing destinations + appending the new public URI.
+    dests = list(full.get("destinations") or [])
+    if not any(d.get("uri") == new_path for d in dests):
+        dests.append({"type": "public", "uri": new_path})
+
+    # The Access apps endpoint rejects PATCH under API-token auth (10405 "Method not
+    # allowed for this authentication scheme") — it requires a FULL-OBJECT PUT. So we
+    # echo the existing app config back, mutating only the two path fields. We strip
+    # server-managed/read-only keys CF won't accept on write (ids/timestamps/aud).
+    body = {k: v for k, v in full.items() if k not in (
+        "id", "uid", "aud", "created_at", "updated_at",
+        "destinations", "self_hosted_domains",
+    )}
+    body["self_hosted_domains"] = domains
+    body["destinations"] = dests
+    api(token, "PUT", f"/accounts/{ACCOUNT_ID}/access/apps/{app_id}", body)
+    print(f"Added {new_path!r} to {full.get('name')!r} (id={app_id}). ✓")
+    print(f"  self_hosted_domains now: {domains}")
+    print(f"  AUD (unchanged) = {full.get('aud')}")
+
+
 def cmd_delete_app_by_id(token, domain, args):
     """Delete an Access app by id (cleanup). Refuses the wildcard."""
     app = api(token, "GET", f"/accounts/{ACCOUNT_ID}/access/apps/{args.target}")
@@ -318,11 +362,16 @@ def main():
     s.add_argument("--policy", default="linkedin-any",
                    choices=["linkedin-any", "any-auth"])
     s = sub.add_parser("delete-app"); s.add_argument("target", help="Access app id")
+    s = sub.add_parser("add-destination",
+                       help="append a path-scoped destination to an existing gated app (keeps AUD)")
+    s.add_argument("target", help="Access app id")
+    s.add_argument("path", help="path-scoped match, e.g. blog.bytesofpurpose.com/api/redirect")
     args = p.parse_args()
     {"list": cmd_list, "show": cmd_show,
      "make-public": cmd_make_public, "make-private": cmd_make_private,
      "list-idps": cmd_list_idps, "show-idp": cmd_show_idp,
      "create-gated-app": cmd_create_gated_app,
+     "add-destination": cmd_add_destination,
      "delete-app": cmd_delete_app_by_id}[args.cmd](
         token, domain, args)
 

--- a/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
@@ -80,10 +80,11 @@ sequenceDiagram
 
     U->>App: open premium page
     App-->>U: sneak-peek + lock (body is ciphertext)
-    U->>Acc: click "Sign in with LinkedIn"
+    U->>Acc: click "Sign in" → nav to /api/redirect?redirect_url=…
     Acc->>LI: OIDC redirect
     LI-->>Acc: id_token (email, picture)
-    Acc-->>App: set CF_Authorization (Access JWT, httpOnly)
+    Acc-->>App: set CF_Authorization (httpOnly); Worker 303 → content page
+    Note over App: lands back on the page (NOT /api/me JSON)
     App->>W: GET /api/me (Cf-Access-Jwt-Assertion)
     W->>W: verify JWT vs team JWKS, check aud
     W-->>App: 200 {email, picture}
@@ -106,6 +107,85 @@ flowchart TD
     F --> G{200?}
     G -- yes --> H[Decrypt + render real body]
     G -- no --> C
+```
+
+## Workers & API endpoints
+
+There is exactly **one Worker** — `access-gate` (`workers/access-gate/`) — deployed on
+Cloudflare and mounted on the `/api/*` route, sitting **behind a single Cloudflare Access
+app** (LinkedIn OIDC, with a Service-Auth policy for dev). It exposes **three GET
+endpoints**. All three run *only* after Access admits the request (anonymous → 302 to
+LinkedIn before the Worker executes); the Worker re-verifies the Access JWT
+(signature + issuer + `aud` vs. the team JWKS) as belt-and-suspenders.
+
+| Endpoint | Role | Auth required | Response | Who calls it | When |
+|---|---|---|---|---|---|
+| **`GET /api/me`** | Identity readback (Access JWT → person) | Access JWT **with an email** (LinkedIn user; service tokens get 401 `no_email`) | `200 {email, name?, picture?, isInternal}` · `401` otherwise | `fetch()` from `AuthProvider` (`src/lib/auth.tsx`) + `posthog.js` | On every page load, to set navbar state + PostHog `identify`/`is_internal` |
+| **`GET /api/unlock-key`** | Vend the StatiCrypt passphrase (the hard-gate key) | Any valid Access JWT (LinkedIn user **or** dev service token — no email needed) | `200 {passphrase}` · `401` otherwise | `fetch()` from `fetchUnlockKey()`, used by `PremiumGate` | When a signed-in reader opens a `premium: true` page, to decrypt in-browser |
+| **`GET /api/redirect`** | Post-sign-in **bounce** back to content | Any valid Access JWT (only runs authenticated) | `303 Location: <same-origin path>` (sanitized; off-origin → `/`) | Top-level browser **navigation** from `signIn()` (`src/lib/auth.tsx`) | Immediately after LinkedIn auth, to land the reader on the page they came from |
+
+**Why three, and why `/api/redirect` is separate.** `/api/me` and `/api/unlock-key` are
+**data** endpoints — meant to be `fetch()`'d, returning JSON. Sign-in, by contrast, is a
+**top-level navigation**: the browser must visit a *protected* path so Access runs the
+LinkedIn round-trip, and Access returns the browser to **that same path**. If that path is
+a JSON endpoint, the reader lands on JSON (the SPA renders "Page Not Found"). So a dedicated
+`/api/redirect` is the one protected path whose job is to **303 the browser onward** to the
+real content page. It's a distinct *response type* (redirect, not JSON), so it's a distinct
+endpoint — not an overload of `/api/me` on a request header.
+
+> **Open-redirect guard.** `/api/redirect` emits a caller-supplied `redirect_url` as a
+> `Location` header to an authenticated user — a textbook open-redirect/header-injection
+> sink if unvalidated. `safeRedirectPath()` (Worker) coerces anything that could leave the
+> origin to `/`: rejects absolute URLs, any scheme (`https:`, `javascript:`), protocol-
+> relative `//evil.com`, backslash tricks, and control chars (CR/LF). `signIn()` mirrors the
+> same check client-side (defense in depth). Both are covered by unit tests
+> (`workers/access-gate/test`) + an e2e flow test (`test/e2e/signin-redirect.spec.ts`).
+
+### Who calls what
+
+```mermaid
+flowchart LR
+    subgraph Client["🌐 Browser (site bundle)"]
+        AP["AuthProvider<br/>(src/lib/auth.tsx)"]
+        PG["PremiumGate"]
+        PH["posthog.js"]
+        SI["signIn()"]
+    end
+    subgraph CF["☁️ Cloudflare Access app (/api/*)"]
+        ME["/api/me<br/>identity"]
+        UK["/api/unlock-key<br/>key-vend"]
+        RD["/api/redirect<br/>303 bounce"]
+    end
+    AP -->|"fetch (on load)"| ME
+    PH -->|"fetch (on load)"| ME
+    PG -->|"fetch (when signed in)"| UK
+    SI -->|"top-level navigation"| RD
+    RD -->|"303 → content page"| Client
+```
+
+### Sequence: the `/api/redirect` sign-in bounce
+
+```mermaid
+sequenceDiagram
+    participant U as Reader
+    participant App as Site (static SPA)
+    participant Acc as CF Access
+    participant LI as LinkedIn
+    participant W as Worker (/api/redirect)
+
+    U->>App: click "Sign in" on /craft/premium-gating-demo
+    Note over App: signIn() → window.location = <br/>/api/redirect?redirect_url=/craft/premium-gating-demo
+    App->>Acc: GET /api/redirect?redirect_url=…
+    alt no Access session yet
+        Acc->>LI: 302 OIDC redirect
+        LI-->>Acc: id_token (email)
+        Acc-->>Acc: set CF_Authorization, return to /api/redirect
+    end
+    Acc->>W: admitted request (valid JWT)
+    W->>W: safeRedirectPath(redirect_url) → same-origin path
+    W-->>App: 303 Location: /craft/premium-gating-demo
+    App->>App: SPA boots on the content page
+    App->>W: (now) GET /api/me + /api/unlock-key → gate unlocks
 ```
 
 ## Why StatiCrypt + Worker key-vend

--- a/bytesofpurpose-blog/playwright.config.ts
+++ b/bytesofpurpose-blog/playwright.config.ts
@@ -99,7 +99,7 @@ export default defineConfig({
       // The build MUST be produced with STATICRYPT_PASSPHRASE=e2e-premium-passphrase (the spec
       // stubs /api/unlock-key with that value). Run via `make test-premium-e2e`.
       name: 'premium',
-      testMatch: /premium-gating\.spec\.ts$/,
+      testMatch: /(premium-gating|signin-redirect)\.spec\.ts$/,
       use: { ...devices['Desktop Firefox'], baseURL: PROD_BASE },
     },
   ],

--- a/bytesofpurpose-blog/src/lib/auth.tsx
+++ b/bytesofpurpose-blog/src/lib/auth.tsx
@@ -21,8 +21,29 @@ import React from 'react';
 //   sign in  → hitting any /api/* path triggers the Access → LinkedIn redirect.
 //   sign out → /cdn-cgi/access/logout clears the CF_Authorization cookie.
 
-export const ACCESS_LOGIN_PATH = '/api/me';
+// Sign-in navigates the top-level window to a PROTECTED /api/* path so Cloudflare
+// Access runs the LinkedIn round-trip. It must NOT be a data endpoint (/api/me,
+// /api/unlock-key return JSON — landing the browser there shows the SPA 404). The
+// Worker's /api/redirect route is the one protected path that, once authenticated,
+// 303s the browser onward to the real content page. See the premium-content-gating
+// design ("Workers & API endpoints").
+export const ACCESS_LOGIN_PATH = '/api/redirect';
 export const ACCESS_LOGOUT_PATH = '/cdn-cgi/access/logout';
+
+// Client-side mirror of the Worker's safeRedirectPath(): coerce `next` to a
+// same-origin path before putting it in the sign-in URL. Defense in depth — the
+// Worker re-validates authoritatively — and it avoids a pointless round-trip on an
+// obviously bad value. Keep in lockstep with workers/access-gate/src/index.ts.
+function sameOriginPath(next: string): string {
+  if (!next || !next.startsWith('/')) return '/';
+  if (next.startsWith('//') || next.startsWith('/\\')) return '/';
+  for (let i = 0; i < next.length; i++) {
+    const c = next.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) return '/'; // control chars
+  }
+  if (/^\/+[a-z][a-z0-9+.-]*:/i.test(next)) return '/';
+  return next;
+}
 
 export interface AuthUser {
   email: string;
@@ -45,18 +66,21 @@ const AuthContext = React.createContext<AuthState>({
 });
 
 /**
- * Begin the Cloudflare Access → LinkedIn sign-in flow. Navigating to a gated
- * /api/* path makes Access 302 to LinkedIn, then return the reader here with a
- * CF_Authorization cookie set. `next` is where to land after auth completes.
+ * Begin the Cloudflare Access → LinkedIn sign-in flow. Navigating to the gated
+ * `/api/redirect` path makes Access 302 to LinkedIn (if not already signed in);
+ * once authenticated the Worker 303s the browser to `next` — the content page the
+ * reader was on. `next` is sanitized to a same-origin path both here and in the
+ * Worker (open-redirect defense in depth).
  */
 export function signIn(next: string = typeof window !== 'undefined'
   ? window.location.pathname + window.location.search
   : '/'): void {
   if (typeof window === 'undefined') return;
-  // /api/* is reachable in both prod and dev (the dev server proxies it to the
-  // real Worker), so navigate unconditionally. redirect_url is honoured by
-  // Access on the way back from the IdP.
-  const url = `${ACCESS_LOGIN_PATH}?redirect_url=${encodeURIComponent(next)}`;
+  // /api/* is reachable in both prod and dev (the dev server proxies it to the real
+  // Worker), so navigate unconditionally. `next` rides as redirect_url; the Worker's
+  // /api/redirect 303s there after auth (NOT /api/me, which returns JSON → SPA 404).
+  const dest = sameOriginPath(next);
+  const url = `${ACCESS_LOGIN_PATH}?redirect_url=${encodeURIComponent(dest)}`;
   window.location.assign(url);
 }
 

--- a/bytesofpurpose-blog/test/e2e/signin-redirect.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/signin-redirect.spec.ts
@@ -1,0 +1,92 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * Sign-in REDIRECT flow — the post-LinkedIn bounce back to content.
+ *
+ * Regression guard for the bug where signing in navigated the top-level window to
+ * `/api/me` (a JSON data endpoint) and, after auth, left the reader stranded on
+ * `/api/me` → the SPA rendered "Page Not Found". The fix: signIn() targets the
+ * Worker's `/api/redirect` route, which 303s an authenticated navigation back to the
+ * (same-origin) content page. See workers/access-gate/src/index.ts + src/lib/auth.tsx
+ * and the premium-content-gating design ("Workers & API endpoints").
+ *
+ * The real Worker/Access aren't reachable in CI, so we intercept `/api/redirect` and
+ * emulate the Worker's behavior (303 → the sanitized same-origin redirect_url). What
+ * this proves is the CLIENT wiring: (a) signIn() builds the right URL — `/api/redirect`,
+ * NOT `/api/me`, carrying the current page as redirect_url; (b) following that redirect
+ * lands the browser back on the content page, never on a JSON endpoint. The Worker's own
+ * 303 + open-redirect sanitizer are proven separately in workers/access-gate/test.
+ *
+ * Runs in the same encrypted-prod `premium` project as premium-gating.spec.ts (:4173).
+ */
+
+const DEMO = '/craft/premium-gating-demo';
+
+test.describe('Sign-in redirect flow', () => {
+  test('clicking sign-in targets /api/redirect (not /api/me) with the page as redirect_url', async ({
+    page,
+  }) => {
+    // Capture the would-be top-level navigation to /api/* instead of actually leaving
+    // for Access/LinkedIn (which CI can't reach). Abort it so the test stays on-page.
+    let loginUrl: string | null = null;
+    await page.route('**/api/redirect*', (route) => {
+      loginUrl = route.request().url();
+      route.abort();
+    });
+    // If the old bug regressed, the click would navigate to /api/me — catch that too.
+    let hitApiMeAsNavigation = false;
+    await page.route('**/api/me*', (route) => {
+      // A navigation (document) request to /api/me is the bug; a fetch() for identity
+      // is normal. Distinguish by resource type.
+      if (route.request().resourceType() === 'document') hitApiMeAsNavigation = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}), // anonymous: no email
+      });
+    });
+
+    await page.goto(DEMO, {waitUntil: 'networkidle'});
+
+    // Open the gate's sign-in modal and click the LinkedIn button.
+    await page.locator('[class*="gate"]').first().click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByRole('button', {name: /sign in with linkedin to unlock/i}).click();
+
+    await expect.poll(() => loginUrl, {timeout: 5000}).not.toBeNull();
+    expect(hitApiMeAsNavigation, 'sign-in must NOT navigate to /api/me').toBe(false);
+
+    const u = new URL(loginUrl!);
+    expect(u.pathname).toBe('/api/redirect');
+    // redirect_url must carry the content page we were on (same-origin path).
+    const redirectUrl = u.searchParams.get('redirect_url');
+    expect(redirectUrl).toBe(DEMO);
+  });
+
+  test('following /api/redirect lands back on the content page, not a JSON 404', async ({
+    page,
+  }) => {
+    // Emulate the Worker: an authenticated GET /api/redirect 303s to the same-origin
+    // redirect_url. Playwright follows the redirect, so the browser ends on the page.
+    await page.route('**/api/redirect*', (route) => {
+      const dest = new URL(route.request().url()).searchParams.get('redirect_url') || '/';
+      route.fulfill({
+        status: 303,
+        headers: {Location: dest},
+        body: '',
+      });
+    });
+
+    // Drive the navigation the way signIn() does.
+    await page.goto(`/api/redirect?redirect_url=${encodeURIComponent(DEMO)}`, {
+      waitUntil: 'networkidle',
+    });
+
+    // We must have LANDED on the content page — its URL, and its content shell.
+    await expect(page).toHaveURL(new RegExp(`${DEMO}$`));
+    // The Docusaurus 404 must NOT be what we see.
+    await expect(page.getByRole('heading', {name: /page not found/i})).toHaveCount(0);
+    // The premium teaser (the real page) is present.
+    await expect(page.getByText(/live demo of premium gating/i)).toBeVisible();
+  });
+});

--- a/workers/access-gate/src/index.ts
+++ b/workers/access-gate/src/index.ts
@@ -1,17 +1,25 @@
 /**
  * access-gate — Cloudflare Worker behind a Cloudflare Access application.
  *
- * Two GET endpoints, both reachable only through the Access app (an
+ * Three GET endpoints, all reachable only through the Access app (an
  * unauthenticated request is 302'd to LinkedIn by Access before this code
  * even runs — so the JWT below is belt-and-suspenders, not the only gate):
  *
  *   GET /api/me          → { email, name?, picture?, isInternal }  (identity + analytics flag)
  *   GET /api/unlock-key  → { passphrase }                (the StatiCrypt key-vend)
+ *   GET /api/redirect    → 303 Location: <same-origin path>  (post-sign-in bounce)
  *
  * The hard gate for premium content: /api/unlock-key returns the single
  * PREMIUM_PASSPHRASE secret ONLY to a request carrying a valid Access JWT
  * (a signed-in LinkedIn user). The client uses it to decrypt the build-time
  * ciphertext in the page bundle. See the premium-content-gating system design.
+ *
+ * /api/redirect exists because /api/me and /api/unlock-key are DATA endpoints
+ * (JSON, meant to be fetch()'d). The sign-in flow navigates the top-level browser
+ * window to a protected /api/* path so Access runs the LinkedIn round-trip — but
+ * Access returns the browser to the SAME protected path it gated, and landing on a
+ * JSON endpoint renders the SPA's 404. /api/redirect is the one protected path that,
+ * for an authenticated navigation, 303s the browser onward to the real content page.
  *
  * JWT validation: every Access request carries `Cf-Access-Jwt-Assertion`. We
  * verify it against the team JWKS (https://<team>.cloudflareaccess.com/cdn-cgi/
@@ -54,6 +62,38 @@ const INTERNAL_EMAILS: ReadonlyArray<string> = ['omar_eid21@yahoo.com'];
 function isInternalEmail(email: string): boolean {
   const e = email.toLowerCase();
   return INTERNAL_EMAILS.some((x) => x.toLowerCase() === e);
+}
+
+/**
+ * Sanitize a caller-supplied `redirect_url` to a SAME-ORIGIN PATH ONLY. The
+ * /api/redirect route emits this as a `Location` header to an authenticated user,
+ * so an unvalidated value is a textbook open redirect (…?redirect_url=https://evil
+ * → a signed-in reader phished). Anything that could leave our origin — or inject a
+ * header — is coerced to '/'. Rejected: absolute URLs / any scheme (`https:`,
+ * `javascript:`, …), protocol-relative `//evil.com`, backslash tricks (`/\evil`),
+ * control chars (CR/LF header-splitting), and anything not starting with a single
+ * '/'. The result is always a local path we can safely resolve against ALLOWED_ORIGIN.
+ */
+function safeRedirectPath(raw: string | null): string {
+  if (!raw) return '/';
+  let v = raw;
+  // Access URL-encodes the nested redirect_url; decode once so we inspect the real
+  // value (a `%2F%2Fevil.com` would otherwise slip a `//` past the checks).
+  try {
+    v = decodeURIComponent(raw);
+  } catch {
+    /* malformed escape — fall back to the raw form, still checked below */
+  }
+  v = v.trim();
+  if (!v.startsWith('/')) return '/'; // must be a local absolute path
+  if (v.startsWith('//') || v.startsWith('/\\')) return '/'; // protocol-relative / backslash
+  // Reject any C0 control char or DEL — CR/LF would enable response-header splitting.
+  for (let i = 0; i < v.length; i++) {
+    const c = v.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) return '/';
+  }
+  if (/^\/+[a-z][a-z0-9+.-]*:/i.test(v)) return '/'; // a scheme after the slash(es)
+  return v;
 }
 
 // Cache the JWKS keyset across requests in the same isolate (jose memoizes the
@@ -155,6 +195,21 @@ export default {
       // No email required — the key isn't tied to a person. Any admitted caller
       // (LinkedIn user or the dev service token) may decrypt premium content.
       return json({passphrase: env.PREMIUM_PASSPHRASE}, 200, req);
+    }
+
+    if (url.pathname === '/api/redirect') {
+      // Post-sign-in bounce. The browser navigated here (Access already admitted the
+      // request — this code only runs authenticated), so 303 it onward to the
+      // same-origin content page it wanted. safeRedirectPath blocks open-redirect /
+      // header-injection: any off-origin or malformed value collapses to '/'.
+      const dest = safeRedirectPath(url.searchParams.get('redirect_url'));
+      return new Response(null, {
+        status: 303,
+        headers: {
+          Location: new URL(dest, ALLOWED_ORIGIN).toString(),
+          'Cache-Control': 'no-store',
+        },
+      });
     }
 
     if (url.pathname === '/api/me') {

--- a/workers/access-gate/test/worker.test.mjs
+++ b/workers/access-gate/test/worker.test.mjs
@@ -154,4 +154,71 @@ test('access-gate JWT gate', async (t) => {
     const body = await r.json();
     assert.equal(body.email, 'cookie@example.com');
   });
+
+  // ---- /api/redirect: the post-sign-in bounce (authenticated-only 303) ----------
+
+  // Helper: build /api/redirect?redirect_url=<raw> with a valid token, return Response.
+  const redirectCall = async (rawRedirect, headers) => {
+    const qs =
+      rawRedirect === undefined
+        ? ''
+        : `?redirect_url=${encodeURIComponent(rawRedirect)}`;
+    return call(`/api/redirect${qs}`, headers);
+  };
+
+  await t.test('/api/redirect 303s an authed nav to a safe same-origin path', async () => {
+    const jwt = await mint({email: 'reader@example.com'});
+    const r = await redirectCall('/craft/premium-gating-demo', {
+      'Cf-Access-Jwt-Assertion': jwt,
+    });
+    assert.equal(r.status, 303);
+    assert.equal(
+      r.headers.get('Location'),
+      'https://blog.bytesofpurpose.com/craft/premium-gating-demo',
+    );
+    // never cache an auth-dependent redirect
+    assert.equal(r.headers.get('Cache-Control'), 'no-store');
+  });
+
+  await t.test('/api/redirect requires auth — no token → 401, no Location', async () => {
+    const r = await redirectCall('/craft/premium-gating-demo');
+    assert.equal(r.status, 401);
+    assert.equal(r.headers.get('Location'), null);
+  });
+
+  // Open-redirect / header-injection attempts must all collapse to '/'.
+  const OPEN_REDIRECT_ATTEMPTS = [
+    ['absolute https URL', 'https://evil.com/phish'],
+    ['protocol-relative', '//evil.com'],
+    ['encoded protocol-relative', '%2F%2Fevil.com'],
+    ['backslash trick', '/\\evil.com'],
+    ['javascript scheme', '/javascript:alert(1)'],
+    ['no leading slash', 'evil.com'],
+    ['CRLF header split', '/ok%0d%0aSet-Cookie:+x=1'],
+    ['empty', ''],
+  ];
+  for (const [label, attempt] of OPEN_REDIRECT_ATTEMPTS) {
+    await t.test(`/api/redirect blocks open-redirect: ${label}`, async () => {
+      const jwt = await mint({email: 'reader@example.com'});
+      const r = await redirectCall(attempt, {'Cf-Access-Jwt-Assertion': jwt});
+      assert.equal(r.status, 303);
+      assert.equal(
+        r.headers.get('Location'),
+        'https://blog.bytesofpurpose.com/',
+        `"${attempt}" should have collapsed to the origin root`,
+      );
+    });
+  }
+
+  await t.test('/api/redirect preserves query + hash on a safe path', async () => {
+    const jwt = await mint({email: 'reader@example.com'});
+    const r = await redirectCall('/craft/x?a=1&b=2#frag', {
+      'Cf-Access-Jwt-Assertion': jwt,
+    });
+    assert.equal(r.status, 303);
+    assert.equal(
+      r.headers.get('Location'),
+      'https://blog.bytesofpurpose.com/craft/x?a=1&b=2#frag',
+    );
+  });
 });

--- a/workers/access-gate/wrangler.toml
+++ b/workers/access-gate/wrangler.toml
@@ -12,11 +12,15 @@ main = "src/index.ts"
 compatibility_date = "2024-11-01"
 account_id = "e22f4531704a3141ddb150ac47eabc87"
 
-# Route the two API paths on the live blog host to this Worker. The same host is
-# fronted by GitHub Pages for everything else; only /api/* hits the Worker.
+# Route the API paths on the live blog host to this Worker. The same host is
+# fronted by GitHub Pages for everything else; only these paths hit the Worker.
+# NOTE: routes are explicit per-path (no /api/* wildcard), so ANY new endpoint must
+# be added here AND gated by the Access app (cf_access.py) — otherwise it 404s at the
+# GitHub Pages origin (no Worker) or, if routed but not gated, skips the LinkedIn flow.
 routes = [
   { pattern = "blog.bytesofpurpose.com/api/me", zone_name = "bytesofpurpose.com" },
   { pattern = "blog.bytesofpurpose.com/api/unlock-key", zone_name = "bytesofpurpose.com" },
+  { pattern = "blog.bytesofpurpose.com/api/redirect", zone_name = "bytesofpurpose.com" },
 ]
 
 # Public (non-secret) vars. TEAM_DOMAIN is the Zero Trust team domain (verified


### PR DESCRIPTION
## What

Fixes the post-sign-in redirect bug: signing in landed the reader on `/api/me` (a JSON endpoint) → the SPA rendered **"Page Not Found"** instead of returning to the content page.

## Root cause

`signIn()` navigated the top-level window to `/api/me?redirect_url=…`. Cloudflare Access **ignores** a nested `redirect_url` we append to a protected path — it returns the browser to the path it gated (`/api/me`). That path is a JSON data endpoint, so the reader landed on JSON (404 in the SPA).

## Fix

A dedicated **`/api/redirect`** Worker route that, for an authenticated navigation, `303`s the browser to the (sanitized, same-origin) `redirect_url`. `signIn()` now targets `/api/redirect` instead of `/api/me`. `/api/me` + `/api/unlock-key` stay `fetch()`'d data endpoints.

### Security: open-redirect guard
`/api/redirect` emits a caller-supplied `redirect_url` as a `Location` header to an authenticated user. `safeRedirectPath()` (Worker) + `sameOriginPath()` (client, defense in depth) coerce anything off-origin to `/`: absolute URLs, any scheme (`https:`, `javascript:`), protocol-relative `//evil.com`, backslash tricks, control chars (CR/LF).

## Tests
- **Worker unit** (`workers/access-gate/test`): authed 303, **8 open-redirect vectors → `/`**, 401 without auth, query/hash preserved — **20/20 pass**.
- **e2e** (`test/e2e/signin-redirect.spec.ts`): click targets `/api/redirect` (not `/api/me`); the bounce lands on the content page — **premium project 4/4 pass**.

## Infra (already applied)
- **Worker deployed** with the new route (`/api/me`, `/api/unlock-key`, `/api/redirect` all bound).
- **Access app** extended to gate `blog.bytesofpurpose.com/api/redirect` (same AUD, policies intact) via a new `cf_access.py add-destination` helper. Verified live: anon `/api/redirect` → **302 → LinkedIn**.

## Docs
- Design doc: new **"Workers & API endpoints"** section (role/purpose/caller/auth table for all 3 endpoints + who-calls-what and `/api/redirect` sequence mermaid); corrected the auth sequence diagram.

## Remaining
Merge → deploy the site from master (ships the `signIn()` change) → validate the live sign-in lands on content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
