### PR TITLE
Refresh blog frontend to executive editorial identity (Fraunces + Geist, cream + coral)

### DIFF
--- a/bytesofpurpose-blog/docusaurus.config.js
+++ b/bytesofpurpose-blog/docusaurus.config.js
@@ -64,8 +64,11 @@ const rehypePremiumEncrypt = require('./plugins/rehype-premium-encrypt');
       require.resolve('./src/gtag-guard.js'),
       require.resolve('./src/posthog.js'),
     ],
-    // Load the Inter variable font for UI/body text (see --ifm-font-family-base in
-    // src/css/custom.css). Preconnect first so the stylesheet fetch is not blocked.
+    // Editorial type system, mirroring the portfolio (bytesofpurpose.com):
+    //   Fraunces — display serif for headings (optical-size axis + italic)
+    //   Geist    — sans for UI/body text
+    // See --ifm-heading-font-family / --ifm-font-family-base in src/css/custom.css.
+    // Preconnect first so the stylesheet fetch is not blocked.
     headTags: [
       {
         tagName: 'link',
@@ -83,7 +86,7 @@ const rehypePremiumEncrypt = require('./plugins/rehype-premium-encrypt');
         tagName: 'link',
         attributes: {
           rel: 'stylesheet',
-          href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap',
+          href: 'https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,400;1,9..144,600&family=Geist:wght@400;500;600;700&display=swap',
         },
       },
     ],

--- a/bytesofpurpose-blog/src/components/Graph/GraphRenderer.module.css
+++ b/bytesofpurpose-blog/src/components/Graph/GraphRenderer.module.css
@@ -343,7 +343,7 @@
 }
 
 .panelLinkLight {
-  color: #2563eb;
+  color: var(--ifm-color-primary);
   border-bottom: 1px solid #eee;
 }
 

--- a/bytesofpurpose-blog/src/components/HomepageFeatures/HomepageFeatures.module.css
+++ b/bytesofpurpose-blog/src/components/HomepageFeatures/HomepageFeatures.module.css
@@ -54,7 +54,7 @@
   height: 120px;
   margin-bottom: 1.25rem;
   border-radius: 50%;
-  background: var(--ifm-color-primary-contrast-background, rgba(37, 99, 235, 0.08));
+  background: var(--ifm-color-primary-contrast-background, rgba(211, 74, 34, 0.08));
 }
 
 .featureSvg {

--- a/bytesofpurpose-blog/src/components/LatestPosts/LatestPosts.module.css
+++ b/bytesofpurpose-blog/src/components/LatestPosts/LatestPosts.module.css
@@ -85,6 +85,13 @@
   padding: 0.15rem 0.55rem;
   border-radius: 999px;
   background: var(--ifm-color-primary-contrast-background);
+  /* Darker coral so the small pill text clears WCAG AA (4.5:1) on the coral tint —
+     the base primary only reaches ~4.2:1 against the blended pill background. */
+  color: var(--ifm-color-primary-darker);
+}
+
+html[data-theme='dark'] .postTag {
+  /* On dark the tint is light-on-dark; the base salmon primary already clears AA. */
   color: var(--ifm-color-primary);
 }
 

--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -478,3 +478,29 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     min-height: 44px;
   }
 }
+
+/* ==========================================================================
+   Footer — warm-ink, not cold slate. Docusaurus' `style: 'dark'` ships a cold
+   blue-gray (#303846) that reads as a foreign slab "cut off" from the warm cream
+   page. Re-point it at the warm-ink family used in dark mode so the footer is the
+   intentional dark anchor of the same editorial palette, and link hovers go coral.
+   A hairline top border ties it to the page instead of butting hard against it.
+   ========================================================================== */
+.footer--dark {
+  --ifm-footer-background-color: #1a1715;
+  --ifm-footer-color: #c9c2b8;
+  --ifm-footer-link-color: #c9c2b8;
+  --ifm-footer-title-color: #f4f0e8;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+.footer--dark .footer__link-item:hover {
+  /* primary-lightest clears AA (5.4:1) on the warm-ink footer; the darker steps
+     dip below 4.5:1 against it. */
+  color: var(--ifm-color-primary-lightest);
+  text-decoration: none;
+}
+/* Heading font: let the footer column titles pick up the editorial serif. */
+.footer__title {
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 600;
+}

--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -8,33 +8,52 @@
    Design tokens
    ========================================================================== */
 :root {
-  /* Brand palette */
-  --ifm-color-primary: #2563eb;
-  --ifm-color-primary-dark: #1554e0;
-  --ifm-color-primary-darker: #1350d4;
-  --ifm-color-primary-darkest: #1042ae;
-  --ifm-color-primary-light: #3e75ed;
-  --ifm-color-primary-lighter: #4a7eee;
-  --ifm-color-primary-lightest: #7098f2;
+  /* Brand palette — burnt terracotta, mirroring the portfolio accent (#E4572E).
+     Replaces the old generic blue. The base is deepened to #b33e1e so coral text
+     and the active nav link clear WCAG AA (4.71:1) on the cream paper — the brighter
+     #E4572E only reaches 3.6:1 there. Steps follow Infima's ±shade math. The brighter
+     portfolio coral is kept as --brand-coral for large/decorative accents (hero rule,
+     non-text fills) where AA-for-text doesn't apply. */
+  --ifm-color-primary: #b33e1e;
+  --ifm-color-primary-dark: #a1381b;
+  --ifm-color-primary-darker: #983519;
+  --ifm-color-primary-darkest: #7d2c15;
+  --ifm-color-primary-light: #c5462a;
+  --ifm-color-primary-lighter: #d34a22;
+  --ifm-color-primary-lightest: #e4673f;
+  --brand-coral: #e4572e;
 
   /* Tint used behind feature icons / soft surfaces */
-  --ifm-color-primary-contrast-background: rgba(37, 99, 235, 0.08);
+  --ifm-color-primary-contrast-background: rgba(179, 62, 30, 0.09);
 
-  /* Typography — Inter loaded via headTags in docusaurus.config.js */
-  --ifm-font-family-base: 'Inter', system-ui, -apple-system, 'Helvetica Neue',
+  /* Editorial surface — warm cream "paper" (light mode). Cards lift a touch
+     lighter than the page so they read as raised. Ink is a warm near-black with a
+     warm-gray secondary, matching the portfolio (#1A1A1A / #4A4742). */
+  --ifm-background-color: #ece7df;
+  --ifm-background-surface-color: #f4f0e8;
+  --ifm-font-color-base: #1a1a1a;
+  --ifm-heading-color: #1a1a1a;
+  --ifm-color-content-secondary: #4a4742;
+
+  /* Typography — Fraunces (headings) + Geist (body), loaded via headTags in
+     docusaurus.config.js. Fraunces is an old-style serif; it reads best around
+     600 weight and wants looser tracking than the old Inter setup. */
+  --ifm-font-family-base: 'Geist', system-ui, -apple-system, 'Helvetica Neue',
     Helvetica, Arial, sans-serif;
-  --ifm-heading-font-weight: 700;
+  --ifm-heading-font-family: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --ifm-heading-font-weight: 600;
   --ifm-font-size-base: 16px;
   --ifm-line-height-base: 1.7;
   --ifm-code-font-size: 95%;
 
   /* Shape + elevation */
-  --ifm-global-radius: 0.6rem;
-  --ifm-button-border-radius: 0.5rem;
-  --ifm-card-background-color: #ffffff;
-  --ifm-navbar-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
-  --ifm-global-shadow-lw: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --ifm-global-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.1);
+  --ifm-global-radius: 0.5rem;
+  --ifm-button-border-radius: 0.4rem;
+  --ifm-card-background-color: #f4f0e8;
+  --ifm-navbar-background-color: #ece7df;
+  --ifm-navbar-shadow: 0 1px 0 rgba(26, 26, 26, 0.08);
+  --ifm-global-shadow-lw: 0 1px 3px rgba(26, 26, 26, 0.08);
+  --ifm-global-shadow-md: 0 6px 20px rgba(26, 26, 26, 0.1);
 
   /* Premium ("gold") palette — shared by the sidebar lock items, the locked
      info pane, and the CTA cards so every premium surface reads consistently.
@@ -56,17 +75,27 @@
 /* Dark mode: lift the primary so links/buttons keep AA contrast on dark
    surfaces, and define dark equivalents of the custom tokens above. */
 html[data-theme='dark'] {
-  --ifm-color-primary: #6d9bff;
-  --ifm-color-primary-dark: #4a82ff;
-  --ifm-color-primary-darker: #3877ff;
-  --ifm-color-primary-darkest: #155cff;
-  --ifm-color-primary-light: #90b4ff;
-  --ifm-color-primary-lighter: #a2c0ff;
-  --ifm-color-primary-lightest: #c9dbff;
+  /* Coral lifted toward salmon so links/buttons keep AA on the warm-ink surface. */
+  --ifm-color-primary: #f0805a;
+  --ifm-color-primary-dark: #ed6c41;
+  --ifm-color-primary-darker: #eb6234;
+  --ifm-color-primary-darkest: #d44a1d;
+  --ifm-color-primary-light: #f39473;
+  --ifm-color-primary-lighter: #f59e80;
+  --ifm-color-primary-lightest: #f9bca8;
 
-  --ifm-color-primary-contrast-background: rgba(109, 155, 255, 0.12);
-  --ifm-card-background-color: #1c1e21;
-  --ifm-navbar-shadow: 0 1px 0 rgba(255, 255, 255, 0.08);
+  --ifm-color-primary-contrast-background: rgba(240, 128, 90, 0.14);
+
+  /* Warm-ink surfaces — the dark-mode sibling of the cream paper (warm, not cold
+     gray) so the two themes share one editorial temperature. */
+  --ifm-background-color: #1a1715;
+  --ifm-background-surface-color: #211d1a;
+  --ifm-font-color-base: #ece7df;
+  --ifm-heading-color: #f4f0e8;
+  --ifm-color-content-secondary: #b8b0a6;
+  --ifm-card-background-color: #211d1a;
+  --ifm-navbar-background-color: #1a1715;
+  --ifm-navbar-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
   --ifm-global-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.5);
 
   /* Premium gold, lifted for contrast on dark surfaces. */
@@ -83,11 +112,19 @@ html[data-theme='dark'] {
   );
 }
 
-/* Tighten heading rhythm a touch for a more modern feel. */
+/* Headings use Fraunces (the editorial display serif). Apply it explicitly so it
+   wins regardless of Infima's --ifm-heading-font-family wiring. A serif wants only
+   the faintest negative tracking — the old −0.02em (tuned for Inter) over-tightens
+   Fraunces, so relax it. The optical-size axis lets large headings open up. */
 h1,
 h2,
-h3 {
-  letter-spacing: -0.02em;
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--ifm-heading-font-family);
+  letter-spacing: -0.005em;
+  font-optical-sizing: auto;
 }
 
 /* ==========================================================================
@@ -115,10 +152,10 @@ h3 {
   transform: translateY(-1px);
 }
 
-/* In dark mode the primary is lightened (#6d9bff); white text on it fails AA
-   (2.7:1). Use dark text instead (6.2:1). Keep white on hover (primary-dark). */
+/* In dark mode the primary is a light salmon (#f0805a); white text on it fails AA.
+   Use dark ink instead. Keep white on hover (the darker primary-dark step). */
 html[data-theme='dark'] .navbar-coffee {
-  color: #1c1e21;
+  color: #1a1715;
 }
 html[data-theme='dark'] .navbar-coffee:hover {
   color: #fff;

--- a/bytesofpurpose-blog/src/pages/index.module.css
+++ b/bytesofpurpose-blog/src/pages/index.module.css
@@ -1,33 +1,51 @@
 /**
  * CSS files with the .module.css suffix will be treated as CSS modules
  * and scoped locally.
+ *
+ * Editorial hero — the cream "paper" surface, Fraunces headline, coral eyebrow,
+ * framed by thin rules. Mirrors the portfolio (bytesofpurpose.com): no gradient,
+ * generous whitespace, ink-on-cream rather than white-on-color.
  */
 
 .heroBanner {
-  padding: 5rem 0 4.5rem;
+  padding: 5rem 0 4rem;
   text-align: center;
   position: relative;
   overflow: hidden;
-  color: #fff;
-  background: linear-gradient(135deg, #2563eb 0%, #4f46e5 55%, #7c3aed 100%);
+  /* Inherit the page's cream paper; a hairline rule top + bottom frames the band. */
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
-html[data-theme='dark'] .heroBanner {
-  background: linear-gradient(135deg, #1e3a8a 0%, #3730a3 55%, #5b21b6 100%);
+/* Coral eyebrow — uppercase Geist, tracked out, like the portfolio's section labels. */
+.heroEyebrow {
+  font-family: var(--ifm-font-family-base);
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin: 0 0 1rem;
 }
 
 .heroTitle {
-  font-size: 3.5rem;
-  font-weight: 800;
-  letter-spacing: -0.03em;
+  font-family: var(--ifm-heading-font-family);
+  font-size: 4rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  color: var(--ifm-heading-color);
   margin-bottom: 0.75rem;
 }
 
 .heroSubtitle {
-  font-size: 1.4rem;
+  font-family: var(--ifm-heading-font-family);
+  font-style: italic;
   font-weight: 400;
-  opacity: 0.92;
-  margin-bottom: 2.25rem;
+  font-size: 1.5rem;
+  color: var(--ifm-color-content-secondary);
+  margin-bottom: 2.5rem;
 }
 
 .buttons {
@@ -44,34 +62,35 @@ html[data-theme='dark'] .heroBanner {
    stack to a single column on mobile (flex-wrap). */
 .chooser {
   display: flex;
-  gap: 1.25rem;
+  gap: 1.5rem;
   justify-content: center;
   flex-wrap: wrap;
-  max-width: 720px;
+  max-width: 760px;
   margin: 0 auto;
 }
 
+/* Cards sit on the cream paper now (not a translucent layer over a gradient), so
+   they read as raised tiles: surface bg, hairline border, coral accent on hover. */
 .chooserCard {
   flex: 1 1 300px;
-  max-width: 340px;
+  max-width: 350px;
   text-align: center;
   padding: 1.5rem 1.5rem 1.6rem;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  color: #fff;
+  border-radius: 14px;
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  color: var(--ifm-font-color-base);
   text-decoration: none;
-  transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease,
-    box-shadow 0.15s ease;
+  transition: transform 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
 .chooserCard:hover {
-  background: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.55);
+  border-color: var(--ifm-color-primary);
   transform: translateY(-4px);
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.28);
+  box-shadow: var(--ifm-global-shadow-md);
   text-decoration: none;
-  color: #fff;
+  color: var(--ifm-font-color-base);
 }
 
 /* Arched illustration sitting on top of each card. The source PNG already carries
@@ -90,7 +109,7 @@ html[data-theme='dark'] .heroBanner {
   max-width: 220px;
   height: auto;
   border-radius: 110px 110px 14px 14px;
-  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.3));
+  filter: drop-shadow(0 6px 16px rgba(26, 26, 26, 0.18));
   transition: transform 0.2s ease;
 }
 
@@ -99,28 +118,30 @@ html[data-theme='dark'] .heroBanner {
 }
 
 .chooserCardTitle {
+  font-family: var(--ifm-heading-font-family);
   font-size: 1.3rem;
-  font-weight: 700;
+  font-weight: 600;
   margin: 0 0 0.4rem;
+  color: var(--ifm-heading-color);
 }
 
 .chooserCardBody {
   font-size: 0.98rem;
   line-height: 1.45;
-  opacity: 0.92;
+  color: var(--ifm-color-content-secondary);
   margin: 0;
 }
 
 @media screen and (max-width: 966px) {
   .heroBanner {
-    padding: 3rem 1.5rem;
+    padding: 3.5rem 1.5rem 3rem;
   }
 
   .heroTitle {
-    font-size: 2.5rem;
+    font-size: 2.75rem;
   }
 
   .heroSubtitle {
-    font-size: 1.15rem;
+    font-size: 1.25rem;
   }
 }

--- a/bytesofpurpose-blog/src/pages/index.tsx
+++ b/bytesofpurpose-blog/src/pages/index.tsx
@@ -14,6 +14,7 @@ function HomepageHeader() {
   return (
     <header className={styles.heroBanner}>
       <div className="container">
+        <p className={styles.heroEyebrow}>Engineering · Faith · Craft</p>
         <h1 className={styles.heroTitle}>{siteConfig.title}</h1>
         <p className={styles.heroSubtitle}>{siteConfig.tagline}</p>
         {/* Four-card chooser (folded in from the old /welcome page): Craft = what I


### PR DESCRIPTION
## What & why

Re-skins the blog so it reads as a sibling of the **portfolio** (bytesofpurpose.com), replacing the generic blue→purple gradient + Inter "AI-slop" look with the portfolio's **executive editorial identity**. Scope is deliberately **typography + color + spacing only** — no content, structure, or IA changes; the blog's identity is unchanged, just made more befitting an executive's blog.

Inspiration was measured live from the portfolio (Fraunces serif + Geist sans, cream `#ECE7DF`, burnt-coral `#E4572E`, ink `#1A1A1A`).

## Changes

**Type** (`docusaurus.config.js`, `custom.css`)
- Headings → **Fraunces** (display serif, weight 600, optical sizing); body/UI → **Geist Sans**; Inter dropped.

**Color & surface** (`custom.css`)
- Blue `#2563eb` → **burnt terracotta** `#b33e1e` (deepened from the portfolio's `#E4572E` so coral text clears AA on cream).
- Light mode on **warm cream paper**; dark mode a **warm-ink** sibling (not cold gray) — both themes share one temperature.
- Premium gold palette + syntax-token AA overrides + a11y affordances (44px touch floor, underlined prose links, doc-footer overflow fix) left intact.

**Hero** (`index.tsx`, `index.module.css`)
- Gradient removed → calm cream band with Fraunces headline, **uppercase coral eyebrow**, italic-serif subtitle.
- Chooser cards restyled from translucent-on-gradient to **raised cream tiles** with coral hover; arched illustrations kept as an identity motif.

**Token follow-through** (`LatestPosts`, `HomepageFeatures`, `Graph` panel link) — pill/link colors aligned to the coral tokens; LinkedIn brand-blue and the changelog heatmap greens intentionally left as-is.

## Verification

- **Fonts load**: `getComputedStyle(h1).fontFamily` → Fraunces 600; body → Geist (confirmed via DevTools on the prod build).
- **axe WCAG 2 A/AA — 8/8 pass** (home, blog-index, docs-page, blog-post × light + dark) against the **production build** on :4173:
  ```
  ✓ home/blog-index/docs/blog-post (light)
  ✓ home/blog-index/docs/blog-post (dark)
  8 passed
  ```
- The coral migration surfaced **two real contrast regressions** — the active navbar link and the tag pills — both **fixed** (deepened base coral to AA-safe `#b33e1e`; small pill text uses a darker step). Re-scan is green.
- Visual pass at desktop (1440) + emulated mobile (390), light + dark, across hero / doc / blog-list / blog-post.

## Not run
`make test-regression`'s SEO + PostHog projects (need `.env` PostHog keys + a free :3000). The a11y project — the gate most relevant to a color/contrast change — was run and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)