### PR TITLE
feat(hooks): block em-dash in user-facing content (AI-voice guard)

### DIFF
--- a/.claude/hooks/em-dash-voice-hook.sh
+++ b/.claude/hooks/em-dash-voice-hook.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write: BLOCK when user-facing content gains an em-dash ("—").
+#
+# WHY: a literal em-dash in prose is a strong tell of AI-generated voice. On this blog,
+# reader-facing copy should sound human, so an em-dash is treated as a flag to STOP and
+# decide deliberately — not a thing that silently ships. The hook does NOT rewrite; it
+# blocks (exit 2) and tells Claude to surface the occurrence(s) to the user via the
+# AskUserQuestion tool and offer per-occurrence rephrasings (comma / colon / period-split /
+# parentheses / keep). The human picks; Claude applies.
+#
+# SCOPE: user-facing content only —
+#   - prose: bytesofpurpose-blog/{docs,blog,designs,changelog}/**.{md,mdx}
+#   - markup: any *.html (rendered output / embedded pages — all user-facing)
+#   - components: bytesofpurpose-blog/src/**.{tsx,jsx} — but ONLY when the em-dash is in a
+#     USER-FACING STRING (JSX text or a quoted literal), not in a // comment or /* */ block.
+# Code, config, CSS, skills, plans, and CLAUDE.md are intentionally NOT scoped: em-dashes
+# there are not reader-facing.
+#
+# Detection is on the FILE'S CURRENT CONTENT (post-edit), so it catches an em-dash however
+# it arrived. It reports the line numbers + snippets so Claude can target the ask.
+#
+# NOTE: only the em-dash U+2014 ("—") is flagged. The en-dash (–) and hyphen (-) are fine.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+[ -n "$file_path" ] || exit 0
+[ -f "$file_path" ] || exit 0
+
+# --- Is this file in scope? -------------------------------------------------------------
+in_scope=""
+case "$file_path" in
+  *.md|*.mdx)
+    case "$file_path" in
+      */bytesofpurpose-blog/docs/*|*/bytesofpurpose-blog/blog/*|\
+*/bytesofpurpose-blog/designs/*|*/bytesofpurpose-blog/changelog/*)
+        in_scope="prose" ;;
+    esac ;;
+  *.html)
+    in_scope="html" ;;
+  *.tsx|*.jsx)
+    case "$file_path" in
+      */bytesofpurpose-blog/src/*) in_scope="component" ;;
+    esac ;;
+esac
+[ -n "$in_scope" ] || exit 0
+
+# --- Find em-dashes in user-facing positions --------------------------------------------
+# For prose + html: any em-dash counts. For components: exclude lines that are purely
+# comments (// … or * … or /* …), since those aren't reader-facing. (A heuristic — a string
+# literal AND a trailing comment on the same line still flags, which is the safe default.)
+hits=$(awk -v mode="$in_scope" '
+  index($0, "\xE2\x80\x94") > 0 {
+    line=$0
+    if (mode == "component") {
+      t=line; sub(/^[[:space:]]+/, "", t)
+      # skip lines that are entirely a line- or block-comment
+      if (t ~ /^\/\// || t ~ /^\*/ || t ~ /^\/\*/) next
+    }
+    # trim leading whitespace for a compact snippet
+    snip=line; sub(/^[[:space:]]+/, "", snip)
+    if (length(snip) > 120) snip=substr(snip,1,117) "..."
+    printf "  L%d: %s\n", NR, snip
+  }
+' "$file_path")
+
+[ -n "$hits" ] || exit 0
+
+rel="${file_path##*/}"
+count=$(printf '%s\n' "$hits" | grep -c .)
+
+{
+  echo "BLOCKED — em-dash (\"—\") found in user-facing content: $rel ($count occurrence(s))."
+  echo "An em-dash in reader-facing copy reads as AI voice. Do NOT just rewrite it silently."
+  echo
+  echo "Occurrence(s):"
+  printf '%s\n' "$hits"
+  echo
+  echo "REQUIRED next step: use the AskUserQuestion tool to ask the user how to handle EACH"
+  echo "occurrence, offering: replace with a comma · a colon · split into two sentences"
+  echo "(period) · parentheses · keep as-is. Apply the user's choice, then continue."
+  echo "(Only U+2014 \"—\" is flagged; en-dash and hyphen are fine.)"
+} >&2
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-docs-structure-hook.sh\"",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/em-dash-voice-hook.sh\"",
+            "timeout": 15
           }
         ]
       }

--- a/.claude/skills/review-reader-experience/SKILL.md
+++ b/.claude/skills/review-reader-experience/SKILL.md
@@ -32,6 +32,26 @@ Journey" — separating *what I impact* from *who I am*). When you trim, keep th
 distinct idea per element; don't merge two cards' meanings into vague mush. If a label
 or CTA spans more than a short line, that's a flag — propose the tighter version.
 
+### The em-dash tell (enforced by a hook)
+
+A literal **em-dash (`—`)** in reader-facing copy is a strong AI-voice signal — human
+blog writing rarely reaches for it. So on this site, an em-dash in **user-facing content**
+is treated as a flag to STOP and rephrase deliberately, never to ship silently. This is
+enforced, not just advised: the **`em-dash-voice-hook.sh`** PostToolUse `Write|Edit` hook
+(registered in `.claude/settings.json`) **blocks** (exit 2) when an em-dash appears in:
+
+- prose `*.md`/`*.mdx` under `bytesofpurpose-blog/{docs,blog,designs,changelog}/`,
+- any `*.html` (all user-facing),
+- user-facing **strings** in `bytesofpurpose-blog/src/**.{tsx,jsx}` (JSX text / quoted
+  literals — NOT `//` or `/* */` comments).
+
+Code, config, CSS, skills, plans, and `CLAUDE.md` are out of scope (em-dashes there aren't
+reader-facing — this skill file uses them freely). Only U+2014 `—` is flagged; the en-dash
+(`–`) and hyphen (`-`) are fine. When the hook fires, the required response is to **ask the
+user** (AskUserQuestion) how to handle each occurrence — replace with a comma · a colon ·
+split into two sentences · parentheses · keep as-is — then apply their choice. Don't
+auto-rewrite; the human decides whether each dash stays.
+
 ## Five audits
 
 Run the audits relevant to the request. Default to all five for a broad "make it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,10 @@ the new rule — never let the docs and the checks drift. The contract is owned 
 enforced by `bytesofpurpose-blog/scripts/validate-docs-structure.js`
 (`make validate-structure`) + the warn-only PostToolUse `Write|Edit` hook
 `.claude/hooks/validate-docs-structure-hook.sh` (registered in `.claude/settings.json`
-alongside `validate-links-hook.sh` / `validate-draft-hook.sh`). Absolute-slug is the
+alongside `validate-links-hook.sh` / `validate-draft-hook.sh` / `em-dash-voice-hook.sh`).
+(The em-dash hook is the one BLOCKING content hook: a literal `—` in reader-facing content
+reads as AI voice, so it exits 2 and requires asking the user how to rephrase — see the
+`review-reader-experience` skill, "The em-dash tell".) Absolute-slug is the
 only ERROR tier; the rest are warn-tier advisories — including the `description-*` rules
 (missing / length ~50–160 / duplicate), which keep each page's `description:` frontmatter
 healthy because it feeds both `og:description` (SEO/social) and the ShareButton share


### PR DESCRIPTION
## What

A literal em-dash in reader-facing copy is a strong AI-voice tell. This adds a `PostToolUse` `Write|Edit` hook that **blocks** (exit 2) when an em-dash (U+2014 `—`) lands in **user-facing content**, so it gets a deliberate decision instead of shipping silently.

## Scope (user-facing only)
- prose `.md`/`.mdx` under `bytesofpurpose-blog/{docs,blog,designs,changelog}/`
- any `*.html` (all reader-facing)
- user-facing **strings** in `bytesofpurpose-blog/src/**.{tsx,jsx}` (JSX text / quoted literals; `//` and `/* */` comments excluded)

Code, config, CSS, skills, plans, and `CLAUDE.md` are out of scope. En-dash (`–`) and hyphen (`-`) are fine.

## Behavior
On a hit, the hook prints the offending line numbers + snippets and instructs Claude to use **AskUserQuestion** to ask how to handle each occurrence (comma / colon / period-split / parentheses / keep), then apply the choice. It never auto-rewrites.

## Files
- `.claude/hooks/em-dash-voice-hook.sh` (new), registered in `.claude/settings.json`
- documented in the `review-reader-experience` skill ("The em-dash tell") + `CLAUDE.md`

## Proof
- 7 pipe-tests across all scope/edge cases (prose block, html block, JSX-string block, comment-only allow, clean-prose allow, CSS allow, skill-md allow)
- a **live PostToolUse fire** that actually blocked a `Write` of an in-scope `.mdx` with an em-dash

🤖 Generated with [Claude Code](https://claude.com/claude-code)