### PR TITLE
feat(premium): gold premium UX — sidebar tint, disclaimer pane, CTA cards, navbar order

### DIFF
--- a/.claude/skills/manage-premium-content/SKILL.md
+++ b/.claude/skills/manage-premium-content/SKILL.md
@@ -45,13 +45,25 @@ mediocre post costs more goodwill than it earns.
 
 ## Choosing the teaser (the sneak-peek)
 
-The teaser is the only part of a premium doc that ships in clear — it's the hook.
+The teaser is the only part of a premium doc that ships in clear — it's the hook. It also
+populates the gate's gold **disclaimer pane** (the locked-state info box rendered by
+`PremiumGate`), so it must read as reader-facing copy.
 
 - Set **`premium_teaser`** in frontmatter (1–2 sentences). If absent, the gate falls back
   to `description`, so a real `description` is the minimum.
-- Make it a genuine hook: the question the piece answers or the payoff, not "this is
-  premium content." Write it like the first line of the post, because that's what it is.
+- Make it a genuine hook: the question the piece answers or the payoff. Write it like the
+  first line of the post, because that's what it is.
+- **Reader-facing only — never expose the mechanics.** Don't mention encryption, "the
+  published bundle", build-time anything, StatiCrypt, the Worker, or how the gate works.
+  The reader only needs to know it's **premium content that unlocks when they sign in with
+  LinkedIn**. Mechanics belong in the design doc, not on the page. (Same rule for the doc's
+  `description` and the `PremiumGate` fallback string — keep all three jargon-free.)
 - Keep it honest — it should accurately preview the gated body, not oversell it.
+
+  Good: *"This is premium content — sign in with LinkedIn to read the rest."* · a real
+  one-line hook for the piece.
+  Bad: *"Everything below is encrypted in the published bundle and decrypts once you sign
+  in."* (leaks implementation; reads like a system note, not an invitation).
 
 ## Soft `<Premium>` vs hard whole-doc gate (policy view)
 

--- a/bytesofpurpose-blog/docs/craft/premium-gating-demo.mdx
+++ b/bytesofpurpose-blog/docs/craft/premium-gating-demo.mdx
@@ -1,9 +1,9 @@
 ---
 slug: /premium-gating-demo
 title: 🔒 Premium Gating Demo
-description: A live demonstration of the premium content hard-gate — the body below is encrypted at build time and only decrypts for signed-in readers.
+description: A live demo of premium content — the rest of this page unlocks when you sign in with LinkedIn.
 premium: true
-premium_teaser: This page is a live demo of premium gating. Everything below this line is encrypted in the published bundle and only unlocks once you sign in with LinkedIn.
+premium_teaser: This is premium content — sign in with LinkedIn to read the rest.
 draft: false
 ---
 

--- a/bytesofpurpose-blog/src/components/AuthNavbarItem/index.tsx
+++ b/bytesofpurpose-blog/src/components/AuthNavbarItem/index.tsx
@@ -104,9 +104,13 @@ function AuthControl(): React.JSX.Element {
 }
 
 export default function AuthNavbarItem(): React.JSX.Element {
+  // The stable `navbarAuthItem` class lets custom.css order this AFTER the color-mode
+  // toggle in the navbar-right cluster (toggle on the left, profile/sign-in on the right).
   return (
-    <BrowserOnly fallback={<span className={styles.placeholder} aria-hidden="true" />}>
-      {() => <AuthControl />}
-    </BrowserOnly>
+    <span className="navbarAuthItem">
+      <BrowserOnly fallback={<span className={styles.placeholder} aria-hidden="true" />}>
+        {() => <AuthControl />}
+      </BrowserOnly>
+    </span>
   );
 }

--- a/bytesofpurpose-blog/src/components/PremiumGate/index.tsx
+++ b/bytesofpurpose-blog/src/components/PremiumGate/index.tsx
@@ -105,7 +105,7 @@ export default function PremiumGate({
           <p className={styles.noticeBody}>
             {teaser
               ? teaser
-              : 'The rest of this page is premium — encrypted in the published bundle and unlocked for signed-in readers.'}
+              : 'The rest of this page is premium — sign in to read it.'}
           </p>
         </div>
       </aside>

--- a/bytesofpurpose-blog/src/components/PremiumGate/index.tsx
+++ b/bytesofpurpose-blog/src/components/PremiumGate/index.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import {useAuth, fetchUnlockKey} from '@site/src/lib/auth';
+import posthog from 'posthog-js';
+import {useAuth, fetchUnlockKey, signIn} from '@site/src/lib/auth';
 import {decryptPremium} from '@site/src/lib/premium-crypto';
-import {openSignInModal} from '@site/src/components/SignInModal';
+import {showToast} from '@site/src/components/Toast';
 import styles from './styles.module.css';
 
 // Page-level premium gate. The rehype-premium-encrypt plugin REPLACES an encrypted doc's
 // body with <PremiumGate payload="/premium/<id>.json" teaser="…" /> at compile time, so
 // the plaintext is in neither the HTML nor the JS bundle. This component:
 //
-//   - Anonymous: shows the teaser + a lock; clicking opens the sign-in modal.
+//   - Anonymous: a gold "premium / locked" info pane (disclaimer ONLY — no CTA in it),
+//     then two CTA cards in the body: (1) sign in with LinkedIn to unlock, (2) ask for
+//     this to be made free. Both fire PostHog events.
 //   - Signed in: fetches the passphrase (/api/unlock-key) + the encrypted payload, decrypts
 //     in-browser (src/lib/premium-crypto, StatiCrypt engine), injects the body HTML.
 //
@@ -22,6 +25,10 @@ type GateState =
   | {phase: 'unlocked'; html: string}
   | {phase: 'error'};
 
+function currentPath(): string | undefined {
+  return typeof window !== 'undefined' ? window.location.pathname : undefined;
+}
+
 export default function PremiumGate({
   payload,
   teaser,
@@ -31,6 +38,9 @@ export default function PremiumGate({
 }): React.JSX.Element {
   const {status} = useAuth();
   const [state, setState] = React.useState<GateState>({phase: 'idle'});
+  // Whether the reader has already asked for this to be free this session — flips the
+  // request card to a thank-you state so the demand event can't be spammed.
+  const [requested, setRequested] = React.useState(false);
 
   React.useEffect(() => {
     if (status !== 'authenticated') return undefined;
@@ -65,30 +75,82 @@ export default function PremiumGate({
     return <p className={styles.status}>Unlocking premium content…</p>;
   }
 
-  // Anonymous / unlock failed: teaser + lock; click → sign-in modal.
-  const openModal = () => openSignInModal({what: 'This content'});
+  // Sign-in CTA: navigate to the LinkedIn flow + record the click as an intent signal.
+  const onSignIn = () => {
+    posthog.capture('premium_signin_click', {path: currentPath()});
+    signIn();
+  };
+
+  // "Make this free" CTA: a demand signal for un-gating (NOT an unlock). Idempotent per
+  // session via `requested`. Reuses the existing premium_interest event name so the
+  // signed-out gate and the modal aggregate into one funnel.
+  const onRequestFree = () => {
+    if (requested) return;
+    posthog.capture('premium_interest', {path: currentPath(), source: 'gate_card'});
+    setRequested(true);
+    showToast('Noted — thanks for the nudge!', {icon: '🙌'});
+  };
+
+  const failed = state.phase === 'error';
+
   return (
-    <div
-      className={styles.gate}
-      role="button"
-      tabIndex={0}
-      onClick={openModal}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          openModal();
-        }
-      }}>
-      {teaser ? <p className={styles.teaser}>{teaser}</p> : null}
-      <div className={styles.lockRow}>
-        <span className={styles.lockIcon} aria-hidden="true">
+    <div className={styles.wrap}>
+      {/* Disclaimer-only info pane — gold, says ONLY that this is premium/locked. */}
+      <aside className={styles.notice} role="note">
+        <span className={styles.noticeLock} aria-hidden="true">
           🔒
         </span>
-        <span className={styles.lockLabel}>
-          {state.phase === 'error'
-            ? 'Couldn’t unlock just yet — sign in with LinkedIn to read the rest.'
-            : 'Sign in with LinkedIn to read the rest →'}
-        </span>
+        <div>
+          <p className={styles.noticeTitle}>Premium content</p>
+          <p className={styles.noticeBody}>
+            {teaser
+              ? teaser
+              : 'The rest of this page is premium — encrypted in the published bundle and unlocked for signed-in readers.'}
+          </p>
+        </div>
+      </aside>
+
+      {/* Two CTA cards. */}
+      <div className={styles.cards}>
+        <div className={styles.card}>
+          <span className={styles.cardIcon} aria-hidden="true">
+            🔓
+          </span>
+          <h3 className={styles.cardTitle}>Unlock with LinkedIn</h3>
+          <p className={styles.cardText}>
+            Sign in with LinkedIn to read the rest. It’s free — the gate is just a friendly
+            way to say hi.
+          </p>
+          <button type="button" className={styles.cardCtaPrimary} onClick={onSignIn}>
+            <span className={styles.inMark} aria-hidden="true">
+              in
+            </span>
+            Sign in with LinkedIn
+          </button>
+          {failed ? (
+            <p className={styles.cardHint}>
+              Couldn’t unlock just yet — signing in again should do it.
+            </p>
+          ) : null}
+        </div>
+
+        <div className={styles.card}>
+          <span className={styles.cardIcon} aria-hidden="true">
+            🙌
+          </span>
+          <h3 className={styles.cardTitle}>Rather it were free?</h3>
+          <p className={styles.cardText}>
+            Tell me you’d like this opened up — enough nudges and I’ll un-gate it. No sign-in
+            needed.
+          </p>
+          <button
+            type="button"
+            className={styles.cardCtaSecondary}
+            onClick={onRequestFree}
+            disabled={requested}>
+            {requested ? 'Thanks for the nudge! 🙌' : 'Ask me to make this free'}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/bytesofpurpose-blog/src/components/PremiumGate/styles.module.css
+++ b/bytesofpurpose-blog/src/components/PremiumGate/styles.module.css
@@ -1,42 +1,152 @@
-/* Premium page/section gate: teaser + lock placeholder shown to anonymous readers. */
+/* Premium page gate (anonymous view): a gold disclaimer pane + two CTA cards.
+   Shares the --premium-gold token set with the sidebar lock items (custom.css)
+   so every premium surface reads consistently. */
 
-.gate {
+.wrap {
   margin: 1.5rem 0;
-  padding: 1.5rem 1.5rem 1.5rem 1.75rem;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  /* Brand accent rail on the left so the gate reads as an intentional blog surface. */
-  border-left: 4px solid var(--ifm-color-primary);
-  border-radius: 0.6rem;
-  background: var(--ifm-color-primary-contrast-background);
-  cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
-.gate:hover,
-.gate:focus-visible {
-  border-color: var(--ifm-color-primary);
+
+/* ---- Disclaimer-only info pane (gold). Says ONLY that this is premium. ---- */
+.notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--premium-gold-border);
+  /* Gold rail on the left + faint gold wash, matching the sidebar gold tint. */
+  border-left: 4px solid var(--premium-gold-bright);
+  border-radius: 0.6rem;
+  background: var(--premium-gold-wash);
+}
+.noticeLock {
+  font-size: 1.3rem;
+  line-height: 1.4;
+  flex: none;
+}
+.noticeTitle {
+  margin: 0 0 0.15rem;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--premium-gold-strong);
+  letter-spacing: 0.01em;
+}
+.noticeBody {
+  margin: 0;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+/* ---- The two CTA cards ---- */
+.cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+@media (max-width: 768px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 1.25rem 1.25rem 1.35rem;
+  border: 1px solid var(--premium-gold-border);
+  border-radius: 0.7rem;
+  background: var(--ifm-card-background-color);
+  box-shadow: var(--ifm-global-shadow-lw);
+  /* A thin gold top accent so the cards read as part of the premium surface. */
+  border-top: 3px solid var(--premium-gold-bright);
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+.card:hover {
+  box-shadow: var(--ifm-global-shadow-md);
+  transform: translateY(-1px);
+}
+.cardIcon {
+  font-size: 1.5rem;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+.cardTitle {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+.cardText {
+  margin: 0 0 1rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  flex: 1 1 auto;
+}
+
+/* Primary CTA — LinkedIn brand-blue (it's a LinkedIn action). */
+.cardCtaPrimary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: #0a66c2; /* LinkedIn blue */
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+.cardCtaPrimary:hover,
+.cardCtaPrimary:focus-visible {
+  background: #084e96;
   box-shadow: var(--ifm-global-shadow-md);
   outline: none;
 }
-
-.teaser {
-  margin: 0 0 1rem;
-  color: var(--ifm-color-emphasis-800);
-  font-size: 1.02rem;
-  line-height: 1.6;
-}
-
-.lockRow {
-  display: flex;
+.inMark {
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 0.2rem;
+  background: #fff;
+  color: #0a66c2;
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+/* Secondary CTA — gold outline (the "make it free" demand signal). */
+.cardCtaSecondary {
+  padding: 0.55rem 1rem;
+  border: 1.5px solid var(--premium-gold-bright);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--premium-gold-strong);
   font-weight: 600;
-  color: var(--ifm-color-primary);
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
 }
-.lockIcon {
-  font-size: 1.15rem;
+.cardCtaSecondary:hover:not(:disabled),
+.cardCtaSecondary:focus-visible:not(:disabled) {
+  background: var(--premium-gold-wash);
+  outline: none;
 }
-.lockLabel {
-  font-size: 0.95rem;
+.cardCtaSecondary:disabled {
+  cursor: default;
+  opacity: 0.85;
+  border-color: var(--premium-gold-border);
+}
+
+.cardHint {
+  margin: 0.6rem 0 0;
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-600);
 }
 
 .status {

--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -35,6 +35,22 @@
   --ifm-navbar-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
   --ifm-global-shadow-lw: 0 1px 3px rgba(0, 0, 0, 0.08);
   --ifm-global-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.1);
+
+  /* Premium ("gold") palette — shared by the sidebar lock items, the locked
+     info pane, and the CTA cards so every premium surface reads consistently.
+     A metallic gold: a saturated base for text/icons, a gradient pair for the
+     sheen, a faint wash for backgrounds, and a border tint. */
+  --premium-gold: #9a7b1f; /* readable gold for text on light bg (AA on white) */
+  --premium-gold-strong: #7a5f12;
+  --premium-gold-bright: #d4af37; /* classic metallic gold (icons/sheen) */
+  --premium-gold-sheen-1: #e8cd6a;
+  --premium-gold-sheen-2: #b8860b;
+  --premium-gold-border: rgba(201, 162, 39, 0.55);
+  --premium-gold-wash: linear-gradient(
+    135deg,
+    rgba(212, 175, 55, 0.1),
+    rgba(184, 134, 11, 0.05)
+  );
 }
 
 /* Dark mode: lift the primary so links/buttons keep AA contrast on dark
@@ -52,6 +68,19 @@ html[data-theme='dark'] {
   --ifm-card-background-color: #1c1e21;
   --ifm-navbar-shadow: 0 1px 0 rgba(255, 255, 255, 0.08);
   --ifm-global-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.5);
+
+  /* Premium gold, lifted for contrast on dark surfaces. */
+  --premium-gold: #e2c466; /* readable gold text on dark bg */
+  --premium-gold-strong: #f0d27a;
+  --premium-gold-bright: #f1cf5b;
+  --premium-gold-sheen-1: #ffe9a3;
+  --premium-gold-sheen-2: #c9a227;
+  --premium-gold-border: rgba(212, 175, 55, 0.5);
+  --premium-gold-wash: linear-gradient(
+    135deg,
+    rgba(212, 175, 55, 0.14),
+    rgba(184, 134, 11, 0.06)
+  );
 }
 
 /* Tighten heading rhythm a touch for a more modern feel. */
@@ -291,4 +320,32 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   #__docusaurus > div.main-wrapper > div > div > div {
     display: none;
   }
+}
+
+/* ==========================================================================
+   Navbar right cluster: color-mode toggle to the LEFT of the auth control,
+   with breathing room between the two. The auth item is the custom 'custom-auth'
+   navbar item (position:right); Docusaurus renders the color-mode toggle after
+   it by default, so we reorder via flex `order` and add a gap.
+   ========================================================================== */
+.navbar__items--right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+/* Order: search (0) · color-mode toggle (1) · auth control (2, far right).
+   The auth control carries a stable `.navbarAuthItem` wrapper so we can target it
+   regardless of its CSS-module-hashed inner classes. */
+.navbar__items--right [class*='colorModeToggle'] {
+  order: 1;
+  /* Breathing room between the toggle and the profile/sign-in. */
+  margin-right: 0.5rem;
+}
+.navbar__items--right .navbarAuthItem {
+  order: 2;
+  display: inline-flex;
+  align-items: center;
+}
+.navbar__items--right [class*='navbarSearchContainer'] {
+  order: 0;
 }

--- a/bytesofpurpose-blog/src/posthog-integration-plan.md
+++ b/bytesofpurpose-blog/src/posthog-integration-plan.md
@@ -50,7 +50,8 @@ needed. Revisit (`mask_all_text`) if any authenticated/PII surface is ever added
 | `ingress` | arrival with `?im=<marker>` (then stripped), or untagged direct deep arrival (`direct_or_bookmark`) | `src/posthog.js` |
 | `bookmarklet_used` | the saved bookmarklet is clicked (beaconed straight to PostHog, survives the redirect) | `src/components/BookmarkletButton/index.tsx` (embedded `javascript:`) |
 | `bookmarklet_help_opened` / `bookmarklet_dragged` | user opens the drag-instructions modal / drags the bookmarklet | `src/components/BookmarkletButton/index.tsx` |
-| `premium_interest` | reader presses "I'd rather this were free" on the premium sign-in modal — a demand signal for un-gating a doc (props: `path`, `what`). Distinct from the LinkedIn sign-in CTA, which is an unlock, not a vote. | `src/components/SignInModal/index.tsx` |
+| `premium_interest` | reader asks for a premium doc to be made free — a demand signal for un-gating (props: `path`, plus `what` from the modal or `source: 'gate_card'` from the page gate's "Ask me to make this free" card). Distinct from the LinkedIn sign-in CTA, which is an unlock, not a vote. | `src/components/SignInModal/index.tsx`, `src/components/PremiumGate/index.tsx` |
+| `premium_signin_click` | reader clicks "Sign in with LinkedIn" on a premium page gate's unlock CTA card — intent to unlock (props: `path`). Fires just before the Access/LinkedIn redirect. | `src/components/PremiumGate/index.tsx` |
 
 **Ingress-attribution layer:** the `egress_*` / `bookmark_intent` / `ingress` events
 form a "how a URL left and came back" loop. The ShareButton (mounted in the doc/blog H1

--- a/bytesofpurpose-blog/src/theme/DocSidebarItem/Link/index.tsx
+++ b/bytesofpurpose-blog/src/theme/DocSidebarItem/Link/index.tsx
@@ -46,6 +46,7 @@ export default function DocSidebarItemLink({
         className={clsx(
           'menu__link',
           !isInternalLink && styles.menuExternalLink,
+          isPremium && styles.premiumLink,
           {
             'menu__link--active': isActive,
           },

--- a/bytesofpurpose-blog/src/theme/DocSidebarItem/Link/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/DocSidebarItem/Link/styles.module.css
@@ -11,3 +11,14 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
+
+/* Premium (gated) sidebar entries read in metallic gold so a reader can spot
+   which docs are premium at a glance. Tints the label text; the lock badge
+   carries the gold sheen (see lockBadge.module.css). The active state keeps the
+   brand-blue highlight so "you are here" still wins. */
+.premiumLink:not(.menu__link--active) {
+  color: var(--premium-gold);
+}
+.premiumLink:not(.menu__link--active):hover {
+  color: var(--premium-gold-strong);
+}

--- a/bytesofpurpose-blog/src/theme/DocSidebarItem/lockBadge.module.css
+++ b/bytesofpurpose-blog/src/theme/DocSidebarItem/lockBadge.module.css
@@ -1,10 +1,22 @@
-/* "premium" lock badge shown after a sidebar item's label (ships to production). */
+/* "premium" lock badge shown after a sidebar item's label (ships to production).
+   A small gold sheen pill behind the lock gives the metallic-premium read. */
 .lockBadge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   flex: none;
   margin-left: 0.4rem;
+  padding: 0.05rem 0.28rem;
   font-size: 0.72rem;
   line-height: 1.5;
   vertical-align: middle;
   white-space: nowrap; /* never wrap the lock to its own line beside long labels */
+  border-radius: 0.5rem;
+  background: linear-gradient(
+    135deg,
+    var(--premium-gold-sheen-1),
+    var(--premium-gold-sheen-2)
+  );
+  border: 1px solid var(--premium-gold-border);
+  /* Slightly desaturate the emoji's own color so it blends with the gold pill. */
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.45);
 }

--- a/bytesofpurpose-blog/test/e2e/premium-gating.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/premium-gating.spec.ts
@@ -45,7 +45,8 @@ test.describe('Premium hard-gate (V3 + round-trip)', () => {
     await page.goto(DEMO, {waitUntil: 'networkidle'});
     const bodyText = await page.locator('body').innerText();
     expect(bodyText).not.toContain(SENTINEL);
-    await expect(page.getByText(/sign in with linkedin to read the rest/i)).toBeVisible();
+    // Disclaimer-only info pane says ONLY that this is premium (the teaser text).
+    await expect(page.getByText(/premium content/i).first()).toBeVisible();
     await expect(page.getByText(/live demo of premium gating/i)).toBeVisible(); // teaser
 
     // None of the loaded JS chunks may contain the gated sentinel.
@@ -54,29 +55,26 @@ test.describe('Premium hard-gate (V3 + round-trip)', () => {
       expect(js, `JS chunk leaked the sentinel: ${u}`).not.toContain(SENTINEL);
     }
 
-    // THEMED, not generic: the gate carries the brand accent (a non-transparent left
-    // border rail in the brand colour) — proves #15 styling actually shipped.
-    const gate = page.locator('[class*="gate"]').first();
-    const leftBorder = await gate.evaluate(
+    // GOLD info pane, not generic: a non-transparent left rail in the premium-gold
+    // colour — proves the gold tint shipped.
+    const notice = page.locator('[class*="notice"]').first();
+    const leftBorder = await notice.evaluate(
       (el) => getComputedStyle(el).borderLeftWidth,
     );
     expect(leftBorder).toBe('4px');
 
-    // Clicking the lock opens the THEMED sign-in modal.
-    await gate.click();
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
+    // Two CTA cards live in the BODY (not the disclaimer). The sign-in card has a direct
+    // LinkedIn button; the "make it free" card has its own demand-signal button.
     await expect(
-      page.getByRole('button', {name: /sign in with linkedin to unlock/i}),
+      page.getByRole('button', {name: /sign in with linkedin/i}).last(),
     ).toBeVisible();
-    // The "I'd rather this were free" interest button is present (distinct CTA, #16).
-    await expect(page.getByRole('button', {name: /rather this were free/i})).toBeVisible();
-    // Modal is branded: a 4px brand top-band on the modal card.
-    const topBand = await dialog
-      .locator('[class*="modal"]')
-      .first()
-      .evaluate((el) => getComputedStyle(el).borderTopWidth);
-    expect(topBand).toBe('4px');
+    const freeBtn = page.getByRole('button', {name: /make this free/i});
+    await expect(freeBtn).toBeVisible();
+
+    // The "make it free" CTA records a demand signal + flips to a thank-you state
+    // (idempotent — can't be spammed).
+    await freeBtn.click();
+    await expect(page.getByRole('button', {name: /thanks for the nudge/i})).toBeVisible();
   });
 
   test('unlocked: signed-in reader decrypts the body in-browser (round-trip)', async ({
@@ -103,9 +101,7 @@ test.describe('Premium hard-gate (V3 + round-trip)', () => {
     // The gate fetches the key + payload, decrypts client-side, injects the body. The
     // sentinel — absent from HTML/JS — now appears in the rendered DOM.
     await expect(page.getByText(new RegExp(SENTINEL))).toBeVisible({timeout: 15000});
-    // The lock prompt is gone once unlocked.
-    await expect(
-      page.getByText(/sign in with linkedin to read the rest/i),
-    ).toHaveCount(0);
+    // The locked CTA cards are gone once unlocked.
+    await expect(page.getByRole('button', {name: /make this free/i})).toHaveCount(0);
   });
 });

--- a/bytesofpurpose-blog/test/e2e/premium-gating.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/premium-gating.spec.ts
@@ -47,7 +47,7 @@ test.describe('Premium hard-gate (V3 + round-trip)', () => {
     expect(bodyText).not.toContain(SENTINEL);
     // Disclaimer-only info pane says ONLY that this is premium (the teaser text).
     await expect(page.getByText(/premium content/i).first()).toBeVisible();
-    await expect(page.getByText(/live demo of premium gating/i)).toBeVisible(); // teaser
+    await expect(page.getByText(/this is premium content/i)).toBeVisible(); // teaser
 
     // None of the loaded JS chunks may contain the gated sentinel.
     for (const u of jsUrls) {

--- a/bytesofpurpose-blog/test/e2e/signin-redirect.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/signin-redirect.spec.ts
@@ -86,6 +86,6 @@ test.describe('Sign-in redirect flow', () => {
     // The Docusaurus 404 must NOT be what we see.
     await expect(page.getByRole('heading', {name: /page not found/i})).toHaveCount(0);
     // The premium teaser (the real page) is present.
-    await expect(page.getByText(/live demo of premium gating/i)).toBeVisible();
+    await expect(page.getByText(/this is premium content/i)).toBeVisible();
   });
 });

--- a/bytesofpurpose-blog/test/e2e/signin-redirect.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/signin-redirect.spec.ts
@@ -48,10 +48,9 @@ test.describe('Sign-in redirect flow', () => {
 
     await page.goto(DEMO, {waitUntil: 'networkidle'});
 
-    // Open the gate's sign-in modal and click the LinkedIn button.
-    await page.locator('[class*="gate"]').first().click();
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await page.getByRole('button', {name: /sign in with linkedin to unlock/i}).click();
+    // The premium gate's "Unlock with LinkedIn" card has a direct sign-in button
+    // (no intermediate modal) — clicking it kicks off signIn() → /api/redirect.
+    await page.getByRole('button', {name: /sign in with linkedin/i}).last().click();
 
     await expect.poll(() => loginUrl, {timeout: 5000}).not.toBeNull();
     expect(hitApiMeAsNavigation, 'sign-in must NOT navigate to /api/me').toBe(false);


### PR DESCRIPTION
## What

UX polish for the premium surfaces (all requested from screenshots):

1. **Sidebar** — premium (lock) entries render in metallic **gold** with a gold-sheen lock pill, so gated docs stand out.
2. **Locked page gate redesigned**:
   - The info pane is now **disclaimer-only** ("Premium content" + what it is) — gold rail + gold wash, **no CTA inside it**.
   - CTAs moved into the body as **two gold-accented cards**: **Unlock with LinkedIn** (LinkedIn-blue → `signIn()`, fires `premium_signin_click`) and **Rather it were free?** (gold outline → fires `premium_interest {source:'gate_card'}`, flips to a thank-you state + toast, idempotent).
3. **Navbar** — the light/dark toggle now sits to the **left** of the profile/sign-in, with spacing between them.

All premium surfaces share a new `--premium-gold` token set (light + dark, AA-tuned).

## Screenshots
Light + dark verified. The "make it free" card fires the event + toast and disables after one click.

## Tests
- `posthog-integration-plan.md` updated with the two events.
- e2e `premium-gating` + `signin-redirect` updated for the new markup — **4/4 pass** against the encrypted build (anonymous body still ciphertext; hard-gate intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)