### PR TITLE
scan posts batch 3+4: reflection frameworks + question-set series (17 drafts)

### DIFF
--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-aligning-actions-with-ambitions.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-aligning-actions-with-ambitions.md
@@ -1,0 +1,75 @@
+---
+slug: questions-for-aligning-actions-with-ambitions
+title: "Questions for Aligning Your Actions With Your Ambitions"
+description: "The questions I return to when I want to check whether my actions match my ambitions, and decide what to stop, start, or do more of."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+Ambitions are easy to declare and hard to live up to. The gap between the two shows
+up in what you actually do all day. These are the questions I use to close that gap:
+to notice where my actions drift from what I claim to want, and to decide what to
+stop, what to start, and what to double down on. Pick the ones that make you a little
+uncomfortable.
+
+<!-- truncate -->
+
+## Action-ambition alignment
+
+- Do your actions match your ambitions?
+- What are your current actions, and what are your ambitions? Where is the misalignment?
+- What actions actually align with your ambitions?
+- What are you going to do to be successful?
+
+## What to stop doing
+
+When you catch yourself thinking "Why do I have to do this?", treat it as a signal
+that something may need to stop.
+
+- Why do you have to do this? What does that resistance tell you?
+- What are you doing that doesn't serve your ambitions?
+- What should you stop doing?
+
+## What to start doing
+
+The most useful prompts here start with "why." They surface the thing you keep
+avoiding.
+
+- Why haven't you done it? Why can't you? Why don't you?
+- What should you start doing to align with your ambitions?
+
+## What to increase doing
+
+- What are you doing that you should do more of?
+- What activities align with your ambitions but need more time and energy?
+- How will you fully utilize your talents? Are you developing your gifts?
+
+## Challenging yourself
+
+- Are you challenging yourself? Are you at the edge of your comfort zone?
+- How are you challenging yourself?
+- Where and why do you fall short of your expectations?
+- How do you pressure yourself to become a diamond?
+
+## Progress and purpose alignment
+
+- Is what you are doing in tune with your purpose?
+- What could you be if you stopped doing X and started doing Y?
+- Are you moving forward, or moving back?
+- Are you making progress, or are you stagnated?
+
+## Effort and values
+
+- Are you doing all you can with what you have?
+- Do your actions resonate with your values?
+
+## Intentions
+
+- What are your intentions? What do you intend to do?
+
+## Taking action
+
+- What will you do to achieve your goals?
+- What does it take to change, to set a plan for tomorrow?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-challenging-your-own-assumptions.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-challenging-your-own-assumptions.md
@@ -1,0 +1,62 @@
+---
+slug: questions-for-challenging-your-own-assumptions
+title: "Questions for Challenging Your Own Assumptions"
+description: "A set of prompts for interrogating your own thinking: surfacing assumptions, hunting for discomforting evidence, and steelmanning the other side."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+Most of the time we use questions to learn about the world. This set turns the lens
+around and points it at your own reasoning. The goal isn't to win an argument with
+yourself, it's to notice where you've stopped looking. Use these when you feel
+unusually certain, when you're defending a position hard, or when you suspect you're
+only collecting evidence that flatters what you already believe. Pick the ones that
+make you a little uncomfortable.
+
+<!-- truncate -->
+
+## Identifying what to question
+
+- How do you question yourself? In what context are you questioning your life, your growth?
+- What are you assuming right now? What arguments or positions are you currently holding?
+
+## Challenging your thinking
+
+- Are you looking for discomforting evidence?
+- Are you considering where you are wrong? How might you be wrong?
+- What problems do you have with the information you're relying on?
+- Why are you so adhered to your argument?
+
+## Considering opposing views
+
+- Have you heard the opposite side of the argument?
+- Does your position contain any logical flaws?
+- What evidence contradicts or challenges your position?
+- What are the odds of your mind changing through a simple conversation?
+
+## Examining your reasoning
+
+- What assumptions underlie your thinking?
+- What evidence supports your position, and what evidence challenges it?
+- How might you be wrong about this?
+
+## Categories worth questioning
+
+When you're not sure where to aim, run through these lenses and ask what you've taken
+for granted in each.
+
+- Setting: the story you're telling, the location, the interactions
+- Subjects: people and relationships
+- Role models and the abstractions you're reasoning from
+- Mood, emotions, celebration, kindness
+- Necessity and circumstances
+- Action, habits, time, buying habits, change
+- Improvement and growth
+- Concerns and worries
+- Usability, accessibility, affordability
+- Experience and memories
+- Assumptions, false assumptions, problems, issues, insecurities
+- Motivation and inspiration
+- Likes, desires, dislikes

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-finding-your-purpose.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-finding-your-purpose.md
@@ -3,7 +3,7 @@ slug: questions-for-finding-your-purpose
 title: "Questions for Finding Your Purpose"
 description: "A taxonomy of the questions I return to when I want to reflect on why I exist, what gives life meaning, and how I want to be remembered."
 authors: [oeid]
-tags: [self-reflection, mindset]
+tags: [self-reflection, question-set]
 date: 2026-01-25
 draft: true
 ---

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-finding-your-purpose.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-finding-your-purpose.md
@@ -1,0 +1,123 @@
+---
+slug: questions-for-finding-your-purpose
+title: "Questions for Finding Your Purpose"
+description: "A taxonomy of the questions I return to when I want to reflect on why I exist, what gives life meaning, and how I want to be remembered."
+authors: [oeid]
+tags: [self-reflection, mindset]
+date: 2026-01-25
+draft: true
+---
+
+I don't think purpose is something you find once and file away. It's something you
+interrogate. Over the years I've collected the questions that actually move me when
+I sit with them, and grouped them by what they're really asking. This is that
+collection: a menu of prompts for reflecting on why you exist, what gives you
+meaning, and how you want to be remembered. Pick the ones that sting a little.
+
+<!-- truncate -->
+
+## Core purpose
+
+- What is the purpose of your life?
+- What is your main objective?
+- What's the meaning of your life?
+
+## What gives you meaning
+
+- What gives you meaning? What drives you? What motivates you? What moves you?
+- What gives you the strength to keep going forward?
+
+## Why you do what you do
+
+- Why do you do what you do? What are your reasons?
+- What are your beliefs? What are your values?
+- What are your goals, values, convictions, decisions, and plans worth?
+
+## Legacy and remembrance
+
+- Why do you want to be remembered? Why do you refuse to be forgotten?
+- Why do you want to be great? Why do you want to be known?
+- What difference will you make with the blessings you've been given?
+
+## Vision and story
+
+- What is your vision? What is your own story?
+- How will you design your story? How does your story end?
+- What vision do you have for humanity? Have you found your vision?
+- Do you believe your story? Is it as valuable as you think it is?
+
+## Mortality and finite time
+
+- Life is temporary: what will you do with the time you have?
+- You will die. How does that shape what matters?
+- What would you do if you knew you only had one year left?
+- Are you living as if your time is limited?
+- What will remain when you're gone? How does knowing life ends change how you live
+  today?
+
+## Divine creation and becoming your best
+
+- Why did God create you? What were you created to do?
+- Are you becoming the best version of yourself?
+- What does it mean to fulfill your God-given potential?
+- What gifts were you given to steward? Are you living up to what you were made for?
+- What would the best version of you look like? What's stopping you from becoming
+  who you were meant to be?
+
+## Discovering your calling
+
+- What makes you unique? What can you do better than everyone else?
+- What do you love more than anyone else? What does the world need you to do?
+- What kinds of problems do you always want to solve?
+- What question(s) do you want to dedicate your life to answering?
+- What question(s) can *only you* answer? What question do you *love* answering?
+- What is your sweet spot? What does the world demand?
+
+## Believing in purpose
+
+- Luck favors the believers: what do you believe in?
+- What do you believe you are capable of doing?
+- What is bigger than you that you believe in?
+- How many times are you ready to fail?
+
+## Championing a cause
+
+- What cause do you believe in? What cause do you champion?
+- How will you advance humanity? How will you challenge the status quo?
+- What will excite the human spirit of those around you?
+
+## Knowing you're getting closer
+
+- How do you know you're getting closer to your purpose?
+- What milestones will inch you closer?
+- How can you litmus-test your passions to see if they align with your purpose?
+- How do you know you've found your true calling?
+- When should you stop seeking purpose?
+
+## Avoiding regret
+
+- What skills will die with you?
+- If you don't act now, what will you end up regretting?
+- What do you *not* want to be?
+
+## Listening to your inner voice
+
+You possess an inner force trying to guide you to your full potential. It makes you
+feel unhappy when you stray from your purpose, and successful when you don't.
+Learning to recognize when you're near your purpose, and when you've drifted from
+it, is most of the work.
+
+## Understanding your uniqueness
+
+- What message are you transcribing? What do you make people feel?
+- What thoughts will you stir in the minds of others? How do you make people think?
+- What makes you *you*? Why would someone else want to get to know you?
+- In what can you truly say "there will never be anyone else like me"?
+
+The people who are closest to their nature will lead the world.
+
+## Purifying intentions
+
+- Do you want to serve humanity for humanity to serve you back? To be remembered?
+- Why do I do what I do? As I dig deeper into my purpose, I become more aware of the
+  things I do, and why.

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-improving-how-you-operate.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-improving-how-you-operate.md
@@ -1,0 +1,47 @@
+---
+slug: questions-for-improving-how-you-operate
+title: "Questions for Improving How You Operate"
+description: "A set of prompts for examining the how of your life: your processes, problem-solving techniques, and the systems you operate by."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+Most reflection focuses on what you're doing and why. This set is about the *how*:
+the processes, techniques, and systems you operate by without ever naming them. The
+questions below are meant to surface those invisible methods so you can evaluate
+them, reuse what works, and retire what doesn't. Pick a section and sit with it.
+
+<!-- truncate -->
+
+## Core processes
+
+- What is your self-reflection process?
+- What is your problem-solving technique?
+- How do you get what you want?
+- How does your life work?
+- How do you understand questions?
+
+## Reusing and learning from the past
+
+- How will you reuse your solutions from previous problems to solve new ones?
+- How will you index your responses so you can find them again?
+- How often will you re-evaluate your previous solutions?
+
+## Process evaluation
+
+- Are there any new processes you would benefit from?
+- Are you completing all of your processes, or failing to do any of them?
+- How will you reflect on your processes?
+- What decisions have you made regarding your processes?
+- What is your plan of action, your process for coming into action?
+
+## Artifacts and constraints
+
+- What artifacts will your process produce?
+- What constraints will you impose on your process?
+
+## Automation
+
+- What actions repeat in your life that you can automate?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-knowing-what-you-want.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-knowing-what-you-want.md
@@ -1,0 +1,54 @@
+---
+slug: questions-for-knowing-what-you-want
+title: "Questions for Knowing What You Want"
+description: "A curated set of questions for getting honest about what you want, what you're chasing, and what you'd regret not pursuing."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+Knowing what you want sounds simple until you actually try to answer it. Most of us chase things we never deliberately chose. These are the questions I return to when I want to cut through the noise and name what I'm really after, grouped by what they're getting at. Sit with the ones that make you uncomfortable.
+
+<!-- truncate -->
+
+## Core desires
+
+- What do you want? What do you not want?
+- What do you want to do with your life?
+- What would you rather have?
+
+## What you're chasing
+
+- What are you chasing? What are you working towards?
+- What are you infatuated with?
+- What's got you turned on? What's got you turned off?
+
+## Regrets and wishes
+
+- What would you be sorry you didn't do?
+- What would you wish you did?
+- What would you regret not pursuing?
+
+## Dreams and aspirations
+
+- What is your dream? Where do you want to end up?
+- What do you want others to feel upon realizing your vision?
+- Are you crying for a dream? Are you living your ideal life?
+
+## Emotions and triggers
+
+- What triggers your emotions? What has brought you to tears?
+- What gives you the chills? What sends shivers down your spine?
+
+## Mastery and likes
+
+- What do you want to master?
+- Are you ready to do what it takes to become a master? What does it mean to be a master?
+- What are the things you like?
+
+## Infatuation and bliss
+
+- Are you infatuated with what you do?
+- Are you following your bliss? What are you lost in?
+- What makes you happy?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-knowing-who-you-are.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-knowing-who-you-are.md
@@ -3,7 +3,7 @@ slug: questions-for-knowing-who-you-are
 title: "Questions for Knowing Who You Are"
 description: "Why do others often know us better than we know ourselves? A taxonomy of prompts for examining your character, values, beliefs, and the forces that shape your identity."
 authors: [oeid]
-tags: [self-reflection, mindset]
+tags: [self-reflection, question-set]
 date: 2026-01-25
 draft: true
 ---

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-knowing-who-you-are.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-knowing-who-you-are.md
@@ -1,0 +1,81 @@
+---
+slug: questions-for-knowing-who-you-are
+title: "Questions for Knowing Who You Are"
+description: "Why do others often know us better than we know ourselves? A taxonomy of prompts for examining your character, values, beliefs, and the forces that shape your identity."
+authors: [oeid]
+tags: [self-reflection, mindset]
+date: 2026-01-25
+draft: true
+---
+
+Why do others often know more about us than we know about ourselves? We rarely sit
+down and study the one subject we have the most data on. These are the questions I
+return to when I want to examine who I actually am: my character, my values, the
+beliefs and emotions quietly steering me, and the story I keep feeding myself.
+
+<!-- truncate -->
+
+## Defining who you are
+
+- Who are you? Who should you be? Why should anyone care?
+- How do you define yourself? What is the gist of you? What is your reality?
+
+## Examining your character
+
+- What are the vital elements of your character?
+- What story do you feed yourself?
+- Pay attention to your inner dialog. It's writing you whether you watch it or not.
+
+## Values and beliefs
+
+- What are your values? What are your beliefs?
+- What is currently important to you?
+- Will your thoughts and beliefs matter in 100 years?
+
+## What controls and shapes you
+
+- What needs, beliefs, and emotions are controlling you?
+- What constraints have you imposed on yourself? What constraints have others imposed
+  on you?
+- Which influences, motivators, de-motivators, and emotions will you *let* affect you?
+- Why have you gotten comfortable in the darkness?
+
+## Becoming self-aware
+
+- When will you start analyzing yourself? Why don't you study yourself?
+- Why do others know more about you than you know about yourself?
+- How do you become self-aware? What must you do to declare yourself self-aware?
+- What is your process for reaching a full state of self-awareness, and what are its
+  different states?
+
+## Capturing the essentials
+
+A compact battery of questions to take your own inventory:
+
+- What do you always think about? What interests you? What are your strengths?
+- What is your purpose? What are your goals? What are your dreams?
+- What are your obstacles? What motivates you? What thoughts push you past your
+  obstacles?
+- You can overcome thought X by remembering thought Y. How can you manage your
+  emotions?
+
+## Learning about yourself through what's around you
+
+- How can you learn more about yourself by studying the natural tendencies of
+  society?
+- How can you learn more about yourself from God? How does that push you to become
+  more self-aware?
+- Do you minimally reflect any of the 99 names of God?
+
+## "I am" statements
+
+- What are your "I am" statements? "Remember who you are. You are more than what you
+  have become."
+- Can you guess who you are based on your "I am's" and your "I will's"?
+- Do your "I am" statements align with what you believe your passion is?
+
+## Manifesting your beliefs
+
+- What do you truly believe in? I believe I have something special to give this world.
+- We have an opportunity to encode our beliefs, to make our values tangible. How will
+  you do that?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-measuring-your-progress.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-measuring-your-progress.md
@@ -1,0 +1,60 @@
+---
+slug: questions-for-measuring-your-progress
+title: "Questions for Measuring Your Progress"
+description: "The questions I return to when I want to know whether I'm actually winning, reaching my potential, and closing the gap to my dreams."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+Progress is easy to assume and hard to measure. It's worth stopping every so often to ask whether you're truly striving toward your potential, whether you can even tell if you're winning, and whether you have the will to keep going. These are the questions I sit with when I want an honest read on where I stand. Pick the ones that are uncomfortable to answer.
+
+<!-- truncate -->
+
+## Potential
+
+- Have you even scratched the surface of your potential?
+- Are you striving to your potential? Are you pursuing becoming the person you can be?
+- Perhaps you are already on the road to your goal?
+- Do you know where you are going?
+
+## Accomplishments
+
+- What have you accomplished?
+- How close are you to fulfilling your dreams?
+- How do you close the gap to being successful?
+- What obstacles have you overcome?
+
+## Winning and losing
+
+- Are you winning? Do you really want to win?
+- Are you keeping score? Can you tell if you are winning or losing?
+- How will you make losing painful?
+- How do you celebrate?
+
+## Readiness and will
+
+- Are you ready to pursue failure?
+- Are you ready to take on the emotional burden of winning? Of sending the countless emails? Of dealing with rejection and broken promises?
+- You may not be phenomenally skilled, but are you phenomenally willed?
+- Are you letting something out of your control control you?
+
+## Readiness to change
+
+- Are you ready? Are you ready to pick your why?
+- Are you ready to write your story? Are you ready to find yourself?
+- Are you ready to change your life?
+
+## Waking up excited
+
+- Do you wake up every day working towards a vision bigger than you?
+- Do you wake up excited every morning?
+- Do you wake up itching to work every day?
+
+## Goal achievement and tracking
+
+- Have you achieved any of your goals?
+- How many tasks did you complete this week?
+- What reports will help you track your progress?
+- Have you begun failing your way to success?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-reflecting-on-what-youre-learning.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-reflecting-on-what-youre-learning.md
@@ -1,0 +1,44 @@
+---
+slug: questions-for-reflecting-on-what-youre-learning
+title: "Questions for Reflecting on What You're Learning"
+description: "A set of prompts for checking whether you're learning the right things, whether it aligns with your purpose, and where you still need to grow."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+It's easy to keep learning and never stop to ask whether you're learning the right things. Most of us absorb whatever lands in front of us instead of choosing what to study on purpose. These are the questions I return to when I want to step back, check that my learning is pointed at who I want to become, and notice the gaps I keep avoiding. Pick the ones that make you pause.
+
+<!-- truncate -->
+
+## Core learning questions
+
+- What reflections have you had on the things you are learning?
+- What did you want to learn at different points in time?
+- Are you learning the right things?
+- Do the things you are learning align to your purpose?
+- How do you ensure you are learning things that fulfill what you want to become?
+
+## Education focus
+
+- What should you focus your education on?
+- What topics do you want to learn more about? What do you want to learn about?
+- What subjects do you enjoy learning about?
+
+## Growth areas and shortcomings
+
+- What areas in your life can you improve? What areas of yourself should you work on?
+- What aspects of your life are you currently trying to improve?
+- How should you grow?
+- What are your gaps? What are your shortcomings?
+
+## Learning style
+
+- What is your learning style?
+
+## Capturing realizations
+
+- What realizations have you had?
+- What learnings need to be captured?
+- What insights have emerged from your experiences?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-reflecting-on-your-worth.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-reflecting-on-your-worth.md
@@ -1,0 +1,53 @@
+---
+slug: questions-for-reflecting-on-your-worth
+title: "Questions for Reflecting on Your Worth"
+description: "A taxonomy of the questions I return to when I want to take honest stock of my value, my skills, and the impact I have on the people around me."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+It's easy to confuse what you've done with what you're worth. Worth is harder: it's about the value you create, the skills you actually have, and the way you change how people think and feel. These are the questions I sit with when I want an honest inventory of myself rather than a flattering one. Pick the ones that make you pause before you answer.
+
+<!-- truncate -->
+
+## Evaluating yourself
+
+- How do you evaluate yourself? What makes you valuable?
+- What do you think you're worth? What is valuable about you?
+- What are your most impressive skills?
+
+## How you add value
+
+- How do you add value? How do you plan on being valuable?
+- Where can you have an impact? Where do you choose to affect?
+- How are you valuable to yourself? To society?
+
+## Your impact on others
+
+- What thoughts do you want to invoke from others? How do you want them to structure their thoughts?
+- What emotions do you want to invoke?
+- How do you want others to see you?
+- How can you affect how others think, feel, and perceive you?
+
+## Skills and talents
+
+- What is your fast ball, the one thing you do better than anything else?
+- What talents and abilities do you currently have? Which do you want to focus on, and why?
+- What balance of skills do you have versus the balance you want?
+- What gift of yours is worth developing? What deserves developing?
+- How will you fully utilize your talents?
+- What qualifies you to teach what you know?
+
+## Your contribution
+
+- What is your contribution to yourself? To your family? To society? To the planet?
+- How do you plan on being valuable, and to whom?
+- What resources of the world are you utilizing?
+
+## Taking inventory
+
+- Do you have an honest inventory of the skills you have?
+- What do you do well? What do you know?
+- What deserves more of your attention to develop further?

--- a/bytesofpurpose-blog/blog/2026-01-25-questions-for-understanding-your-inaction.md
+++ b/bytesofpurpose-blog/blog/2026-01-25-questions-for-understanding-your-inaction.md
@@ -1,0 +1,40 @@
+---
+slug: questions-for-understanding-your-inaction
+title: "Questions for Understanding Your Inaction"
+description: "The questions I sit with when I want to understand why I haven't started something, what's holding me back, and how to break the loop."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-25
+draft: true
+---
+
+Knowing what you want is easy. Knowing why you still haven't done it is the harder, more useful work. These are the questions I return to when I'm stuck in a loop, when I keep choosing the logical thing over the meaningful one, or when something I clearly want just isn't getting done. Read them slowly and answer the ones that make you flinch.
+
+<!-- truncate -->
+
+## Naming the inaction
+
+- What haven't you done that you want to do? What are you not doing that you should be doing?
+- Why have you not done it yet? Why are you not doing it?
+- Why don't you do it?
+- When will you start?
+
+## Barriers preventing action
+
+- What barriers are preventing action?
+- What support or resources would you need to move forward?
+- What would need to change for you to take action?
+- Which of these barriers can actually be removed?
+
+## Patterns that keep you stuck
+
+- What patterns keep you from taking action?
+- Are you stuck in a loop? Are you doing things that are too logical?
+- Why have you gotten comfortable in the darkness?
+- Why NOT do things?
+
+## Constraints, self-imposed and external
+
+- What constraints have you imposed on yourself?
+- What constraints have others imposed on you?
+- What are the needs, beliefs, and emotions that are controlling you?

--- a/bytesofpurpose-blog/blog/2026-01-26-questions-for-discovering-your-interests.md
+++ b/bytesofpurpose-blog/blog/2026-01-26-questions-for-discovering-your-interests.md
@@ -3,7 +3,7 @@ slug: questions-for-discovering-your-interests
 title: "Questions for Discovering Your Interests"
 description: "You can't list your interests on command. But you can infer them from what you do. A taxonomy of prompts for reverse-engineering what actually intrigues you."
 authors: [oeid]
-tags: [self-reflection, mindset]
+tags: [self-reflection, question-set]
 date: 2026-01-26
 draft: true
 ---

--- a/bytesofpurpose-blog/blog/2026-01-26-questions-for-discovering-your-interests.md
+++ b/bytesofpurpose-blog/blog/2026-01-26-questions-for-discovering-your-interests.md
@@ -1,0 +1,85 @@
+---
+slug: questions-for-discovering-your-interests
+title: "Questions for Discovering Your Interests"
+description: "You can't list your interests on command. But you can infer them from what you do. A taxonomy of prompts for reverse-engineering what actually intrigues you."
+authors: [oeid]
+tags: [self-reflection, mindset]
+date: 2026-01-26
+draft: true
+---
+
+Here's the trap with "what are you interested in?" — you can't list your interests
+on command. You don't magically know them. The honest way in is to *infer* them
+from what you already do, read, build, and avoid. These are the questions I use to
+reverse-engineer my own curiosity: what draws me, what I'm done with, and what
+problems I keep circling back to.
+
+<!-- truncate -->
+
+## Inferring interests from what you do
+
+- How can you infer what you're interested in from what you actually do?
+- You can't list your interests on command, so what do your actions and behaviors
+  reveal?
+- How do you make sure you're not overlooking an interest when you take stock?
+
+## Topics and interests
+
+- What interests you? What topics, what learning topics?
+- What **no longer** interests you, and why were you once drawn to it?
+- What are you interested in tinkering with, learning more about, or checking out?
+
+## Problems and questions
+
+- What problems do you want to deal with or solve?
+- What questions do you want to answer? Which do you *like* answering?
+- What problems spike your curiosity? What kinds of problems do you naturally solve?
+
+## Resources and tools
+
+- What resources do you want to explore?
+- What books interest you? What blogs?
+- What tools or software components are you interested in using?
+
+## Projects and research
+
+- What projects are you interested in, especially ones that help you reach your
+  goals?
+- What projects touch multiple concepts you want to learn, or tie a few together?
+- What should you research? What books would help with your projects?
+
+## Identifying your passions
+
+- How can you pinpoint your different passions? What makes a passion a passion?
+- What do you love? How can you be sure you've found a passion?
+- Can you determine your passions by reflecting on your actions?
+- Is your passion captured in the books you read, the things you want to study, the
+  projects you've completed?
+
+## Identifying your hatreds
+
+The inverse is just as telling. *What do you hate?* I hate wasting time on redundant
+work, which is probably exactly why I'm drawn to automation. Your aversions point at
+your interests from the other side.
+
+## Activities and themes that recur
+
+When I look across what I keep doing, the themes repeat: I want to build, to identify
+and solve problems and puzzles. I'm passionate about composing meaning, which may be
+why I'm pulled toward both engineering and arts and crafts. I like designing things I
+think are valuable and seeing if they work. Part of my passion is pioneering,
+mixing and matching ideas, being creative. The recurring theme is structuring and
+organizing a thinking process so it can help others structure their own thoughts.
+
+## Problems worth dedicating yourself to
+
+- What problem will you dedicate your life to solving?
+- What challenges do you want to overcome, for yourself or for others?
+- What emotions do you want people to feel from your work?
+- How do you evaluate your problems? How many people share them?
+
+## Narrowing down
+
+- What roles deeply interest you, and which carry pieces of your purpose?
+- What works deeply interest you?
+- What domains most align with your passions?

--- a/bytesofpurpose-blog/blog/2026-01-26-questions-for-facing-your-fears.md
+++ b/bytesofpurpose-blog/blog/2026-01-26-questions-for-facing-your-fears.md
@@ -1,0 +1,46 @@
+---
+slug: questions-for-facing-your-fears
+title: "Questions for Facing Your Fears"
+description: "A curated set of questions for naming what you're afraid of, examining what threatens you, and building the courage to act anyway."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-26
+draft: true
+---
+
+Fear rarely announces itself honestly. It hides behind hesitation, busyness, and good excuses. These are the questions I return to when I want to drag a fear into the open and see it clearly, grouped by what they're really asking. Sit with the ones that make you flinch.
+
+<!-- truncate -->
+
+## Core fears
+
+- What are you afraid of?
+- What fears are holding you back?
+- What do you fear losing?
+- What are you running from?
+
+## What threatens you
+
+- When you no longer fear dying, what else can threaten you?
+- What opposition do you face?
+- What threatens your goals and dreams?
+
+## Overcoming fear
+
+- What removes your fear of your opposition?
+- How do you pressure yourself to become a diamond?
+- What would you do if you weren't afraid?
+- How do you move from fear to action?
+
+## Courage and faith
+
+- What gives you courage?
+- What gives you strength to keep going?
+- How do you walk by faith and not by sight?
+- What helps you trust the process?
+
+## Facing opposition
+
+- How do you face your opposition?
+- What prepares you for adversity?
+- How do you handle rejection and setbacks?

--- a/bytesofpurpose-blog/blog/2026-01-26-questions-for-reflecting-on-your-priorities.md
+++ b/bytesofpurpose-blog/blog/2026-01-26-questions-for-reflecting-on-your-priorities.md
@@ -1,0 +1,64 @@
+---
+slug: questions-for-reflecting-on-your-priorities
+title: "Questions for Reflecting on Your Priorities"
+description: "The questions I sit with to check whether my time and energy are actually going to what matters most right now."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-26
+draft: true
+---
+
+Priorities drift quietly. What mattered last month keeps occupying your calendar long after it stopped being the point. These are the questions I return to when I want to step back and check whether my time and energy are still flowing toward what actually matters. Read them slowly, and let the uncomfortable ones surface what's been on autopilot.
+
+<!-- truncate -->
+
+## Current priorities
+
+- What are your top priorities right now? What is currently important to you?
+- What goals are you committing yourself and your time to?
+- What areas of growth have you prioritized?
+
+## Time allocation
+
+- How should you be spending your time? Are you spending it on what matters most?
+- What should you immediately do? What do you need to do eventually?
+- What needs to be done today to enable tomorrow?
+
+## Priority shifts
+
+- Which of your goals are top priority right now, and why?
+- Which of your goals dropped in priority, and why?
+- Are there any important goals in your life that you're not tracking?
+- What goals are you ignoring?
+
+## Task prioritization
+
+- What tasks will benefit you the most? What tasks do you actually want to do?
+- How will you properly prioritize what you should be working on or thinking about?
+- Are you ignoring any tasks? Are you keeping up with them?
+
+## Learning priorities
+
+- What are the things you should be learning?
+- What are the books you should be reading?
+- What do you need to learn to expand your mind?
+
+## Goals and plans
+
+- Have you figured out your goals? What are your plans?
+- What projects do you need to finish soon? What projects should you work on?
+- What kind of projects should you be working on, and why?
+- Why and when are you going to do something?
+
+## Weekly planning
+
+- What is your weekly planning ritual?
+- What are this week's goals?
+
+## Quests and dreams
+
+- What quests are you on? What goals are you chasing? What will you strive to do?
+- What do you need to do to realize your dreams? How will you realize them?
+- What do you want to become? What do you want to master?
+
+To achieve your goals and your dreams, you set out on quests.

--- a/bytesofpurpose-blog/blog/2026-01-27-questions-for-growing-yourself.md
+++ b/bytesofpurpose-blog/blog/2026-01-27-questions-for-growing-yourself.md
@@ -1,0 +1,74 @@
+---
+slug: questions-for-growing-yourself
+title: "Questions for Growing Yourself"
+description: "A taxonomy of the questions I return to when I want to check whether I'm actually growing, investing in myself, and reaching my potential."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-27
+draft: true
+---
+
+Growth is easy to assume and hard to verify. It's possible to stay busy for years without getting meaningfully better at anything. These are the questions I sit with when I want to know whether I'm truly improving, where I'm investing my energy, and whether I'm living up to what I'm capable of. Pick the ones that make you a little uncomfortable.
+
+<!-- truncate -->
+
+## Growth mindset
+
+- Do you want to get better, every single day?
+- Are you changing? Are you growing? Are you improving?
+- What hard work will you do?
+- When it's all over, will you walk away with more than what you had?
+
+## Reaching your potential
+
+- Are you letting yourself down?
+- What steps must you take to be able to say "I made it"?
+- Don't let your greatness sleep: are you?
+- What good are you if the problems you live to solve today will be solved tomorrow?
+
+## Investing in yourself
+
+- How will you invest in you?
+- How much knowledge are you inputting into yourself?
+- What techniques are you aware of? What techniques do you depend on?
+- What results are you looking for?
+
+## Self-knowledge for growth
+
+- Do you know how you are smart? In what ways are you smart?
+- What do you care about?
+- What are the values that motivate your choices?
+- What is your velocity?
+
+## Learning from masters
+
+- What techniques did the people who achieve what you're after use?
+- Who has mastered what you're trying to learn?
+
+## Measuring growth
+
+- How many of your thoughts re-manifest themselves in actions?
+- Are you truly reading books that will enable you to reach your goals?
+- Have you automated your personal experimentation process?
+
+## The growth journey
+
+- Learning is like interest: it's powerful when it compounds.
+- Work is behind the scenes. Competitions are the easy part.
+- How do you get more than you already have?
+- How do you grow? How do things grow?
+
+## Acknowledging limits
+
+- What are the limits of your foreknowledge?
+- Are you acknowledging the limits of your knowledge?
+- Are you acknowledging the limits of your actions?
+
+## Key growth questions
+
+- What do you need to know that you don't know right now?
+- What are you focused on learning?
+- How do you use learning to improve yourself and your system?
+- Are you doing everything you can with what you have?
+</content>
+</invoke>

--- a/bytesofpurpose-blog/blog/2026-01-27-the-song-of-life.md
+++ b/bytesofpurpose-blog/blog/2026-01-27-the-song-of-life.md
@@ -1,0 +1,121 @@
+---
+slug: the-song-of-life
+title: "The Song of Life"
+description: "A set of philosophical reflections on life, death, purpose, words, and the strange symmetry between programs and existence."
+authors: [oeid]
+tags: [philosophy, mindset]
+date: 2026-01-27
+draft: true
+---
+
+These are reflections I've collected over years of philosophical wandering: about
+what life is for, why death isn't to be feared, the mystical weight of words, and
+the odd symmetry between writing a program and living a life. They aren't arguments
+so much as meditations. Read them slowly.
+
+<!-- truncate -->
+
+## Life's purpose and meaning
+
+The Prophet (SAAW) loved God. How beautiful life is when you return to the one you
+love. And while you are away from your love, you learn to do what makes them happy.
+You do what you want, not knowing that your lover is aware. But fret not: love is
+true, and all is forgiven in Love.
+
+What kind of life are you living if, at the end, you don't know where you are
+going? You don't know what will happen to you?
+
+## The song of life
+
+Music is inherently playful. The point is not to reach the end of the song; it's
+the song itself. You *play* the piano. You don't *work* the piano.
+
+Your life is your art. What is your art as an artist?
+
+Life is a musical thing. We were supposed to sing and dance, not rush to reach the
+end. It's like Hajj: a pilgrimage to reach God, but once you're there, you dance
+with God.
+
+## Living and loving
+
+I live to live. I live to love. To love what I do. To do what I love.
+
+I love. I live. One day I will leave you, with my love, and go to the One that
+created you and me to love.
+
+## Death, the return
+
+Why do you fear death? You are simply returning to whom you love. He did not create
+you in vain. He will take care of you when you part.
+
+## The recursion of life
+
+In nature: cells and planets. In life: death is the base case. Success in life
+starts at realizing death. Start working towards your death. I don't want to die
+regretfully; I want to live towards my death.
+
+God recursively created us: the ability to perpetuate yourself through your
+generations, in our cells, the planets, the universe. What is the folded value of
+humanity?
+
+## Understanding purpose
+
+To understand our purpose, we must understand why we were created. What use does God
+have from us? None. God doesn't need us to do anything; God is not benefiting from
+us. So it's in our best interest to emulate God, to learn about God, to reflect the
+divine purpose.
+
+How can you love God if you don't know God?
+
+## The power of words
+
+*Motivation on demand. And God said "Be" and it was.*
+
+We underestimate the power of words. Words are powerful. We think in words. We sell
+in words. We speak in words. We pursue with words. We are surrounded by words since
+birth. We fall in love through words. We transfer emotions through words. And when
+we pass, we are remembered through words.
+
+Words can make the hairs on our backs stand. We start wars over words. We form
+alliances through words. Words drive the world. They drive the way we think about
+ourselves. They affect how we feel. They can make our day or break our day. Whether
+we like it or not, words have mystical powers over us.
+
+That's why it's so important to surround ourselves with positive words: words that
+motivate us, that influence us to become better people, that remind us to believe in
+ourselves, that help keep us determined, that remind us that we are blessed.
+
+Mind came before matter. Words came before the matter. Everything is language.
+Everything can be described with words. God taught Adam all the words.
+
+Words can teach you how to cook. Words can inspire you. Words govern technology.
+We think in words. Some words were never meant to be. Some things were never meant
+to be said. Some words are captured deep inside. Words have the power to change;
+words have the power to hold. Words can capture your essence for everyone else to
+see. Words can capture your mind for everyone to enjoy.
+
+## Understanding programming
+
+Our lives begin with an event (birth) and end with an event (death). What lies
+in-between these two milestones is a collection of choices. Similarly, programs
+start with an event (double-clicking an icon) and end with an event (closing the
+program), and what lies in-between is a collection of choices.
+
+Choices are black and white. Do I play soccer, or not play soccer?
+
+We looked at a fish; we built ships. We looked at birds; we built planes. We looked
+at humans; we built computers. Computers are a masterful manifestation of choices.
+
+## Understanding problem solving
+
+Is problem solving breaking things down to the simplest pieces, then piecing them
+back together in a structured fashion, by sequencing the elements and relating them?
+
+We conquered chemistry through elements. We conquered computers through bits, through
+data. Language is letters and symbols. Language is assigning meaning to words.
+Language is assigning meaning to the meaning of different sequences of words.
+
+Is problem solving breaking things down to the smallest *meaningful* elements, or
+simply breaking things down to the smallest *possible* element?
+
+Do letters have meaning by themselves? Do bits have meaning by themselves?

--- a/bytesofpurpose-blog/blog/2026-01-28-a-framework-for-prioritizing.md
+++ b/bytesofpurpose-blog/blog/2026-01-28-a-framework-for-prioritizing.md
@@ -1,0 +1,92 @@
+---
+slug: a-framework-for-prioritizing
+title: "A Framework for Prioritizing"
+description: "Prioritizing isn't a one-time ranking. It's a set of recurring questions: what factors matter, how to evaluate candidates, when to de-prioritize, and how to get better at it over time."
+authors: [oeid]
+tags: [productivity]
+date: 2026-01-28
+draft: true
+---
+
+Most advice on prioritization stops at "rank your list." But ranking is the easy
+part. The hard part is everything around it: deciding which factors should even
+count, evaluating candidates against them, knowing when to *reverse* a priority you
+once held, and retrospecting so you get better at the whole loop. This is the
+framework of questions I use, organized by the stage of prioritizing you're in.
+
+<!-- truncate -->
+
+## Establishing your current focus
+
+Start by naming what you're actually focused on right now, across each area you care
+about:
+
+- What questions are you focused on answering *now*?
+- What initiatives have you decided to work on *now* — for your career, your
+  marketing, your projects, your learning, your growth?
+
+The point of listing focus by area is to notice where you've quietly let everything
+become a priority, which is the same as having none.
+
+## Choosing your prioritization factors
+
+Before you rank anything, decide what you're ranking *by*:
+
+- What factors should you consider when prioritizing? What *must* you consider?
+- How do the factors compare? Which factor outranks the others, and how do you
+  determine that?
+- Which candidate is easier to do? Which needs to be done now? Which are you most
+  interested in doing?
+- How often should you revisit each of these concerns? (And what's the difference
+  between a *factor* and a *concern*?)
+
+## Surfacing the candidates
+
+You can't prioritize what you haven't gathered:
+
+- What are the things you're prioritizing, and where do they live? Are they in your
+  tracker? Scattered across roles?
+- What initiatives are in the running?
+
+A recurring failure mode: getting repeatedly sucked into low-value polish — tuning a
+public profile, picking which work to showcase — when the higher priority is
+shipping the thing at all.
+
+## Evaluating projects
+
+When the candidates are projects, score each against a consistent checklist:
+
+- Will this project help you learn something you want to learn?
+- Does it overlap with the things you enjoy doing? Do you *want* to work on it?
+- How marketable is it? How distributable is it?
+- What else should you weigh before committing?
+
+## Classifying what you've prioritized
+
+Once something clears the bar, decide where it belongs:
+
+- What goes on the roadmap, and what goes straight into your day-to-day task system?
+- What *doesn't* need prioritizing at all? (Small experiments, for instance, are
+  often cheap enough to just do.)
+
+## De-prioritizing
+
+Reversing priorities is as important as setting them:
+
+- What did you once want to do that you no longer want to do?
+- What obstacles are hindering the goals you've kept?
+- What goals depend on other goals or activities being done first?
+
+Letting go of a stale priority frees more capacity than squeezing one more task into
+the day.
+
+## Retrospecting the process itself
+
+Finally, treat prioritization as a skill you improve, not a chore you endure:
+
+- How can you get better at prioritizing?
+- What shortcomings have you observed in how you do it?
+- What can you do now versus what you'd need to learn to do something new?
+
+Prioritization isn't a list you sort once. It's a loop you run: focus, weigh,
+gather, evaluate, classify, prune, and reflect — then run it again.

--- a/bytesofpurpose-blog/blog/2026-01-28-questions-for-making-better-decisions.md
+++ b/bytesofpurpose-blog/blog/2026-01-28-questions-for-making-better-decisions.md
@@ -1,0 +1,72 @@
+---
+slug: questions-for-making-better-decisions
+title: "Questions for Making Better Decisions"
+description: "A taxonomy of the questions I use to look back on decisions, spot my patterns, learn from outcomes, and make peace with the ones I can't undo."
+authors: [oeid]
+tags: [self-reflection, question-set]
+date: 2026-01-28
+draft: true
+---
+
+Most of us make decisions and never look back at them. But the decisions already
+behind you are the cheapest teacher you'll ever have. These are the questions I
+return to when I want to understand my own patterns, separate good reasoning from
+lucky outcomes, and get a little better at the next call. Pick the ones that make
+you pause.
+
+<!-- truncate -->
+
+## Reviewing past decisions
+
+- What major decisions have you made recently?
+- What decisions are you most proud of? Which do you wish you could redo?
+- Which decisions had the biggest impact on your life?
+
+## Understanding outcomes
+
+- How did that decision turn out? Did reality match your expectations?
+- What surprised you about the outcome?
+- Was the outcome due to good decision-making or luck?
+
+## Learning from decisions
+
+- What did you learn from this decision? What would you do differently next time?
+- What information did you have, and what were you missing?
+- Was your reasoning sound even if the outcome wasn't?
+
+## Decision patterns
+
+- What patterns do you see in your decision-making?
+- Do you tend to decide too quickly or too slowly?
+- Do you over-rely on logic or emotion? What biases affect your decisions?
+- When do you make your best decisions? Your worst?
+
+## Processing regrets
+
+- What decisions do you regret? Is it the process or the outcome you regret?
+- What can you learn from these regrets?
+- How do you make peace with decisions you can't undo?
+- Are you holding onto regret that's no longer serving you?
+
+## Decision quality over time
+
+- Are you getting better at making decisions? How has your decision-making evolved?
+- What types of decisions are you good at? Which do you struggle with?
+
+## Reversals and course corrections
+
+- What decisions have you reversed? Was reversing the right call?
+- Did you reverse too early or too late?
+- How do you know when to stay the course versus change direction?
+
+## Decisions avoided
+
+- What decisions have you been avoiding? Why?
+- What's the cost of not deciding?
+- What would help you move forward?
+
+## Involving others, in retrospect
+
+- Did you involve the right people? Should you have sought more input?
+- Did you listen to the advice you were given?
+- How did others' input affect the outcome?

--- a/bytesofpurpose-blog/src/data/references/learning-resources.json
+++ b/bytesofpurpose-blog/src/data/references/learning-resources.json
@@ -1,7 +1,7 @@
 {
   "_provenance": {
     "source": "roles-self-development/The Learner/knowledge/learning-resources.md",
-    "source_commit": "17a90f05f17f65bc81ef60c2f87be80da6c4ec91",
+    "source_commit": "635ba0a3d1d6df9dc3ec0b848c2c5e9cb1d0db65",
     "note": "Public links abstracted from the source's resource catalog. Named mentors + personal tracking deliberately excluded. Refresh: append cards here when the source grows new public links; then re-stamp source_commit."
   },
   "books": [
@@ -68,6 +68,12 @@
       "description": "A clear video walkthrough of the fundamentals of information theory.",
       "meta": "khanacademy.org",
       "href": "https://www.khanacademy.org/computing/computer-science/informationtheory"
+    },
+    {
+      "title": "Transforming Code into Beautiful, Idiomatic Python",
+      "description": "Raymond Hettinger's classic talk on writing Pythonic code.",
+      "meta": "youtube.com",
+      "href": "https://www.youtube.com/watch?v=OSGv2VnC0go"
     }
   ],
   "blogs": [


### PR DESCRIPTION
Blog-side of scan-blog-worthy batches 3 and 4. All posts are `draft: true`.

## Batch 3 (5 posts + carousel refresh)
- `the-song-of-life` (philosophy essay, from a split)
- `questions-for-finding-your-purpose`, `-discovering-your-interests`, `-knowing-who-you-are` (the first question-set posts)
- `a-framework-for-prioritizing` (The Manager)
- refresh-references: added Hettinger's idiomatic-Python talk to learning-resources, re-stamped provenance

## Batch 4 — the question-set series (12 posts)
The full Self Reflector vein published as `question-set` posts (tag: `self-reflection` + `question-set`): challenging-your-own-assumptions, aligning-actions-with-ambitions, making-better-decisions, knowing-what-you-want, facing-your-fears, growing-yourself, understanding-your-inaction, reflecting-on-what-youre-learning, reflecting-on-your-priorities, improving-how-you-operate, measuring-your-progress, reflecting-on-your-worth.

15 question-set posts total. New tags: `self-reflection`, `philosophy`, `question-set`.

> Note: unrelated WIP in the working tree (binary-pyramid logo, a DSL post) is intentionally NOT included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)