### PR TITLE
fix(e2e): resolve pre-existing test debt (#27, #28, #29)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -19,8 +19,8 @@ dedup an issue outside the normal flow, update its status here in the same step.
 | 19 | closed (#22) | mobile-pager-midword-break | [#19](https://github.com/omars-lab/omars-lab.github.io/issues/19) pager breaks "Entrepreneurship" mid-word | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
 | 20 | closed (#22) | mobile-share-row-crammed | [#20](https://github.com/omars-lab/omars-lab.github.io/issues/20) share row crammed on premium card | audit-mobile 2026-06-03 | mobile-premium-share-row-and-pager.png |
 | 21 | closed (#22) | desktop-doc-measure-and-whitespace | [#21](https://github.com/omars-lab/omars-lab.github.io/issues/21) doc line-length ~94ch + wide-screen whitespace | audit-desktop 2026-06-03 | desktop-docs-line-length-1440.png, desktop-docs-whitespace-2560.png |
-| 27 | open | stale-test-self-renamed-journey | [#27](https://github.com/omars-lab/omars-lab.github.io/issues/27) craft-self-split asserts navbar 'Self' (renamed to 'Journey') | frontend-design regression 2026-06-05 | (e2e, no screenshot) |
-| 28 | open | stale-test-ingress-welcome-dead-route | [#28](https://github.com/omars-lab/omars-lab.github.io/issues/28) ingress DOC_URL='/welcome' is a dead route | frontend-design regression 2026-06-05 | (e2e, no screenshot) |
-| 29 | open | flaky-test-ab-copy-drift | [#29](https://github.com/omars-lab/omars-lab.github.io/issues/29) support-ab-test copy drifts from live flag payload | frontend-design regression 2026-06-05 | (e2e, no screenshot) |
+| 27 | closed (#30) | stale-test-self-renamed-journey | [#27](https://github.com/omars-lab/omars-lab.github.io/issues/27) craft-self-split asserts navbar 'Self' (renamed to 'Journey') | frontend-design regression 2026-06-05 | (e2e, no screenshot) |
+| 28 | closed (#30) | stale-test-ingress-welcome-dead-route | [#28](https://github.com/omars-lab/omars-lab.github.io/issues/28) ingress DOC_URL='/welcome' is a dead route | frontend-design regression 2026-06-05 | (e2e, no screenshot) |
+| 29 | closed (#30) | flaky-test-ab-copy-drift | [#29](https://github.com/omars-lab/omars-lab.github.io/issues/29) support-ab-test copy drifts from live flag payload | frontend-design regression 2026-06-05 | (e2e, no screenshot) |
 
 All screenshots: `~/Library/CloudStorage/Dropbox/bytesofpurpose-audits/2026-06-03/`

--- a/bytesofpurpose-blog/docs/craft/README.mdx
+++ b/bytesofpurpose-blog/docs/craft/README.mdx
@@ -30,3 +30,9 @@ learnings are reusable: if they helped me get better, they might help you too.
 - **🎯 Interview Prep**: coding challenges, mental models, and how to prepare.
 - **🏢 Companies**: how companies evaluate, level, and value engineers.
 - **🚀 Entrepreneurship**: learning the business side of building things.
+
+## Come back any time
+
+Want to find your way back here? Drag this to your bookmarks bar:
+
+<BookmarkletButton />

--- a/bytesofpurpose-blog/src/components/Support/CoffeeButton.tsx
+++ b/bytesofpurpose-blog/src/components/Support/CoffeeButton.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import posthog from 'posthog-js';
 import { EXPERIMENTS, resolveVariant } from '@site/src/experiments';
 
-// The coffee CTA, wired into the support-button-copy A/B experiment. The variants
-// differ in BOTH copy AND presentation:
-//   control → "Donate $5 for ☕️ in Paypal →"  rendered as a plain text LINK
-//   test    → "Buy me a coffee ☕"             rendered as a styled BUTTON
-// (the same experiment that used to drive the standalone navbar button). Variant
-// copy lives in src/experiments.ts; the conversion event keeps the same
-// 'support button clicked' name so the historical funnel stays continuous.
+// The coffee CTA, wired into the support-button-copy A/B experiment. Post the
+// 2026-06-01 re-scope the variants differ ONLY in PRESENTATION (identical copy):
+//   control → "Buy me a $5 coffee ☕ →"  rendered as a plain text LINK
+//   test    → "Buy me a $5 coffee ☕"    rendered as a styled BUTTON
+// (the same experiment that used to drive the standalone navbar button). The copy
+// lives once in src/experiments.ts (same in both arms); the conversion event keeps
+// the same 'support button clicked' name so the historical funnel stays continuous.
 const EXP = EXPERIMENTS['support-button-copy'];
 
 const PAYPAL =

--- a/bytesofpurpose-blog/test/e2e/craft-self-split.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/craft-self-split.spec.ts
@@ -4,13 +4,13 @@ import { test, expect, Page } from '@playwright/test';
  * Craft/Self two-tier IA (dev project, :3000).
  *
  * The docs split into two halves, each its own navbar item + sidebar:
- *   - Craft (/craft) — outrospective: the professional topics.
- *   - Self  (/journey)  — introspective: faith + personal growth.
+ *   - Craft   (/craft)   — outrospective: the professional topics.
+ *   - Journey (/journey) — introspective: faith + personal growth.
  *
  * What this proves:
- *   1. The navbar has BOTH "Craft" and "Self" (and no legacy "Learn").
- *   2. Landing in Craft shows ONLY craft topics in the sidebar (no Self topics),
- *      and landing in Self shows ONLY self topics (no Craft) — the halves don't
+ *   1. The navbar has BOTH "Craft" and "Journey" (and no legacy "Learn").
+ *   2. Landing in Craft shows ONLY craft topics in the sidebar (no Journey topics),
+ *      and landing in Journey shows ONLY journey topics (no Craft) — the halves don't
  *      bleed into each other.
  *   3. Each section landing renders its DISTINCT framing (outrospective vs
  *      introspective) — they are not the same page.
@@ -34,7 +34,7 @@ const CRAFT_TOPICS = [
 const SELF_TOPICS = ['Faith', 'Personal Growth'];
 
 // The sidebar nav (Docusaurus doc sidebar). Scope all sidebar queries to it so we
-// don't accidentally match the navbar's own "Craft"/"Self" items.
+// don't accidentally match the navbar's own "Craft"/"Journey" items.
 function sidebar(page: Page) {
   return page.locator('nav.menu, .theme-doc-sidebar-container').first();
 }
@@ -46,18 +46,18 @@ async function sidebarLabels(page: Page): Promise<string[]> {
   return (await links.allInnerTexts()).map((t) => t.trim()).filter(Boolean);
 }
 
-test.describe('Craft/Self — navbar', () => {
-  test('navbar shows Craft and Self (and not the old "Learn")', async ({ page }) => {
+test.describe('Craft/Journey — navbar', () => {
+  test('navbar shows Craft and Journey (and not the old "Learn")', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     const navbar = page.locator('.navbar');
     await expect(navbar.getByRole('link', { name: 'Craft', exact: true })).toBeVisible();
-    await expect(navbar.getByRole('link', { name: 'Self', exact: true })).toBeVisible();
+    await expect(navbar.getByRole('link', { name: 'Journey', exact: true })).toBeVisible();
     await expect(navbar.getByRole('link', { name: 'Learn', exact: true })).toHaveCount(0);
   });
 });
 
-test.describe('Craft/Self — sidebar isolation', () => {
-  test('Craft sidebar shows ONLY craft topics (no Self bleed-through)', async ({
+test.describe('Craft/Journey — sidebar isolation', () => {
+  test('Craft sidebar shows ONLY craft topics (no Journey bleed-through)', async ({
     page,
   }) => {
     await page.goto('/craft', { waitUntil: 'domcontentloaded' });
@@ -68,13 +68,13 @@ test.describe('Craft/Self — sidebar isolation', () => {
     for (const t of CRAFT_TOPICS) {
       expect(joined, `Craft sidebar should list "${t}"`).toContain(t);
     }
-    // ...and NO self topic leaks in.
+    // ...and NO journey topic leaks in.
     for (const t of SELF_TOPICS) {
-      expect(joined, `Craft sidebar must NOT list self topic "${t}"`).not.toContain(t);
+      expect(joined, `Craft sidebar must NOT list journey topic "${t}"`).not.toContain(t);
     }
   });
 
-  test('Self sidebar shows ONLY self topics (no Craft bleed-through)', async ({
+  test('Journey sidebar shows ONLY journey topics (no Craft bleed-through)', async ({
     page,
   }) => {
     await page.goto('/journey', { waitUntil: 'domcontentloaded' });
@@ -82,16 +82,16 @@ test.describe('Craft/Self — sidebar isolation', () => {
     const labels = await sidebarLabels(page);
     const joined = labels.join(' | ');
     for (const t of SELF_TOPICS) {
-      expect(joined, `Self sidebar should list "${t}"`).toContain(t);
+      expect(joined, `Journey sidebar should list "${t}"`).toContain(t);
     }
     for (const t of CRAFT_TOPICS) {
-      expect(joined, `Self sidebar must NOT list craft topic "${t}"`).not.toContain(t);
+      expect(joined, `Journey sidebar must NOT list craft topic "${t}"`).not.toContain(t);
     }
   });
 });
 
-test.describe('Craft/Self — distinct section welcomes', () => {
-  test('Craft landing is outrospective; Self landing is introspective', async ({
+test.describe('Craft/Journey — distinct section welcomes', () => {
+  test('Craft landing is outrospective; Journey landing is introspective', async ({
     page,
   }) => {
     await page.goto('/craft', { waitUntil: 'domcontentloaded' });
@@ -112,7 +112,7 @@ test.describe('Craft/Self — distinct section welcomes', () => {
 });
 
 test.describe('Homepage chooser', () => {
-  test('homepage links into BOTH halves (Craft + Self)', async ({ page }) => {
+  test('homepage links into BOTH halves (Craft + Journey)', async ({ page }) => {
     // The /welcome chooser was folded into the homepage hero; /welcome now → /.
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('a[href$="/craft"]').first()).toBeVisible();

--- a/bytesofpurpose-blog/test/e2e/debug-menu.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/debug-menu.spec.ts
@@ -11,17 +11,18 @@ import { test, expect, Page } from '@playwright/test';
  * What this proves:
  *   1. The menu appears on localhost and lists the registered experiment.
  *   2. Toggling a variant in the Experiments section ACTUALLY CHANGES the
- *      rendered UI — the <Support/> button copy flips control → test → back.
- *      This is the "switching does stuff" guarantee.
+ *      rendered UI — the /support coffee CTA flips its PRESENTATION
+ *      (link ↔ styled button) control → test → back. This is the
+ *      "switching does stuff" guarantee.
  *
- * Variant copy (flag: support-button-copy):
- *   control → "Buy me a coffee ☕"   test → "Support the dev 💜"
+ * Variant presentation (flag: support-button-copy, re-scoped 2026-06-01):
+ *   identical copy ("Buy me a $5 coffee ☕") in both arms; control renders a
+ *   plain text LINK, test renders a styled BUTTON (button--primary).
  */
 
-// A docs page that embeds <Support/> (same page support-ab-test.spec.ts uses).
-const PAGE_WITH_BUTTON =
-  process.env.AB_PAGE ||
-  '/craft/blogging/embed-structural-components/footer';
+// The /support page hosts the coffee CTA (CoffeeButton) wired to the experiment,
+// and the DebugMenu renders on every localhost page. Override with AB_PAGE.
+const PAGE_WITH_BUTTON = process.env.AB_PAGE || '/support';
 
 async function openMenu(page: Page) {
   const fab = page.getByRole('button', { name: 'Open debug menu' });
@@ -46,7 +47,7 @@ test.describe('DebugMenu — experiments switching', () => {
   test('toggling a variant writes the override and reloads', async ({ page }) => {
     await page.goto(PAGE_WITH_BUTTON, { waitUntil: 'domcontentloaded' });
 
-    const btn = page.getByTestId('support-button');
+    const btn = page.getByTestId('support-coffee-button');
     await expect(btn).toBeVisible();
 
     // Force "test" via the menu. The toggle writes ?ab-support-button-copy=test
@@ -61,7 +62,7 @@ test.describe('DebugMenu — experiments switching', () => {
       .click();
 
     await expect(page).toHaveURL(/ab-support-button-copy=test/);
-    await expect(page.getByTestId('support-button')).toBeVisible();
+    await expect(page.getByTestId('support-coffee-button')).toBeVisible();
   });
 
   test('support page coffee CTA reflects the variant (link vs button)', async ({ page }) => {
@@ -102,6 +103,6 @@ test.describe('DebugMenu — experiments switching', () => {
 
     // Clear strips the ab params and reloads → back to control (no override).
     await expect(page).not.toHaveURL(/ab-support-button-copy/);
-    await expect(page.getByTestId('support-button')).toBeVisible();
+    await expect(page.getByTestId('support-coffee-button')).toBeVisible();
   });
 });

--- a/bytesofpurpose-blog/test/e2e/ingress-attribution.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/ingress-attribution.spec.ts
@@ -24,8 +24,12 @@ import { test, expect, Page } from '@playwright/test';
 
 const PH_BASE = process.env.PH_BASE_URL || 'http://localhost:4173';
 
-// Docs are served under the /docs route prefix (see the navbar "Learn" link).
-const DOC_URL = '/welcome';
+// The Craft section landing (/craft) is a published doc with a normal H1, so the
+// swizzled DocItem/Content injects the inline ShareButton, and its markdown renders
+// the <BookmarkletButton/> "come back any time" affordance (re-homed here after the
+// standalone /welcome page was folded into the homepage). It exercises BOTH the
+// share-control and the bookmarklet assertions below.
+const DOC_URL = '/craft';
 // "Docs vs Blogs" is a CRAFT doc (its canonical home is /craft/blogging/...), NOT a
 // blog post — there is no /thoughts/docs-vs-blog-posts page. Point straight at the
 // canonical permalink so the share-control assertions exercise the real rendered page.
@@ -292,7 +296,7 @@ test.describe('Ingress attribution (production build)', () => {
     expect(text).toContain('im=share_cp');
   });
 
-  // ---- Bookmarklet affordance (on the welcome doc) ------------------------
+  // ---- Bookmarklet affordance (on the Craft landing doc) ------------------
   test('bookmarklet button renders a javascript: bookmarklet href', async ({ page }) => {
     await page.goto(DOC_URL, { waitUntil: 'domcontentloaded' });
     test.skip(!(await posthogReady(page)), 'PostHog disabled (no key).');
@@ -316,6 +320,6 @@ test.describe('Ingress attribution (production build)', () => {
     await expect(page.locator('[data-testid="bookmarklet-modal"]')).toBeVisible();
     await expect(page.locator('[data-testid="bookmarklet-drag-target"]')).toBeVisible();
     // Still on the same page (no in-place bookmarklet execution / navigation).
-    expect(page.url()).toContain('/welcome');
+    expect(page.url()).toContain('/craft');
   });
 });

--- a/bytesofpurpose-blog/test/e2e/support-ab-test.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/support-ab-test.spec.ts
@@ -1,26 +1,35 @@
 import { test, expect, Page } from '@playwright/test';
+import { EXPERIMENTS } from '../../src/experiments';
 
 /**
- * Validates the Support-button A/B experiment (flag: support-button-copy).
- *  control → "Buy me a coffee ☕"   test → "Support the dev 💜"
+ * Validates the Support-CTA A/B experiment (flag: support-button-copy).
+ *
+ * RE-SCOPED 2026-06-01 (copy → presentation): both arms now render the SAME copy
+ * ("Buy me a $5 coffee ☕", defined once in src/experiments.ts); the only thing that
+ * varies is PRESENTATION on the /support page coffee CTA:
+ *   control → plain text LINK   test → styled BUTTON (button--primary button--lg)
+ * (see src/components/Support/CoffeeButton + the experiment doc
+ *  docs/craft/product-management/experiments/2026-05-31-support-button-copy.md).
+ *
+ * To avoid drifting from the live PostHog payload, the expected copy is read from
+ * the component's source of truth (EXPERIMENTS) rather than hardcoded, and the
+ * variant is forced deterministically via the localhost-only ?ab=<variant> URL
+ * override (src/experiments.ts urlOverride()) — NOT the live flag assignment.
  *
  * Run against the production build with POSTHOG_TEST_MODE=1 (so PostHog's bot
  * filter doesn't drop events):  make test-posthog  also runs these, or:
  *   set -a; source .env; set +a
  *   ( cd bytesofpurpose-blog && POSTHOG_TEST_MODE=1 yarn build && yarn serve --port 4173 & )
  *   PH_BASE_URL=http://localhost:4173 npx playwright test support-ab-test
- *
- * Strategy: force each variant with posthog.featureFlags.overrideFeatureFlags,
- * reload so the component re-reads the flag, then assert the rendered copy and
- * that exposure ($feature_flag_called) + conversion ('support button clicked')
- * events reach the ingestion host with the right variant.
  */
 
 const PH_BASE = process.env.PH_BASE_URL || 'http://localhost:4173';
-// A docs page that embeds <Support/>. Override with PH_AB_PAGE if it moves.
-const PAGE_WITH_BUTTON =
-  process.env.PH_AB_PAGE ||
-  '/craft/blogging/embed-structural-components/footer';
+// The /support page is the single home of the coffee CTA (CoffeeButton). Override
+// with PH_AB_PAGE if it moves.
+const PAGE_WITH_BUTTON = process.env.PH_AB_PAGE || '/support';
+
+// Source of truth for the rendered copy — identical in both arms post-re-scope.
+const EXP = EXPERIMENTS['support-button-copy'];
 
 async function posthogReady(page: Page) {
   try {
@@ -31,21 +40,34 @@ async function posthogReady(page: Page) {
   }
 }
 
-test.describe('Support button A/B experiment', () => {
+test.describe('Support CTA A/B experiment (link vs button)', () => {
   test.use({ baseURL: PH_BASE });
 
-  for (const [variant, expectedCopy] of [
-    ['control', 'Donate $5'],
-    ['test', 'Buy me a coffee'],
-  ] as const) {
-    test(`variant "${variant}" renders "${expectedCopy}"`, async ({ page }) => {
+  for (const variant of ['control', 'test'] as const) {
+    test(`variant "${variant}" renders the ${variant === 'test' ? 'styled button' : 'plain link'}`, async ({
+      page,
+    }) => {
       // Force the variant via the localhost-only URL override (deterministic,
       // applied before hydration — see src/experiments.ts urlOverride()).
       await page.goto(`${PAGE_WITH_BUTTON}?ab=${variant}`, { waitUntil: 'domcontentloaded' });
 
-      const btn = page.getByTestId('support-button');
+      const btn = page.getByTestId('support-coffee-button');
       await expect(btn).toBeVisible();
-      await expect(btn).toContainText(expectedCopy);
+
+      // Copy is IDENTICAL in both arms — assert it matches the registry source of
+      // truth (so the test can never drift from the live flag payload). The control
+      // (link) variant appends a trailing arrow when the copy lacks one.
+      const copy = EXP.variants[variant];
+      await expect(btn).toContainText(copy.replace(/\s*→\s*$/, ''));
+
+      // Presentation is the variable under test: control is a plain text LINK
+      // (no Infima button classes), test is a styled BUTTON.
+      const className = (await btn.getAttribute('class')) || '';
+      if (variant === 'test') {
+        expect(className).toContain('button--primary');
+      } else {
+        expect(className).not.toContain('button--primary');
+      }
 
       // Capture a per-variant screenshot artifact so control vs treatment can be eyeballed
       // (and embedded in the experiment timeline doc) without re-running. Artifacts only —


### PR DESCRIPTION
## What

Resolves three pre-existing e2e test failures (#27, #28, #29) found by the
`make test-regression` run on 2026-06-05. All are **stale-test debt** unrelated to
the design refresh (#26) — they drifted from the live site after the nav rename
(#25), the `/welcome` → homepage fold, and the support A/B **copy → presentation**
re-scope (2026-06-01).

## Fixes

### #27 — `craft-self-split.spec.ts` asserted navbar "Self"
The nav item was renamed **Self → Journey** in #25 (`docusaurus.config.js` truth:
`label: 'Journey'`). Updated the navbar assertion, the `describe`/`test` titles, and
the doc-comments. Sidebar-isolation already targeted `/journey`.

### #28 — `ingress-attribution.spec.ts` `DOC_URL='/welcome'` was a dead route
`/welcome` no longer exists (the chooser was folded into the homepage). Repointed
`DOC_URL` to the **published Craft landing (`/craft`)**, and **re-homed the
`<BookmarkletButton/>`** there — after `/welcome` was removed it had no published
home, so the 3 bookmarklet tests had no real target. Now the share-control **and**
bookmarklet assertions exercise a real rendered page. (`/welcome → /` client-redirect
already present in `createRedirects`.)

### #29 — `support-ab-test.spec.ts` hardcoded copy drifted from the live flag
The experiment was **re-scoped 2026-06-01 from copy → presentation**: both arms now
render identical copy (`"Buy me a $5 coffee ☕"`, defined once in `src/experiments.ts`);
**control = plain text link, test = styled button**, on the **`/support`** page
(`CoffeeButton`). Rewrote the spec to:
- target `/support` + the real testid `support-coffee-button`,
- read expected copy from the **`EXPERIMENTS` source of truth** (so it can't drift again),
- assert the **link-vs-button presentation** difference.

Also fixed the **same stale footer-doc / `support-button` references in
`debug-menu.spec.ts`** (this was the dev project's lone failure — same root cause)
and corrected `CoffeeButton.tsx`'s stale doc-comment.

## Regression evidence (this branch)

| Project | Result |
|---|---|
| **dev** (`--project=dev`, isolated :3737) | **34 passed, 1 skipped** (known build-only draft-sidebar skip), 0 failed |
| **prod** (`make test-prod-checks`) | **35/35** (axe WCAG 2 A/AA light+dark, SEO, dev-only-surfaces-absent) |
| **posthog** (`make test-posthog`) | **26/26** (incl. 14 ingress, 2 support-ab, 3 support-page, 3 vote, 4 posthog-events) |

## Notes
- Closes #27, #28, #29. `ISSUES.md` updated to mark all three closed.
- No production behavior change beyond re-homing the bookmarklet affordance onto the
  `/craft` landing (the feature was previously orphaned when `/welcome` was deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
