### PR TITLE
fix(premium): wildcard Worker routes so /api/redirect?query reaches the Worker

### DIFF
--- a/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
@@ -188,6 +188,29 @@ sequenceDiagram
     App->>W: (now) GET /api/me + /api/unlock-key → gate unlocks
 ```
 
+### Deployment & routing gotchas (hard-won)
+
+The Worker lives on the **same hostname as the static site** (`blog.bytesofpurpose.com`),
+which is otherwise served by GitHub Pages. Only the `/api/*` paths are peeled off to the
+Worker by **explicit per-path Worker routes**. That split is the source of several traps —
+each cost a debugging round, so they're recorded here:
+
+| Gotcha | Symptom | Rule |
+|---|---|---|
+| **A Worker route pattern matches the QUERY STRING too.** `…/api/redirect` (no star) does **not** match `…/api/redirect?redirect_url=…`. | The request **falls through to GitHub Pages** → its `text/html` 404 page (the "Page Not Found" the SPA renders), even though the route "exists". | **Every route MUST end in `*`** — `…/api/redirect*`. `/api/redirect` is *always* hit with a `?redirect_url=` query (it's the sign-in bounce), so a bare pattern is guaranteed to miss. |
+| **Per-path routes, no `/api/*` wildcard.** Each endpoint is its own route. | A *new* endpoint that isn't added to `wrangler.toml` 404s at the GitHub Pages origin (no Worker ever sees it). | Adding an endpoint = add its route to `wrangler.toml` (with `*`) **and** gate it on the Access app (below). The Worker also handles a trailing slash (`/api/redirect/` ≡ `/api/redirect`) by normalizing `pathname`. |
+| **Where a 404 comes from tells you which layer failed.** | `content-type: text/html` + `server: cloudflare` = the **GitHub Pages** 404 (routing missed the Worker). `content-type: application/json` = the **Worker's own** `not_found` (routing worked; the path/branch didn't match). | Always check the 404's `content-type` first when an `/api/*` path misbehaves — it localizes the bug to routing vs. Worker logic in one curl. |
+| **Two separate "does this path exist" gates.** The Access app's destinations gate it (anonymous → LinkedIn); the Worker route binds it (request → Worker). | If a path is route-bound but NOT an Access destination, anonymous skips the LinkedIn flow. If it's an Access destination but not route-bound, it 404s at origin. | A new endpoint needs **both**: `cf_access.py add-destination <app-id> <host/path>` **and** the `wrangler.toml` route. |
+| **The Access app edit is a full-object PUT, not PATCH.** | `PATCH /access/apps/{id}` → `10405 "Method not allowed for this authentication scheme"` under API-token auth. | `cf_access.py add-destination` GETs the app, appends the path to `self_hosted_domains` + `destinations`, strips read-only keys (`id`/`aud`/timestamps), and **PUTs the whole object** — preserving the AUD and existing policies. **AUD must not change** or the Worker's `POLICY_AUD` breaks. |
+
+> **Why these matter to the design, not just ops:** the gate's correctness depends on the
+> request actually reaching the Worker. A routing miss doesn't fail safe with an error — it
+> silently serves the *static origin* (the SPA 404, or worse, a static asset), bypassing the
+> Worker entirely. The `*`-suffixed routes + the dual Access/route registration are therefore
+> part of the security contract, not incidental config. (Build-side fail-closed guarantees —
+> the V5 leak gate, the cache-busted encrypted build — are covered under *Verification &
+> assurance* and *What ships to prod vs dev-only*.)
+
 ## Why StatiCrypt + Worker key-vend
 
 [StatiCrypt](https://github.com/robinmoisson/staticrypt) encrypts an HTML body

--- a/workers/access-gate/src/index.ts
+++ b/workers/access-gate/src/index.ts
@@ -177,6 +177,13 @@ async function verifyAccessJwt(
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
+    // Normalize a single trailing slash so /api/redirect/ == /api/redirect. The
+    // Worker route patterns end in `*` (they must — a CF route matches the query
+    // string, so a bare path misses `?redirect_url=…`), which means a trailing-slash
+    // variant also REACHES the Worker; without this it would fall to the exact-match
+    // checks below and 404. Keep "/" itself intact.
+    const pathname =
+      url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
 
     if (req.method === 'OPTIONS') {
       return new Response(null, {status: 204, headers: corsHeaders(req)});
@@ -191,13 +198,13 @@ export default {
     const payload = await verifyAccessJwt(req, env);
     if (!payload) return json({error: 'unauthorized'}, 401, req);
 
-    if (url.pathname === '/api/unlock-key') {
+    if (pathname === '/api/unlock-key') {
       // No email required — the key isn't tied to a person. Any admitted caller
       // (LinkedIn user or the dev service token) may decrypt premium content.
       return json({passphrase: env.PREMIUM_PASSPHRASE}, 200, req);
     }
 
-    if (url.pathname === '/api/redirect') {
+    if (pathname === '/api/redirect') {
       // Post-sign-in bounce. The browser navigated here (Access already admitted the
       // request — this code only runs authenticated), so 303 it onward to the
       // same-origin content page it wanted. safeRedirectPath blocks open-redirect /
@@ -212,7 +219,7 @@ export default {
       });
     }
 
-    if (url.pathname === '/api/me') {
+    if (pathname === '/api/me') {
       // /api/me reports the signed-in identity, so it DOES need an email claim.
       // Service tokens have none (they're non-identity) → 401 no_email, which is
       // correct: the dev proxy uses /api/unlock-key, not /api/me, for identity.

--- a/workers/access-gate/test/worker.test.mjs
+++ b/workers/access-gate/test/worker.test.mjs
@@ -221,4 +221,32 @@ test('access-gate JWT gate', async (t) => {
       'https://blog.bytesofpurpose.com/craft/x?a=1&b=2#frag',
     );
   });
+
+  // A trailing slash on the endpoint path must still route (the CF route `*` reaches
+  // the Worker for /api/redirect/ too; the Worker normalizes so it doesn't 404).
+  await t.test('/api/redirect/ (trailing slash) still 303s', async () => {
+    const jwt = await mint({email: 'reader@example.com'});
+    const r = await worker.fetch(
+      new Request(
+        'https://blog.bytesofpurpose.com/api/redirect/?redirect_url=%2Fcraft%2Fx',
+        {method: 'GET', headers: {'Cf-Access-Jwt-Assertion': jwt}},
+      ),
+      env,
+    );
+    assert.equal(r.status, 303);
+    assert.equal(r.headers.get('Location'), 'https://blog.bytesofpurpose.com/craft/x');
+  });
+
+  await t.test('/api/me/ (trailing slash) still returns identity', async () => {
+    const jwt = await mint({email: 'reader@example.com'});
+    const r = await worker.fetch(
+      new Request('https://blog.bytesofpurpose.com/api/me/', {
+        method: 'GET',
+        headers: {'Cf-Access-Jwt-Assertion': jwt},
+      }),
+      env,
+    );
+    assert.equal(r.status, 200);
+    assert.equal((await r.json()).email, 'reader@example.com');
+  });
 });

--- a/workers/access-gate/wrangler.toml
+++ b/workers/access-gate/wrangler.toml
@@ -17,10 +17,17 @@ account_id = "e22f4531704a3141ddb150ac47eabc87"
 # NOTE: routes are explicit per-path (no /api/* wildcard), so ANY new endpoint must
 # be added here AND gated by the Access app (cf_access.py) — otherwise it 404s at the
 # GitHub Pages origin (no Worker) or, if routed but not gated, skips the LinkedIn flow.
+#
+# ⚠️ The TRAILING `*` IS REQUIRED. A Cloudflare Worker route pattern matches the URL
+# including its query string, and `…/api/redirect` (no star) does NOT match
+# `…/api/redirect?redirect_url=…` — the request falls through to GitHub Pages (a 404
+# HTML page). /api/redirect is ALWAYS hit with a `?redirect_url=` query (it's the
+# sign-in bounce), so it MUST be `…/api/redirect*`. The other two get the star too for
+# the same reason (any caller that appends a query would otherwise miss the Worker).
 routes = [
-  { pattern = "blog.bytesofpurpose.com/api/me", zone_name = "bytesofpurpose.com" },
-  { pattern = "blog.bytesofpurpose.com/api/unlock-key", zone_name = "bytesofpurpose.com" },
-  { pattern = "blog.bytesofpurpose.com/api/redirect", zone_name = "bytesofpurpose.com" },
+  { pattern = "blog.bytesofpurpose.com/api/me*", zone_name = "bytesofpurpose.com" },
+  { pattern = "blog.bytesofpurpose.com/api/unlock-key*", zone_name = "bytesofpurpose.com" },
+  { pattern = "blog.bytesofpurpose.com/api/redirect*", zone_name = "bytesofpurpose.com" },
 ]
 
 # Public (non-secret) vars. TEAM_DOMAIN is the Zero Trust team domain (verified


### PR DESCRIPTION
## What

Follow-up to #4. The sign-in bounce **still 404'd after login** in production. Root cause: a Cloudflare Worker **route pattern matches the URL including its query string**, so `blog.bytesofpurpose.com/api/redirect` (no star) does **not** match `/api/redirect?redirect_url=…` — the request fell through to GitHub Pages (the SPA 404 the user saw).

`/api/redirect` is *always* hit with a `?redirect_url=` query (it's the post-LinkedIn bounce), so the route must end in `*`.

## Fix

Add a trailing `*` to all three routes: `/api/me*`, `/api/unlock-key*`, `/api/redirect*`. (Any caller that appends a query would otherwise miss the Worker — e.g. `/api/unlock-key?x=1` was also falling through.)

## Verified live (service-token authed, Worker already redeployed)
- `/api/redirect?redirect_url=/craft/premium-gating-demo` → **303 → the content page** ✅
- `/api/redirect?redirect_url=https://evil.com` → **303 → origin root** (open-redirect guard intact) ✅
- `/api/unlock-key?x=1` → **200** ✅

The Worker is already redeployed with these routes; this PR records the `wrangler.toml` change in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)