### PR TITLE
Fix deferred mobile audit findings (#15, #16, #17)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -15,9 +15,9 @@ dedup an issue outside the normal flow, update its status here in the same step.
 | 15 | open | mobile-doc-footer-row-overflow | [#15](https://github.com/omars-lab/omars-lab.github.io/issues/15) doc-footer `.row` overflows article ~16px | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
 | 16 | open | mobile-changelog-tiny-text | [#16](https://github.com/omars-lab/omars-lab.github.io/issues/16) changelog text down to 10.4px | audit-mobile 2026-06-03 | mobile-changelog-small-text.png |
 | 17 | open | mobile-chrome-tap-targets-sub44 | [#17](https://github.com/omars-lab/omars-lab.github.io/issues/17) navbar/footer tap targets <44px | audit-mobile 2026-06-03 | (across mobile-*.png) |
-| 18 | open (fixing) | mobile-premium-cta-height | [#18](https://github.com/omars-lab/omars-lab.github.io/issues/18) premium CTA 36px tall | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
-| 19 | open (fixing) | mobile-pager-midword-break | [#19](https://github.com/omars-lab/omars-lab.github.io/issues/19) pager breaks "Entrepreneurship" mid-word | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
-| 20 | open (fixing) | mobile-share-row-crammed | [#20](https://github.com/omars-lab/omars-lab.github.io/issues/20) share row crammed on premium card | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
-| 21 | open (fixing) | desktop-doc-measure-and-whitespace | [#21](https://github.com/omars-lab/omars-lab.github.io/issues/21) doc line-length ~94ch + wide-screen whitespace | audit-desktop 2026-06-03 | desktop-docs-line-length-1440.png, desktop-docs-whitespace-2560.png |
+| 18 | closed (#22) | mobile-premium-cta-height | [#18](https://github.com/omars-lab/omars-lab.github.io/issues/18) premium CTA 36px tall | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
+| 19 | closed (#22) | mobile-pager-midword-break | [#19](https://github.com/omars-lab/omars-lab.github.io/issues/19) pager breaks "Entrepreneurship" mid-word | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
+| 20 | closed (#22) | mobile-share-row-crammed | [#20](https://github.com/omars-lab/omars-lab.github.io/issues/20) share row crammed on premium card | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
+| 21 | closed (#22) | desktop-doc-measure-and-whitespace | [#21](https://github.com/omars-lab/omars-lab.github.io/issues/21) doc line-length ~94ch + wide-screen whitespace | audit-desktop 2026-06-03 | desktop-docs-line-length-1440.png, desktop-docs-whitespace-2560.png |
 
 All screenshots: `~/Library/CloudStorage/Dropbox/bytesofpurpose-audits/2026-06-03/`

--- a/bytesofpurpose-blog/src/components/Changelog/EntryTimeline/EntryTimeline.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/EntryTimeline/EntryTimeline.module.css
@@ -147,20 +147,23 @@
     padding: 0.1rem 0.25rem;
   }
   
+  /* Readability floor on mobile: these timeline metadata labels were 9.6–10.4px
+     (0.6–0.65rem) — too small to read on a phone (audit-mobile #16, e.g. "500 days
+     thus far"). Bump to ~12.8px (0.8rem), the floor for secondary labels. */
   .durationLabel {
-    font-size: 0.65rem;
+    font-size: 0.8rem;
   }
-  
+
   .timelineDates {
     gap: 0.25rem;
   }
-  
+
   .timelineLabel {
-    font-size: 0.6rem;
+    font-size: 0.8rem;
   }
-  
+
   .timelineDate {
-    font-size: 0.7rem;
+    font-size: 0.8rem;
   }
   
   .timelineDateItem {

--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -393,3 +393,46 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     font-size: 0.95rem;        /* a touch smaller so common long titles fit one line */
   }
 }
+
+/* ==========================================================================
+   Doc-footer .row must not bleed past the article (audit-mobile #15). The doc
+   footer's tags + "Edit this page"/last-updated rows use Docusaurus' Bootstrap
+   `.row`, whose negative horizontal margin (the column gutter) isn't contained
+   on the narrow doc article — so the footer rendered ~16px wider than its
+   container at 375px (article scrollWidth 348 in clientWidth 332). Zero out the
+   gutter on the doc-footer rows so they stay inside the article box.
+   ========================================================================== */
+.theme-doc-footer .row {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* ==========================================================================
+   Touch-target floor on mobile chrome (audit-mobile #17). The navbar toggle
+   (30x30), color-mode switch (32x32), LinkedIn auth pill (33x28) and footer
+   links (height 32) all rendered below the 44px WCAG-2.2 touch target on a
+   phone. Give the interactive chrome a >=44px effective target at mobile width
+   without changing the visual icon size (padding/min-size on the hit area).
+   Scoped to <=996px so desktop mouse density is untouched.
+   ========================================================================== */
+@media screen and (max-width: 996px) {
+  .navbar__toggle,
+  .navbar [class*='colorModeToggle'] button,
+  .navbar [class*='toggle'] button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+  /* The custom auth control (sign-in pill / avatar) — give the tappable element room. */
+  .navbarAuthItem a,
+  .navbarAuthItem button {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+  /* Footer links: 32px line-height boxes → pad to a 44px row so each is easily tapped. */
+  .footer__link-item {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+  }
+}


### PR DESCRIPTION
## What
Resolves the three deferred mobile-audit findings from the first audit (the ones not fixed in PR #22).

| # | Finding | Fix | Verified @ 375px |
|---|---|---|---|
| **#15** | doc-footer `.row` overflowed article by ~16px on every doc | zero the Bootstrap `.row` gutter on `.theme-doc-footer .row` | article scrollWidth **332 == 332** (was 348-in-332) ✓ |
| **#16** | changelog text down to 10.4px | EntryTimeline duration/label/date → 0.8rem (12.8px) at mobile | "501 days thus far" now **12.8px** ✓ |
| **#17** | navbar/footer chrome tap targets <44px | ≥44px effective targets at ≤996px (no icon-size change) | navbar toggle **44×44** (was 30×30), footer link **70×44** ✓ |

## Honest scope note on #16
The audit's named offender — the readable sentence *"501 days thus far"* at 10.4px — is fixed (→12.8px). The remaining sub-12.8px elements are **uppercase, letter-spaced status/filter BADGE chips** ("PLANNED", "IN PROGRESS"), which are a deliberate pill-label typographic convention (not prose), so they were intentionally left. Flagging this rather than overclaiming "all text ≥13px."

## Verification
Fresh prod build (`make build-premium`, V5 gate passed), served :4173, verified each fix via chrome-devtools probes + screenshot. `make validate-em-dash` clean, gitleaks clean.

Closes #15, #16, #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)