### PR TITLE
Switch footer Support link to Buy Me a Coffee

### DIFF
--- a/bytesofpurpose-blog/docusaurus.config.js
+++ b/bytesofpurpose-blog/docusaurus.config.js
@@ -758,7 +758,7 @@ const rehypePremiumEncrypt = require('./plugins/rehype-premium-encrypt');
                 },
                 {
                   label: 'Support',
-                  href: 'https://www.paypal.com/donate?business=UQ2SHCNPFYBJY&amount=1&no_recurring=0&item_name=Support+a+Developer&currency_code=USD',
+                  href: 'https://buymeacoffee.com/omareid',
                   position: 'right',
                 },
               ]


### PR DESCRIPTION
Follow-up to #34. The footer "Support" link was the last surface still pointing at PayPal donate; this repoints it to **https://buymeacoffee.com/omareid** so every support CTA (coffee buttons + footer) is consistent.

Found while verifying the #34 deploy. One-line change in `themeConfig.footer`; `grep paypal|UQ2SHCNPFYBJY` over `src/` + config is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)