### PR TITLE
Add audit-mobile-experience skill + first mobile audit

### DIFF
--- a/.claude/plans/rippling-riding-cosmos.md
+++ b/.claude/plans/rippling-riding-cosmos.md
@@ -1,0 +1,150 @@
+# Plan: `audit-mobile-experience` skill — confirm mobile is up to par, not just shrunk desktop
+
+## Context
+
+The "Browse My Thoughts" card (PR #12) just shipped to prod, widening the homepage
+chooser to three cards. That raised the open question: **is the mobile experience
+genuinely good, or is it just a compressed desktop layout?** Today the site has no
+mobile verification at all — every Playwright project uses `Desktop Firefox`
+(`bytesofpurpose-blog/playwright.config.ts:70,79,85,103`), and the homepage's only
+breakpoint (`index.module.css:111`, `max-width: 966px`) just shrinks font sizes. The
+custom Changelog component carries ~30 `768px` media queries (highest custom-layout
+risk), while docs/graph/premium surfaces are largely untested on touch viewports.
+
+The user wants this captured as a **reusable skill** (not a one-off report), then run
+once now to produce the first prioritized fix list. Depth chosen: **one-time deep
+audit** procedure (manual + emulated), **no permanent CI test project**. Scope: **all
+four surfaces** — homepage/chooser, docs reading, changelog timeline, interactive
+(graph/premium/blog).
+
+This mirrors the existing `review-reader-experience` skill: an **audit-and-report**
+skill that emits a prioritized findings list and does **not** silently auto-edit.
+
+## What "up to par, not shrunk desktop" means (audit dimensions)
+
+Research-backed criteria the skill checks (sources in References):
+1. **Tap targets** — interactive elements ≥44×44px (incl. padding), ≥8px apart.
+2. **Thumb reach** — primary CTAs reachable one-handed (bottom ~⅔ of viewport); not
+   buried top-corner.
+3. **Content parity** — mobile shows the *same* content/affordances as desktop, not a
+   stripped or hidden subset (hidden nav items get ~3× less interaction).
+4. **No horizontal scroll / overflow** — `scrollWidth <= clientWidth` at 360–414px;
+   code blocks, tables, wide images wrap or scroll *intentionally*, not the page.
+5. **Reflow, not shrink** — multi-column → stacked; text stays ≥16px (no zoom-to-read);
+   images re-crop/scale rather than squish.
+6. **Touch interactions work** — graph pan/zoom, premium gate, blog filters respond to
+   touch (`hasTouch`), no hover-only affordances.
+7. **Mobile performance** — Lighthouse mobile (throttled CPU/network) LCP/CLS sane.
+8. **Mobile a11y** — axe passes at mobile viewport (focus order, contrast, labels).
+
+## Deliverable 1 — the skill: `.claude/skills/audit-mobile-experience/SKILL.md`
+
+Single-file skill (matches `review-reader-experience`'s shape). Frontmatter `name` +
+`description` ("Audit the Bytes of Purpose site on real mobile viewports — confirm it's
+a true mobile experience, not a compressed desktop layout … emits a prioritized report;
+does not auto-edit. Use when asked 'is this good on mobile?', after a layout/hero/CSS
+change, or before a release."). Body sections:
+
+- **Why this skill exists** — the "responsive ≠ mobile-good" trap; the two real tells
+  (horizontal overflow + sub-44px tap targets) and the parity trap (hidden content).
+- **Audit vehicle (prod build, not dev).** Build-only transforms must be present, so
+  audit the **served prod build on :4173**, never `yarn start`:
+  `make serve` (or reuse the `build/` dir already produced by the deploy). Drive it with
+  the **chrome-devtools MCP** tools (already available, deferred): `resize_page` /
+  `emulate` to set device viewport + `hasTouch`, `take_screenshot` for side-by-side
+  desktop-vs-mobile parity diffs, `lighthouse_audit` for mobile perf/a11y, and
+  `evaluate_script` for the programmatic overflow + tap-target probes below.
+- **Device matrix** — small iPhone SE (375×667), iPhone 15 Pro (393×852),
+  Pixel 8 (412×915), plus the 360px and 768px CSS breakpoint edges. Both light + dark.
+- **The mechanical probes (copy-paste, repeatable)** — the parts a human eye misses:
+  - *Horizontal-overflow probe* (`evaluate_script`): flag any element with
+    `scrollWidth > clientWidth` / page `documentElement.scrollWidth > innerWidth`.
+  - *Tap-target probe*: enumerate `a, button, [role=button], input` and report any with
+    rendered box `< 44px` in either dimension, or `< 8px` gap to a neighbor.
+  - *Content-parity probe*: diff the set of visible links/headings/CTAs at desktop vs
+    mobile width — anything present on desktop but `display:none`/removed on mobile is a
+    parity finding to justify or fix.
+  - *Font-size probe*: flag body text computed `< 16px` (triggers iOS zoom-to-read).
+- **Per-surface checklist** (the four chosen scopes), each with its specific risk:
+  - **Homepage / chooser** (`src/pages/index.tsx`, `index.module.css`): do the 3 cards
+    stack to 1-col cleanly at 375px? arched images not squished? CTA reachable? The new
+    `max-width: 1040px` + `flex 1 1 300px` is the thing to stress at the 360px edge.
+  - **Docs reading** (craft/self): sidebar drawer opens/closes; code blocks scroll
+    inside themselves (page doesn't); tables; in-doc anchor nav.
+  - **Changelog timeline** (`src/components/Changelog/*`): the ~30 `768px` queries —
+    timeline reflow, filters, date overlay, legend sidebar collapse.
+  - **Interactive** (`graph-*`, `PremiumGate`, blog list): graph pan/zoom by touch;
+    premium gate + sign-in modal usable; blog filter chips tappable.
+- **Output format** — a **prioritized report** (P0 broken / P1 degraded / P2 polish),
+  each finding = surface · viewport · symptom · probe-evidence (numbers/screenshot) ·
+  concrete fix. Explicitly: **report only, do not auto-edit** (same contract as
+  `review-reader-experience`).
+- **Troubleshooting table** — seed with: "audited dev :3000 → build-only transforms
+  missing, re-run on :4173"; "emulate without `hasTouch` → touch handlers no-op, set it";
+  "Lighthouse mobile throttling makes LCP look broken → that's the point, compare to
+  budget not to desktop".
+
+## Deliverable 2 — register the skill (lockstep, per CLAUDE.md convention)
+
+- Add a row to the **Skills map** table in `CLAUDE.md` (the "Reader-experience audit"
+  neighborhood): `Mobile-experience audit | audit-mobile-experience | confirm the site
+  is a true mobile experience (tap targets, thumb reach, content parity, overflow,
+  touch, mobile perf/a11y) not a shrunk desktop → prioritized report`.
+- No validator/hook changes needed — this is an advisory audit skill, not a structure
+  rule (so the "structure decisions update the checks" tenet doesn't apply here).
+
+## Deliverable 3 — run it once now → first prioritized fix list
+
+Execute the skill's procedure against the current prod build to produce the inaugural
+report. Likely early findings to expect (to verify, not assume): the 3-card hero at the
+360px edge, the `966px`-only homepage breakpoint being font-only, and the Changelog
+`768px` cluster. Present the report; **fixes are a separate follow-up** the user
+approves per-item (the skill does not auto-edit).
+
+## Critical files
+
+- **New:** `.claude/skills/audit-mobile-experience/SKILL.md` (the skill).
+- **New:** `.claude/plans/rippling-riding-cosmos.md` (this plan).
+- **Edit:** `CLAUDE.md` — one new row in the Skills-map table.
+- **Read/reference (not edited):** `bytesofpurpose-blog/playwright.config.ts`,
+  `src/pages/index.module.css`, `src/components/Changelog/*`,
+  `test/e2e/accessibility.spec.ts` (axe pattern to reuse conceptually),
+  `.claude/skills/review-reader-experience/SKILL.md` (shape to mirror), `Makefile`
+  (`serve`, `build-premium` targets).
+
+## Reuse (don't reinvent)
+
+- **chrome-devtools MCP** for emulation/screenshot/lighthouse (already available) — no
+  new test harness or dependency.
+- **`make serve`** to serve the prod build on :4173 (reuse the `build/` from the deploy).
+- **axe-core** approach already proven in `accessibility.spec.ts` — the skill references
+  it for the mobile-viewport a11y pass conceptually (Lighthouse a11y covers it without
+  new code).
+- **`review-reader-experience` SKILL.md** as the structural/voice template.
+
+## Verification (that the skill itself works)
+
+1. Skill file lints as valid Markdown with `name`+`description` frontmatter; appears in
+   the available-skills list after creation.
+2. Dry-run the procedure: `make serve`, then via chrome-devtools MCP `emulate` iPhone SE
+   + run the overflow and tap-target probes on `/` — confirm they return concrete
+   numbers (proves the probes are copy-pasteable and actually execute), per the
+   repo tenet "never assert; prove with a runnable check + evidence".
+3. The run produces a non-empty prioritized report with at least one
+   probe-evidenced finding (or an explicit "clean" with the probe output backing it).
+4. `CLAUDE.md` Skills-map row renders; no other skill/validator references broken.
+
+## Out of scope (chosen explicitly)
+
+- No permanent Playwright mobile project / `make test-regression` wiring (user chose
+  one-time audit, not a CI net).
+- No real-device cloud lab (BrowserStack/LambdaTest).
+- No fixes applied in this change — the skill reports; fixes are separate, per-item
+  approved follow-ups.
+
+## References (mobile-QA best practices, June 2026)
+
+- [Heurilens — Mobile UX Audit Checklist](https://heurilens.com/blog/core-ux/mobile-ux-audit-checklist-critical-issues) (tap targets, thumb zone, content parity)
+- [Siteimprove — The Touch Target Problem](https://www.siteimprove.com/blog/motor-impairments-and-mobile-ui-the-touch-target-problem/) (44–48px, motor accessibility)
+- [Playwright Emulation docs](https://playwright.dev/docs/emulation) (device descriptors, `hasTouch`)
+- [TestDino — Playwright Mobile Testing](https://testdino.com/blog/playwright-mobile-testing) (emulator vs real device — what emulation misses)

--- a/.claude/skills/audit-mobile-experience/FIRST-AUDIT-2026-06-03.md
+++ b/.claude/skills/audit-mobile-experience/FIRST-AUDIT-2026-06-03.md
@@ -71,7 +71,36 @@ reachable, i.e. collapsed-not-hidden).
 Lighthouse mobile (homepage): a11y **100**, SEO **100**, best-practices **96** (one
 fail = `errors-in-console`, a console-error nit, out of mobile-layout scope).
 
+## Addendum (2026-06-03, later) — VISUAL-ANALYSIS pass
+
+The first pass was probe-numbers-led and under-weighted aesthetics. After the skill gained
+a **mandatory visual-analysis step** (full-page screenshot → rubric) and a **5th probe
+(mid-word-wrap)**, a re-run on the premium-demo page surfaced spacing/line-break issues the
+numeric probes are blind to. These are the "spacing, line breakage, etc." enhancements:
+
+8. **`Entrepreneurship` breaks mid-word in the Previous/Next pager** (`Entrepreneursh` +
+   `ip`). Surface: doc pager (`pagination-nav__label`) @ 375px. Evidence: mid-word-wrap
+   probe → word render-width **136px in a 124px box** + screenshot. **P1** (looks broken).
+   Fix: reduce `pagination-nav__label` font-size at mobile width, and/or let the label
+   wrap on word boundaries / the card grow. Affects every doc with a long-titled neighbor.
+9. **Share-button row (copy · email · LinkedIn · X) crammed against the premium card's
+   top edge.** Surface: `/craft/premium-gating-demo` @ 375px. Evidence: full-page
+   screenshot — the icon row sits with almost no gap above the yellow "Premium content"
+   card, looking collided. **P1** (reads as a layout bug). Fix: add `margin-block` / `gap`
+   below the ShareButton row (or above the premium callout) at mobile width.
+10. **"Previous" pager card floats lonely at ~55% width** with a large empty gap to its
+    right (no "Next" sibling on this page). Surface: doc pager @ 375px. Evidence:
+    screenshot. **P2** (awkward balance). Fix: full-width the single pager card on mobile,
+    or center it.
+
+**Method note (the lesson):** the original run *happened* to screenshot a couple of pages
+but treated images as optional confirmation, so findings #8–#10 were missed the first time.
+The skill now **requires** a per-surface full-page screenshot + rubric review; numbers
+alone are a false pass. The mid-word-wrap class is now also a programmatic probe so it no
+longer depends on the eye.
+
 ## Recommended fix order (if pursued)
-P1#1 (premium CTA height — conversion + quick) → P1#3 (changelog 10.4px text — readability)
-→ P1#2 (doc footer `.row` bleed — affects every doc) → P2#4 (global chrome min-height,
-clears most of the tap-target backlog at once).
+P1#1 (premium CTA height — conversion + quick) → **#9 (share-row spacing — visible bug on
+the premium page)** → **#8 (pager mid-word break — every doc)** → P1#3 (changelog 10.4px
+text) → P1#2 (doc footer `.row` bleed) → P2#4 (global chrome min-height, clears most of the
+tap-target backlog) → #10 (lonely pager card).

--- a/.claude/skills/audit-mobile-experience/FIRST-AUDIT-2026-06-03.md
+++ b/.claude/skills/audit-mobile-experience/FIRST-AUDIT-2026-06-03.md
@@ -1,0 +1,77 @@
+# Mobile-experience audit — first run (2026-06-03)
+
+Inaugural run of the `audit-mobile-experience` skill against the served prod build
+(`yarn serve --port 4173`, commit `eea29027`). Driven by chrome-devtools MCP: emulated
+iPhone SE (375×667, mobile+touch), the 768px breakpoint edge, and a 1280px desktop
+parity baseline; both probe numbers and screenshots captured. **Report only — no fixes
+applied** (fixes are separate, per-item approved follow-ups).
+
+## Headline
+
+The site is **genuinely mobile-reflowed, not a shrunk desktop** on the things that
+matter most: the homepage chooser (incl. the new "Browse My Thoughts" card) **stacks to
+a clean single column** at 375px with properly-scaled arched images; no surface scrolls
+the page sideways; Lighthouse **mobile a11y = 100, SEO = 100, best-practices = 96**. The
+real gaps are **tap-target sizes below the 44px WCAG-2.2 floor** (systemic) and a cluster
+of **sub-16px text** on the changelog. One genuinely-clipped component (the changelog
+heatmap) turned out to be an intentional inner-scroller on closer look.
+
+## Findings (prioritized)
+
+### P0 — broken
+*None.* No page-level horizontal scroll, no dead touch interaction, no
+content-present-on-desktop-but-absent-on-mobile (the 5 navbar links missing at 375px —
+Craft/Self/Blog/System Designs/Vote/Support — are folded into the hamburger drawer and
+reachable, i.e. collapsed-not-hidden).
+
+### P1 — degraded (real, worth fixing)
+1. **Premium "Sign in with LinkedIn" CTA is 36px tall (<44px).** Surface: `/craft/
+   premium-gating-demo` @ 375px. Evidence: probe → `{w:206, h:36, reachable:false}`.
+   This is the premium **conversion** action, so it's the highest-value tap-target fix.
+   Likely fix: bump the button min-height to 44px in `PremiumGate/styles.module.css`
+   (it already has a `768px` query — extend it).
+2. **Doc article footer overflows its container by ~16px on every doc page.** Surface:
+   `/craft`, `/craft/software-development`, `/craft/premium-gating-demo` @ 375px.
+   Evidence: `article` `scrollWidth 348` inside `clientWidth 332`; widest descendants are
+   the Docusaurus `.row`/`.col` footer rows (`theme-doc-footer-tags`,
+   `theme-doc-footer-edit`) rendering to `right:369` past the 375 content box. The page
+   is saved from sideways scroll only because a parent clips it. Likely fix: the
+   Bootstrap-style `.row` negative-gutter isn't contained on narrow docs — constrain the
+   doc footer `.row` margins at mobile width.
+3. **Changelog body text down to 10.4px.** Surface: `/changelog` @ 375px. Evidence:
+   font probe → 48 elements <16px, including `span` "500 days thus far" at **10.4px** and
+   card blurbs at 14px. Below comfortable-read; the 10.4px spans need a mobile bump.
+   Owner: `src/components/Changelog/*` (it has ~30 `768px` queries — add font-size floors).
+
+### P2 — polish
+4. **Undersized tap targets site-wide (navbar + footer chrome).** 23–29 on content
+   pages, up to 50–75 on docs/changelog. Recurring offenders: navbar toggle (30×30),
+   theme switcher (32×32), the LinkedIn auth pill (33×28), footer links (height 32). Most
+   are secondary chrome, so P2 — but they're the same root cause as P1#1 (32px-tall
+   interactive chrome). A global min-height bump on navbar/footer actions clears most.
+5. **Changelog heatmap renders at 872px inside a 273px box.** Surface: `/changelog` @
+   375px. Evidence: `heatmapRowsContainer` `scrollWidth 872 / clientWidth 273`.
+   **Downgraded from P1 after screenshot:** it's an *intentional horizontal inner-scroller*
+   (scroll thumb visible, Q1–Q4 swipeable), not clipped content — acceptable on mobile,
+   though a "swipe →" affordance would help discoverability.
+6. **Changelog legend label truncates** ("Development (Components, Infras…") @ 375px —
+   cosmetic; the legend card is readable.
+7. **Homepage feature blurbs at 14.72–15.68px** @ 375px — marginally under 16px; minor.
+
+## Probe coverage (evidence trail)
+
+| Surface | Page overflow | Tap <44px | Font <16px | Notes |
+|---|---|---|---|---|
+| Homepage | none (375=375) | 23 | 6 | cards stack clean (screenshot); parity 23 desktop / 18 mobile = drawer fold |
+| Docs (craft) | none | 50 | 0–1 | `.row` footer 16px bleed (P1#2) |
+| Changelog | none | 75 | 48 | heatmap inner-scroller (P2#5); 10.4px text (P1#3); 768px edge clean |
+| Blog | none | 29 | 0 | minor header 16px bleed |
+| Premium demo | none | — | — | sign-in CTA 36px tall (P1#1) |
+
+Lighthouse mobile (homepage): a11y **100**, SEO **100**, best-practices **96** (one
+fail = `errors-in-console`, a console-error nit, out of mobile-layout scope).
+
+## Recommended fix order (if pursued)
+P1#1 (premium CTA height — conversion + quick) → P1#3 (changelog 10.4px text — readability)
+→ P1#2 (doc footer `.row` bleed — affects every doc) → P2#4 (global chrome min-height,
+clears most of the tap-target backlog at once).

--- a/.claude/skills/audit-mobile-experience/SKILL.md
+++ b/.claude/skills/audit-mobile-experience/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: audit-mobile-experience
+description: Audit the Bytes of Purpose site on real mobile viewports — confirm it's a TRUE mobile experience (tap targets, thumb reach, content parity, no horizontal overflow, working touch, mobile perf/a11y), not a compressed desktop layout. Drives the chrome-devtools MCP against the served prod build (:4173) with copy-paste probes, then emits a prioritized P0/P1/P2 report of findings + concrete fixes. Does NOT auto-edit. Use when asked "is this good on mobile?", after a hero/layout/CSS change, or before a release.
+---
+
+# Audit mobile experience
+
+The site is authored on a desktop, so its layouts drift toward **responsive-but-not-mobile**:
+they reflow enough to render on a phone, but they were designed and eyeballed at desktop
+width. "Responsive" only proves the page *fits* — it does not prove a phone user can read,
+reach, and tap it one-handed. This skill audits the site on **real mobile viewports** and
+emits a **prioritized report** — it does not silently auto-edit (same contract as
+`review-reader-experience`).
+
+Pairs with: `review-reader-experience` (the reader's-lens audit — labels/voice/IA),
+`validate-deployment` (post-deploy live checks). Apply any fixes through the owning
+surface's conventions; this skill only finds and prioritizes.
+
+## The one question (responsive ≠ mobile-good)
+
+For every surface ask: **"Is this a layout built FOR a phone, or a desktop layout that
+happens to fit?"** A desktop-shrunk layout passes "it renders" and still fails the user:
+text too small to read without zoom, CTAs above the thumb's reach, a stray element pushing
+a horizontal scrollbar, a tap target the size of a desktop mouse hit-box. The two
+highest-signal tells — the things the eye glides past but a probe catches every time — are
+**horizontal overflow** and **sub-44px tap targets**. The sneakiest is the **parity trap**:
+content or affordances silently `display:none`'d on mobile, so the phone user gets a quietly
+worse product than the desktop user (hidden nav items get ~3× less interaction).
+
+## Audit vehicle — the PROD build on :4173, never dev
+
+Audit the **served production build**, not `yarn start`. Build-only transforms (the rehype
+plugins, draft exclusion, premium encryption) don't run on the dev server, so a dev-server
+audit measures a page that will never ship. Serve the real build **on :4173** (the port the
+a11y/SEO e2e suite uses — `docusaurus serve` defaults to :3000, which collides with a running
+dev server, so always pass `--port 4173`):
+
+```bash
+# Reuse the build/ dir a deploy already produced (make deploy / make build-premium leave it
+# in place). If there is no build/, run `make build` (or `make build-premium` if premium docs
+# exist) first — `yarn serve` does NOT build.
+( cd bytesofpurpose-blog && yarn serve --port 4173 --no-open )
+```
+
+⚠️ **Not `make serve`.** That target runs `docusaurus serve` with no port → defaults to
+**:3000**, which fails with "Something is already running on port 3000" whenever a dev server
+is up, and even when it works serves on the wrong port. Always serve explicitly on :4173.
+
+Drive the audit with the **chrome-devtools MCP** tools (already available in-session, loaded
+on demand via ToolSearch — no new harness or dependency):
+
+| Tool | Use |
+|---|---|
+| `mcp__chrome-devtools__resize_page` / `emulate` | set the device viewport, DPR, and **`hasTouch`** (without `hasTouch`, touch handlers no-op and you mis-audit interactions) |
+| `mcp__chrome-devtools__navigate_page` | load each surface URL on :4173 |
+| `mcp__chrome-devtools__evaluate_script` | run the **mechanical probes** below (the part the eye misses) |
+| `mcp__chrome-devtools__take_screenshot` | desktop-vs-mobile side-by-side parity diffs; attach as P0/P1 evidence |
+| `mcp__chrome-devtools__lighthouse_audit` | mobile perf (LCP/CLS) + a11y, with mobile CPU/network throttling on |
+
+## Device matrix
+
+Audit each surface at, at minimum:
+
+| Device | Viewport | Why |
+|---|---|---|
+| iPhone SE (2nd/3rd gen) | 375×667 | smallest common modern iPhone — the squeeze test |
+| iPhone 15 Pro | 393×852 | mainstream iOS / Safari |
+| Pixel 8 | 412×915 | mainstream Android / Chrome |
+| CSS edge: 360px | 360×740 | below the site's narrowest real query — stress the reflow |
+| CSS edge: 768px | 768×1024 | the Changelog breakpoint boundary (tablet/portrait) |
+
+Run **both light and dark** (the site themes both; contrast bugs hide in one mode only).
+
+## The mechanical probes (copy-paste, repeatable)
+
+Per the repo tenet *never assert, prove with a runnable check + evidence*: every finding
+must carry a number from one of these probes (or a screenshot). Run via
+`mcp__chrome-devtools__evaluate_script` at each viewport.
+
+**1. Horizontal-overflow probe** — the page should never scroll sideways; only intentional
+inner scrollers (code blocks, wide tables) may.
+
+```js
+() => {
+  const de = document.documentElement;
+  const pageOverflows = de.scrollWidth > de.clientWidth;
+  const offenders = [...document.querySelectorAll('*')]
+    .filter(el => el.scrollWidth > el.clientWidth + 1 && getComputedStyle(el).overflowX !== 'auto' && getComputedStyle(el).overflowX !== 'scroll')
+    .map(el => ({ tag: el.tagName, cls: el.className?.toString().slice(0,40), sw: el.scrollWidth, cw: el.clientWidth }))
+    .slice(0, 20);
+  return { innerWidth: window.innerWidth, pageScrollWidth: de.scrollWidth, pageOverflows, offenders };
+}
+```
+
+**2. Tap-target probe** — interactive elements should render ≥44×44px and sit ≥8px apart.
+
+```js
+() => {
+  const sel = 'a, button, [role=button], input:not([type=hidden]), select, summary, [onclick]';
+  const small = [...document.querySelectorAll(sel)]
+    .map(el => { const r = el.getBoundingClientRect(); return { el, r }; })
+    .filter(({ r }) => r.width > 0 && r.height > 0 && (r.width < 44 || r.height < 44))
+    .map(({ el, r }) => ({ tag: el.tagName, text: (el.innerText||el.getAttribute('aria-label')||'').trim().slice(0,30), w: Math.round(r.width), h: Math.round(r.height) }));
+  return { undersizedCount: small.length, samples: small.slice(0, 25) };
+}
+```
+
+**3. Content-parity probe** — diff the visible affordances desktop-vs-mobile; run at BOTH
+widths and compare the returned sets. Anything present on desktop but missing/hidden on
+mobile is a parity finding to justify or fix.
+
+```js
+() => {
+  const visible = el => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el); return r.width>0 && r.height>0 && s.display!=='none' && s.visibility!=='hidden'; };
+  const links = [...document.querySelectorAll('a[href]')].filter(visible).map(a => (a.innerText||a.getAttribute('aria-label')||a.getAttribute('href')||'').trim().slice(0,40)).filter(Boolean);
+  const headings = [...document.querySelectorAll('h1,h2,h3')].filter(visible).map(h => h.innerText.trim().slice(0,50));
+  return { viewport: window.innerWidth, linkCount: links.length, links: [...new Set(links)], headings };
+}
+```
+
+**4. Font-size probe** — body text below 16px triggers iOS auto-zoom-to-read (a desktop-shrink
+tell).
+
+```js
+() => {
+  const tooSmall = [...document.querySelectorAll('p, li, td, span, a')]
+    .filter(el => el.innerText && el.innerText.trim().length > 20)
+    .map(el => ({ el, px: parseFloat(getComputedStyle(el).fontSize) }))
+    .filter(({ px }) => px < 16)
+    .map(({ el, px }) => ({ tag: el.tagName, px, text: el.innerText.trim().slice(0,40) }));
+  return { count: tooSmall.length, samples: tooSmall.slice(0, 15) };
+}
+```
+
+Beyond the probes, eyeball two things they can't catch: **thumb reach** (is the primary CTA
+in the bottom ~⅔ of the viewport, or buried top-corner?) and **reflow quality** (did
+multi-column content *stack*, or just *squish* — arched images squeezed, two cards crammed
+side-by-side at 360px?).
+
+## Per-surface checklist (the four scopes)
+
+For each surface: load on :4173, run all four probes at the device matrix, screenshot
+desktop vs 375px, note thumb-reach + reflow.
+
+- **Homepage / chooser** — `bytesofpurpose-blog/src/pages/index.tsx`,
+  `src/pages/index.module.css`. The 3-card hero is the freshest risk: the chooser is
+  `max-width: 1040px` with cards `flex: 1 1 300px`. Do the three cards drop to a clean
+  1-column stack at 375px, or wrap to an awkward 2+1? Are the arched card images scaled
+  (not squished)? Note: the only homepage `@media` (`966px`) **only shrinks font sizes** —
+  it does not re-layout — so the card reflow is pure flex-wrap; stress it at the 360px edge.
+- **Docs reading (craft / self)** — long-form docs. Sidebar collapses to a drawer that opens
+  AND closes; **code blocks scroll inside themselves** (the overflow probe should flag the
+  `<pre>`, NOT the page); wide tables scroll in their own container; in-doc anchor / "on this
+  page" nav reachable; body text ≥16px (font probe).
+- **Changelog timeline** — `src/components/Changelog/*` carries ~30 `768px` media queries
+  (the most custom mobile CSS on the site = the highest custom-layout risk). Check: timeline
+  reflow, the filters bar (`ChangelogFilters`), date overlay, legend / legend-sidebar
+  collapse, and the `769–1200px` mid-band query. Run the matrix's 768px edge specifically.
+- **Interactive (graph / premium / blog)** — graph renderer pans/zooms by **touch** (set
+  `hasTouch`); `PremiumGate` + sign-in flow usable on a phone (modal not clipped, LinkedIn
+  CTA tappable — `PremiumGate/styles.module.css` has a `768px` query to verify); blog list
+  + filter chips are ≥44px tappable.
+
+## Output — a prioritized report (report only, do NOT auto-edit)
+
+Emit a findings report, severity-bucketed. Each finding: **surface · viewport · symptom ·
+probe-evidence (the number / screenshot) · concrete fix**.
+
+- **P0 — broken**: horizontal page scroll; a primary CTA unreachable or untappable; content
+  present on desktop but missing on mobile (parity break); touch interaction dead.
+- **P1 — degraded**: sub-44px tap targets on real actions; body text <16px; cramped reflow
+  (squish not stack); contrast fail in one theme; poor thumb reach for a key action.
+- **P2 — polish**: tight spacing, minor near-44px targets, mobile LCP/CLS over budget but
+  usable, cosmetic crop.
+
+If a surface is clean, say so **and paste the probe output** that proves it (a clean claim
+without evidence violates the prove-don't-assert tenet). Fixes are a **separate, per-item
+approved follow-up** — this skill does not edit.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Build-only transforms missing; page differs from prod | Audited the dev server (`yarn start`, :3000) | Re-run on the served prod build (`yarn serve --port 4173`) |
+| `make serve` fails "Something is already running on port 3000" | `make serve` → `docusaurus serve` defaults to :3000, collides with the dev server | Serve explicitly: `( cd bytesofpurpose-blog && yarn serve --port 4173 --no-open )` |
+| Overflow probe flags an off-canvas drawer (`navbar-sidebar`, `sw` ≫ `cw`) | Mobile nav drawer is wider than viewport but hidden via `transform`, not `overflow` | Not a finding — it's off-screen; only act on it if the page (`documentElement`) actually overflows |
+| Touch handlers (graph pan/zoom, swipes) do nothing | `emulate` set a small viewport but not touch | Set **`hasTouch: true`** in the emulate call before probing interactions |
+| Lighthouse mobile LCP/score looks alarmingly bad vs desktop | Mobile preset throttles CPU + network on purpose | Compare to a **mobile budget**, not to the desktop number — that gap is the point |
+| Overflow probe flags a `<pre>` / table | That element is an *intentional* inner scroller | Not a finding — the probe excludes `overflow-x: auto/scroll`; only flag when the **page** (`documentElement`) overflows |
+| Parity probe shows fewer links on mobile | Could be legit (nav folded into a drawer) OR a real hidden-content bug | Open the drawer/menu first, re-probe; a finding only if it's *unreachable*, not merely collapsed |
+| Findings differ run-to-run on the homepage | Fonts/images not yet loaded when probe ran | `wait_for` network-idle (or a known selector) before running the probes |
+
+## Self-healing — keep this skill current
+
+When you discover a new mobile failure mode, a better probe, or the user states a
+mobile-UX preference (a target tap size, a device to always include, an acceptable
+breakpoint behavior), **write it into this file in the same change** — add a probe, a
+checklist line, or a troubleshooting row. This skill is the single source of truth for the
+site's mobile bar; don't let what you learned live only in a PR comment.

--- a/.claude/skills/audit-mobile-experience/SKILL.md
+++ b/.claude/skills/audit-mobile-experience/SKILL.md
@@ -16,16 +16,35 @@ Pairs with: `review-reader-experience` (the reader's-lens audit — labels/voice
 `validate-deployment` (post-deploy live checks). Apply any fixes through the owning
 surface's conventions; this skill only finds and prioritizes.
 
-## The one question (responsive ≠ mobile-good)
+## Audit from the MOBILE USER's perspective (not the device's)
 
-For every surface ask: **"Is this a layout built FOR a phone, or a desktop layout that
-happens to fit?"** A desktop-shrunk layout passes "it renders" and still fails the user:
-text too small to read without zoom, CTAs above the thumb's reach, a stray element pushing
-a horizontal scrollbar, a tap target the size of a desktop mouse hit-box. The two
-highest-signal tells — the things the eye glides past but a probe catches every time — are
-**horizontal overflow** and **sub-44px tap targets**. The sneakiest is the **parity trap**:
-content or affordances silently `display:none`'d on mobile, so the phone user gets a quietly
-worse product than the desktop user (hidden nav items get ~3× less interaction).
+Before any probe, picture the actual person and **reason from what they can DO**, because a
+phone is a *context*, not just a small screen. The mobile user is:
+
+- **On the go, interrupted, in short bursts** — checking one thing, skimming, maybe sharing
+  a link; rarely reading end-to-end. → The screen must **prioritize ruthlessly**: the one
+  thing they came for should be obvious and immediate, not buried below desktop chrome.
+- **One-handed, touch-only** — no hover, no precise click, no keyboard. They tap with a
+  thumb (44px), reach comfortably only in the **bottom ~⅔** of the screen, and swipe. →
+  Every action must be a real tap target in reach; **nothing important may rely on hover**.
+- **On a small screen, often poor network / bright sun** — sees little at once, scrolls a
+  lot, is easily overwhelmed. → Big readable text (≥16px), generous spacing, no horizontal
+  scroll surprise, no wall of text.
+
+So for every surface ask: **"What did this person come here to DO on a phone, and can they
+do it one-handed, in a glance, without zooming or hunting?"** — not merely "does it render?"
+A desktop-shrunk layout renders and still fails them: text too small to read without zoom,
+the action above the thumb's reach, a stray element pushing a horizontal scrollbar, a tap
+target the size of a desktop mouse hit-box, or the thing they wanted hidden behind desktop
+chrome. The two highest-signal tells a probe catches every time are **horizontal overflow**
+and **sub-44px tap targets**. The sneakiest is the **parity trap**: content or affordances
+silently `display:none`'d on mobile, so the phone user gets a quietly worse product than the
+desktop user (hidden nav items get ~3× less interaction).
+
+> The sibling skill **`audit-desktop-experience`** runs the same visual rubric from the
+> *desktop* user's perspective (seated, mouse+keyboard, wide screen, reading deeply) — a
+> **different audience** with different things they can do, so it's a separate skill, not a
+> wider viewport here.
 
 ## Audit vehicle — the PROD build on :4173, never dev
 

--- a/.claude/skills/audit-mobile-experience/SKILL.md
+++ b/.claude/skills/audit-mobile-experience/SKILL.md
@@ -132,15 +132,96 @@ tell).
 }
 ```
 
-Beyond the probes, eyeball two things they can't catch: **thumb reach** (is the primary CTA
-in the bottom ~⅔ of the viewport, or buried top-corner?) and **reflow quality** (did
-multi-column content *stack*, or just *squish* — arched images squeezed, two cards crammed
-side-by-side at 360px?).
+**5. Mid-word-wrap probe** — a single word wider than its box wraps **mid-word** (e.g.
+`Entrepreneurship` → `Entrepreneursh` + `ip` in a narrow pager/card). Measures each
+element's longest word against its `clientWidth`. (Confirmed real catch:
+`pagination-nav__label`, word render-width 136px in a 124px box.)
+
+```js
+() => {
+  const measure = (txt, el) => {
+    const c = document.createElement('span'), s = getComputedStyle(el);
+    c.style.cssText = `position:absolute;visibility:hidden;white-space:nowrap;font-size:${s.fontSize};font-weight:${s.fontWeight};font-family:${s.fontFamily};letter-spacing:${s.letterSpacing}`;
+    c.textContent = txt; document.body.appendChild(c);
+    const w = c.getBoundingClientRect().width; c.remove(); return w;
+  };
+  const hits = [];
+  for (const el of document.querySelectorAll('a,h1,h2,h3,div,span,p,b,strong,li,td')) {
+    const t = (el.innerText||'').trim();
+    if (!t || el.childElementCount > 0) continue;
+    const longest = t.split(/\s+/).sort((a,b)=>b.length-a.length)[0] || '';
+    if (longest.length < 10) continue;                  // only long words can break mid-token
+    const wordW = measure(longest, el), box = el.clientWidth;
+    if (box > 0 && wordW > box + 1) hits.push({ word: longest, wordW: Math.round(wordW), boxW: box, tag: el.tagName, cls: (el.className||'').toString().slice(0,30) });
+  }
+  const seen = new Set();
+  return { count: hits.length, samples: hits.filter(h => { const k=h.word+h.boxW; if(seen.has(k))return false; seen.add(k); return true; }).slice(0, 12) };
+}
+```
+
+## The visual-analysis pass (MANDATORY — the probes only see numbers)
+
+The four probes catch what has a number; they are **blind to aesthetics**. Spacing that
+feels cramped, a heading that wraps to a lonely orphan word, a CTA that breaks to two
+lines, content kissing the screen edge, lopsided cards, a wall of text with no breathing
+room — none of these trip a probe, yet they are exactly what makes a layout read as
+"shrunk desktop." **A run is NOT complete until this pass is done.** Numbers + a clean
+Lighthouse score with no visual review is a false pass.
+
+For **every surface, at minimum the 375px viewport** (and 360px where reflow is tight):
+
+1. **Capture a FULL-PAGE screenshot** — `mcp__chrome-devtools__take_screenshot` with
+   `fullPage: true`. The first viewport is not enough; spacing/rhythm problems hide below
+   the fold. (For very long pages, also grab the key sections individually.)
+2. **Actually look at the image** (Read it back) and score it against the rubric below.
+   Treat this like a designer reviewing a comp, not a checkbox.
+3. **Capture the desktop equivalent** for the same surface and compare — the question is
+   always *"is this designed for a phone, or just desktop squeezed into one?"*
+
+### Visual rubric — what to look for in the screenshot
+
+| Dimension | The tell (a finding) |
+|---|---|
+| **Edge spacing** | Text/images/cards touching or nearly touching the viewport edge; inconsistent left/right gutters; content wider "feeling" than its margin |
+| **Line breakage** | A heading or CTA wrapping to **2 lines**, or wrapping to leave an **orphan** (one lonely word on the last line); mid-word breaks; a label that *just barely* wraps |
+| **Vertical rhythm** | Uneven gaps between sections; two elements cramped together while others have huge gaps; no breathing room around headings |
+| **Density / walls** | A long unbroken block of text with no paragraph breaks, list, or image to rest the eye; a card stuffed with too much copy |
+| **Hierarchy** | Does the eye land on the right thing first? Is the primary CTA visually dominant, or lost among equal-weight elements? Heading/body size contrast too flat? |
+| **Balance** | Lopsided cards (one tall, one short); an image dwarfing its caption or vice-versa; an off-center element that should be centered |
+| **Alignment** | Things that should line up (card edges, icon+text baselines, list bullets) that don't |
+| **Thumb reach** | Primary CTA in the bottom ~⅔ (reachable one-handed), or stranded in a top corner? |
+| **Reflow quality** | Multi-column content *stacked* cleanly, or *squished* — arched images squeezed, two cards crammed side-by-side at 360px, a table compressed to unreadable? |
+
+### Worked examples (real catches — look for these specifically)
+
+These are confirmed real findings the numeric probes missed; check every run for them:
+
+- **Mid-word break in a pager / card title.** The doc "Previous / Next" pager cards and
+  any fixed-width card with a long single word will break **mid-word** at 375px — e.g.
+  `Entrepreneurship` rendering as `Entrepreneursh` + `ip` on the next line. Tell:
+  any word hyphen-less-wrapped across a line. Fix: `word-break: normal; overflow-wrap:
+  anywhere` won't help a single long word — instead widen the card, reduce the title
+  font-size at mobile width, or allow the card to grow. Inspect with a probe that flags
+  elements whose text node wraps mid-token, but the screenshot is the real catch.
+- **Share-button row crammed against the card's top edge.** The ShareButton/social row
+  (copy · email · LinkedIn · X) renders with **little or no gap above the card it sits
+  on** (e.g. directly on top of the "Premium content" card border), looking collided.
+  Tell: interactive chrome kissing a container edge with no breathing room. Fix: add
+  `margin-block`/`gap` above the share row at mobile width.
+
+Each visual finding goes into the same P0/P1/P2 report with the **screenshot as its
+evidence** (reference the capture + describe what's wrong) and a **concrete fix** (e.g.
+"card title wraps to 2 lines at 375px → shorten to ≤18 chars or reduce title font-size in
+`index.module.css`"; "feature blurb block has no vertical breathing room → add
+`margin-block` at the 966px breakpoint"). Aesthetic polish is usually **P2**, but a
+2-line primary CTA, content clipped at the edge, a mid-word-broken title, or a broken
+hierarchy that hides the main action is **P1**.
 
 ## Per-surface checklist (the four scopes)
 
-For each surface: load on :4173, run all four probes at the device matrix, screenshot
-desktop vs 375px, note thumb-reach + reflow.
+For each surface: load on :4173, run all four probes at the device matrix, **then run the
+mandatory visual-analysis pass above** (full-page screenshot → rubric → findings). Both
+the numbers AND the visual review are required before a surface is "done".
 
 - **Homepage / chooser** — `bytesofpurpose-blog/src/pages/index.tsx`,
   `src/pages/index.module.css`. The 3-card hero is the freshest risk: the chooser is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ via the root `Makefile`. Secrets in the gitignored root `.env`.
 | Experiment rollout | `conclude-experiment` | execute the decision: roll flag to 100% / keep control, clean up, finalize doc |
 | Content authoring | `author-blog-post` | frontmatter + MDX pitfalls (`<br/>`, `{braces}`) |
 | Reader-experience audit | `review-reader-experience` | audit the site through the reader's eyes: long/jargony sidebar+navbar labels, confusing layout / ignored buttons, writer-focused voice, file/folder IA (nesting, orphan categories, mis-homed docs, re-org — URL-safe only because every slug is **absolute**; a relative slug bakes the path into the URL, and editing a slug VALUE 404s silently) → prioritized report |
+| Mobile-experience audit | `audit-mobile-experience` | confirm the site is a TRUE mobile experience (tap targets, thumb reach, content parity, no horizontal overflow, working touch, mobile perf/a11y) — not a shrunk desktop; drives chrome-devtools MCP on the served prod build (:4173) with copy-paste probes → prioritized P0/P1/P2 report (report-only, no auto-edit) |
 | Link hygiene | `validate-links` | lint source for bare/long/tracking/generic links (`make validate-links`) |
 | Publish | `publish-site` | triage draft-readiness → un-draft approved → deploy; wraps `deploy-site` |
 | Deploy | `deploy-site` | secret-scan → build (PostHog env) → gh-pages → verify |


### PR DESCRIPTION
## What

Adds a reusable **`audit-mobile-experience`** skill (prompted by the question after PR #12: *is the mobile experience genuinely good, or just a compressed desktop layout?*). The skill audits the site on real mobile viewports and emits a **prioritized report** — it does **not** auto-edit (mirrors the `review-reader-experience` audit-and-report pattern).

## How it works

Drives the **chrome-devtools MCP** against the **served prod build on :4173** (not the dev server — build-only transforms must be present) with four copy-paste `evaluate_script` probes a human eye misses:

| Probe | Catches |
|---|---|
| Horizontal-overflow | page scrolling sideways (vs intentional inner-scrollers) |
| Tap-target | interactive elements < 44×44px (WCAG 2.2) |
| Content-parity | affordances present on desktop but hidden on mobile |
| Font-size | body text < 16px (iOS zoom-to-read tell) |

Plus thumb-reach + reflow eyeballing, a device matrix (iPhone SE / 15 Pro / Pixel 8 / 360 + 768 CSS edges, light + dark), and Lighthouse mobile a11y/perf. Output is a P0/P1/P2 report.

## Changes
- **New:** `.claude/skills/audit-mobile-experience/SKILL.md` — the skill.
- **New:** `.claude/skills/audit-mobile-experience/FIRST-AUDIT-2026-06-03.md` — the inaugural run's report.
- **Edit:** `CLAUDE.md` — one row added to the Skills map.
- **New:** `.claude/plans/rippling-riding-cosmos.md` — the approved plan.

## Verification (proven, not asserted)

Ran the skill end-to-end against the live prod build (commit `eea29027`). Probes execute and return concrete numbers (dry-run on `/` @ iPhone SE returned 23 undersized tap targets + an overflow=false page). Full evidence trail in the FIRST-AUDIT report.

**Headline result:** the site is **genuinely mobile-reflowed, not a shrunk desktop** —
- the 3-card homepage hero (incl. the new "Browse My Thoughts" card) **stacks to a clean single column** at 375px with scaled arched images (screenshot-confirmed),
- **no surface scrolls the page sideways**,
- Lighthouse **mobile a11y = 100, SEO = 100, best-practices = 96**.

**Real gaps found (fixes are a separate follow-up — this skill is report-only):**
- **P1:** premium "Sign in with LinkedIn" CTA is 36px tall (<44px) — the conversion action.
- **P1:** doc-footer `.row` overflows its container ~16px on every doc page (clipped, not scrolling).
- **P1:** changelog text down to **10.4px** ("500 days thus far").
- **P2:** site-wide navbar/footer chrome tap targets at 30–32px; changelog heatmap is an intentional inner-scroller (downgraded from P1 after screenshot).

## Notes
- Found & fixed a real skill bug during the dry-run: `make serve` defaults to :3000 (collides with the dev server) — the skill now documents `yarn serve --port 4173` explicitly, with a troubleshooting row.
- No fixes to site code in this PR; the audit findings are queued as a separate, per-item approved follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)