### PR TITLE
Switch coffee CTA to Buy Me a Coffee + add Claude-agents intro post

### DIFF
--- a/bytesofpurpose-blog/blog/2026-06-19-getting-started-with-claude-agents.md
+++ b/bytesofpurpose-blog/blog/2026-06-19-getting-started-with-claude-agents.md
@@ -1,0 +1,46 @@
+---
+slug: getting-started-with-claude-agents
+title: '🤖 A Hands-On Way to Learn What a Claude Agent Actually Is'
+description: "I built a small, readable example you can open and poke at to answer one question: what is an agent, and what is a skill? It's a working stock-research agent that doubles as a teaching tool."
+authors: [oeid]
+tags: [ai, generative-ai, agents, claude, getting-started]
+date: 2026-06-19T10:00
+---
+
+The fastest way to understand Claude agents isn't to read a framework's docs. It's to open a small, working agent and read it the way you'd read a colleague's playbook. So I built one to play with, and put it online for anyone curious.
+
+👉 **[Getting Started with Claude Agents](https://blog.bytesofpurpose.com/getting-started-with-claude-agents/)**: open it, poke around, and the question *"what is an agent? what is a skill?"* should answer itself.
+
+<!-- truncate -->
+
+## What you're looking at
+
+It's two things at once:
+
+- A **working agent**, a stock research associate that surveys the market each morning, shortlists a few names worth a closer look, pulls the filings and numbers, builds a spreadsheet with sourced math, and stress-tests its own thesis before signing off.
+- A **teaching example**, where the folders are named so that opening them explains the ideas. You don't need to know Python, JSON, or any SDK to read it. You read it like a research analyst's notes.
+
+## The one idea worth keeping
+
+If you take away nothing else, take this:
+
+> **An agent is a *who*.** It's a role, like "senior research associate," that decides what to do next.
+> **A skill is a *how*.** It's a specific recipe, like "spread the financials," that the agent follows.
+
+The agent file describes the role and the workflow. Each skill file describes one recipe and nothing else, and the skills don't know about each other. They just do their one job well. The agent reads its own definition and picks which skill to invoke. That separation is the whole trick: each skill can be read alone, copied into another project, or rewritten, and the agent picks it up automatically. No DSL, no central registry, just markdown a domain expert can read and edit.
+
+## Why I think it clicks
+
+Every skill maps to a discipline you'd recognize from a real desk: a morning idea sweep, a source-of-truth data fetch, the qualitative read, the model, the validation pass before sign-off. If you've ever trained a junior person, you've effectively taught them each of these as a separate skill. Seeing it laid out that way is what made agents stop feeling abstract for me.
+
+There's even a built-in `explain-agent` step that walks the project and draws you an interactive diagram of how the whole thing fits together, which is handy for onboarding someone else.
+
+## Go play
+
+You'll need [Claude Code](https://claude.com/download). After that it's double-click-to-run: one command sets things up, another opens it in Claude, and you ask it *"what's worth looking at today?"* It stops to confirm with you at the expensive steps, so nothing runs away from you.
+
+It's a teaching example, not a production trading system. It triages and explains, and it doesn't give investment advice. But as a way to *get* what agents and skills are, opening it beats any explanation I could write here.
+
+**[Try the intro agent →](https://blog.bytesofpurpose.com/getting-started-with-claude-agents/)**
+
+If it helps something click, [buy me a coffee ☕](https://buymeacoffee.com/omareid).

--- a/bytesofpurpose-blog/src/components/NavbarCoffee/index.tsx
+++ b/bytesofpurpose-blog/src/components/NavbarCoffee/index.tsx
@@ -13,8 +13,7 @@ import {EXPERIMENTS, resolveVariant} from '@site/src/experiments';
 // We keep the existing .navbar-coffee styling + responsive icon/label split.
 const EXP = EXPERIMENTS['support-button-copy'];
 
-const PAYPAL =
-  'https://www.paypal.com/donate?business=UQ2SHCNPFYBJY&amount=1&no_recurring=0&item_name=Support+a+Developer&currency_code=USD';
+const BUY_ME_A_COFFEE = 'https://buymeacoffee.com/omareid';
 
 // Split a variant copy like "Buy me a coffee ☕" into a trailing/leading emoji
 // (decorative icon) and the remaining words (the label). Falls back to a cup.
@@ -34,8 +33,8 @@ export default function NavbarCoffee(): React.JSX.Element {
   return (
     <a
       className="navbar-coffee"
-      href={PAYPAL}
-      aria-label={`${label} (support via PayPal)`}
+      href={BUY_ME_A_COFFEE}
+      aria-label={`${label} (support via Buy Me a Coffee)`}
       onClick={() =>
         posthog.capture('support button clicked', {
           page_path:

--- a/bytesofpurpose-blog/src/components/Support/CoffeeButton.tsx
+++ b/bytesofpurpose-blog/src/components/Support/CoffeeButton.tsx
@@ -4,15 +4,14 @@ import { EXPERIMENTS, resolveVariant } from '@site/src/experiments';
 
 // The coffee CTA, wired into the support-button-copy A/B experiment. Post the
 // 2026-06-01 re-scope the variants differ ONLY in PRESENTATION (identical copy):
-//   control → "Buy me a $5 coffee ☕ →"  rendered as a plain text LINK
-//   test    → "Buy me a $5 coffee ☕"    rendered as a styled BUTTON
+//   control → "Buy me a coffee ☕ →"  rendered as a plain text LINK
+//   test    → "Buy me a coffee ☕"    rendered as a styled BUTTON
 // (the same experiment that used to drive the standalone navbar button). The copy
 // lives once in src/experiments.ts (same in both arms); the conversion event keeps
 // the same 'support button clicked' name so the historical funnel stays continuous.
 const EXP = EXPERIMENTS['support-button-copy'];
 
-const PAYPAL =
-  'https://www.paypal.com/donate?business=UQ2SHCNPFYBJY&amount=5&no_recurring=0&item_name=Support+a+Developer&currency_code=USD';
+const BUY_ME_A_COFFEE = 'https://buymeacoffee.com/omareid';
 
 interface CoffeeButtonProps {
   // Class applied to the LINK-style (control) variant so it matches the other
@@ -36,7 +35,7 @@ export default function CoffeeButton({ linkClassName }: CoffeeButtonProps): Reac
     <a
       className={isButton ? 'button button--primary button--lg' : linkClassName}
       data-testid="support-coffee-button"
-      href={PAYPAL}
+      href={BUY_ME_A_COFFEE}
       target="_blank"
       rel="noopener noreferrer"
       onClick={() =>

--- a/bytesofpurpose-blog/src/components/SupportButton/index.tsx
+++ b/bytesofpurpose-blog/src/components/SupportButton/index.tsx
@@ -4,11 +4,14 @@ import {EXPERIMENTS, resolveVariant} from '@site/src/experiments';
 import {EspressoIcon} from './EspressoIcon';
 
 // A/B experiment: which Support button copy drives more clicks?
-//   control = "Donate $5 for ☕️ in Paypal →"  |  test = "Buy me a $5 coffee ☕"
+//   control = "Buy me a coffee ☕"  |  test = "Buy me a coffee ☕"
 // Variant resolution (incl. the localhost ?ab= URL override that works across
 // all experiments) lives in src/experiments.ts. See the design doc
 // (designs/*-ab-testing-framework.mdx) and the run-ab-test skill.
+// The CTA links to Buy Me a Coffee (was a PayPal donate form).
 const EXP = EXPERIMENTS['support-button-copy'];
+
+const BUY_ME_A_COFFEE = 'https://buymeacoffee.com/omareid';
 
 interface SupportProps {
   /** Optional label override; falls back to the A/B variant copy. */
@@ -22,11 +25,13 @@ export const Support = ({children}: SupportProps) => {
   React.useEffect(() => resolveVariant(EXP, setVariant), []);
 
   return (
-    <form
-      action="https://www.paypal.com/donate"
-      method="post"
-      target="_top"
-      onSubmit={() =>
+    <a
+      className="button button--primary"
+      data-testid="support-button"
+      href={BUY_ME_A_COFFEE}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() =>
         posthog.capture('support button clicked', {
           page_path: window.location.pathname,
           // Tag the conversion with the variant so we can measure the split.
@@ -35,18 +40,8 @@ export const Support = ({children}: SupportProps) => {
         })
       }
     >
-      <input type="hidden" name="business" value="UQ2SHCNPFYBJY" />
-      <input type="hidden" name="amount" value="1" />
-      <input type="hidden" name="no_recurring" value="0" />
-      <input type="hidden" name="item_name" value="Support a Developer" />
-      <input type="hidden" name="currency_code" value="USD" />
-      <button type="submit" className="button button--primary" data-testid="support-button">
-        <EspressoIcon />
-        {children || label}
-      </button>
-      {/* PayPal 1×1 tracking pixel. `border` is a deprecated HTML attr (not a
-          valid React img prop), so drop it; a 1×1 pixel has no visible border. */}
-      <img alt="" style={{border: 0}} src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
-    </form>
+      <EspressoIcon />
+      {children || label}
+    </a>
   );
 };

--- a/bytesofpurpose-blog/src/experiments.ts
+++ b/bytesofpurpose-blog/src/experiments.ts
@@ -28,8 +28,8 @@ export const EXPERIMENTS = {
   'support-button-copy': {
     key: 'support-button-copy',
     variants: {
-      control: 'Buy me a $5 coffee ☕',
-      test: 'Buy me a $5 coffee ☕',
+      control: 'Buy me a coffee ☕',
+      test: 'Buy me a coffee ☕',
     },
   },
 } satisfies Record<string, Experiment>;

--- a/bytesofpurpose-blog/test/e2e/debug-menu.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/debug-menu.spec.ts
@@ -16,7 +16,7 @@ import { test, expect, Page } from '@playwright/test';
  *      "switching does stuff" guarantee.
  *
  * Variant presentation (flag: support-button-copy, re-scoped 2026-06-01):
- *   identical copy ("Buy me a $5 coffee ☕") in both arms; control renders a
+ *   identical copy ("Buy me a coffee ☕") in both arms; control renders a
  *   plain text LINK, test renders a styled BUTTON (button--primary).
  */
 
@@ -76,7 +76,7 @@ test.describe('DebugMenu — experiments switching', () => {
     // Control default: a text link, NOT a button.
     await page.goto('/support', { waitUntil: 'domcontentloaded' });
     await expect(coffee).toBeVisible({ timeout: 15000 });
-    await expect(coffee).toContainText('Buy me a $5 coffee');
+    await expect(coffee).toContainText('Buy me a coffee');
     await expect(coffee).not.toHaveClass(/button--primary/);
 
     // Force "test" → the CTA becomes a styled button.
@@ -84,7 +84,7 @@ test.describe('DebugMenu — experiments switching', () => {
       waitUntil: 'domcontentloaded',
     });
     await expect(coffee).toBeVisible({ timeout: 15000 });
-    await expect(coffee).toContainText('Buy me a $5 coffee');
+    await expect(coffee).toContainText('Buy me a coffee');
     await expect(coffee).toHaveClass(/button--primary/);
   });
 

--- a/bytesofpurpose-blog/test/e2e/support-ab-test.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/support-ab-test.spec.ts
@@ -5,7 +5,7 @@ import { EXPERIMENTS } from '../../src/experiments';
  * Validates the Support-CTA A/B experiment (flag: support-button-copy).
  *
  * RE-SCOPED 2026-06-01 (copy → presentation): both arms now render the SAME copy
- * ("Buy me a $5 coffee ☕", defined once in src/experiments.ts); the only thing that
+ * ("Buy me a coffee ☕", defined once in src/experiments.ts); the only thing that
  * varies is PRESENTATION on the /support page coffee CTA:
  *   control → plain text LINK   test → styled BUTTON (button--primary button--lg)
  * (see src/components/Support/CoffeeButton + the experiment doc


### PR DESCRIPTION
## What

Two small changes bundled:

### 1. Coffee CTA → Buy Me a Coffee
Repoints every support CTA from PayPal donate to **https://buymeacoffee.com/omareid**:
- `Support/CoffeeButton.tsx` (the styled `/support` button in the request)
- `NavbarCoffee/index.tsx` (navbar coffee item)
- `SupportButton/index.tsx` (footer `<Support/>` — converted from a PayPal POST `<form>` to a plain BMC link)
- `experiments.ts`: dropped "$5" from the A/B copy → "Buy me a coffee ☕" (BMC has no fixed amount). Flag key + `support button clicked` event name unchanged, so the funnel stays continuous.
- e2e assertions/comments updated for the new copy.

### 2. New blog post
`/thoughts/getting-started-with-claude-agents` — a short announcement/reference post pointing readers to the **Getting Started with Claude Agents** intro agent (the Stock Analyzer teaching example: "an agent is a *who*, a skill is a *how*"). Published (`draft:false`). Links use the absolute prod URL so Docusaurus doesn't try to resolve them as internal routes.

## Verification
- `yarn build` → `[SUCCESS]`, **0 broken-link errors** (the two remaining warnings — changelog truncation, `/changelog` duplicate route — are pre-existing and unrelated).
- `make validate-links` → **0 errors** (25 pre-existing long-url warns, none on the new post).
- `tsc --noEmit` → no new errors in changed files (only pre-existing JSX-namespace errors in unrelated files).
- em-dash voice hook: passed (post rephrased to remove all `—`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)