### PR TITLE
docs(publish-blog-ui): record the v0.1.0 publish + merge-first ordering

### DIFF
--- a/.claude/skills/publish-blog-ui/SKILL.md
+++ b/.claude/skills/publish-blog-ui/SKILL.md
@@ -101,6 +101,14 @@ GitHub Packages requires auth even for read. In the consuming repo:
 - 2026-06-23 — Created with the package. Tag pattern is `blog-ui-v*` (not plain `v*`, since the
   monorepo may host other packages later). Blog consumes via `file:` so local changes are live;
   publishing is only for OTHER repos. GitHub Packages needs auth even to read.
+- 2026-06-23 — **First publish: `@omars-lab/blog-ui@0.1.0` is LIVE** in GitHub Packages.
+  Lesson on ordering: a tag-triggered workflow only fires reliably when the workflow YAML is on
+  the **default branch** — so MERGE the PR that adds `publish-blog-ui.yml` to `master` FIRST,
+  then tag from master. (Tagging the feature branch may not trigger anything.) Sequence that
+  worked: squash-merge → `git checkout master && git pull --ff-only` → `git tag -a blog-ui-v0.1.0`
+  → `git push origin blog-ui-v0.1.0` → workflow ran all green → confirm with
+  `gh api /users/omars-lab/packages/npm/blog-ui/versions` (omars-lab is a USER, not an org, so
+  the `/users/…` endpoint, not `/orgs/…`). Runner annotated a harmless Node-20-deprecation notice.
 - 2026-06-23 — Added `yarn simulate-publish` (= build + `npm publish --dry-run`) as the
   repeatable rehearsal target, and `prepublishOnly` (rebuild-before-publish guard). Turned
   `sourcemap` OFF in tsup — the first dry-run tarball shipped 65 kB of `.map` files for no


### PR DESCRIPTION
Logs the first `@omars-lab/blog-ui` release in the `publish-blog-ui` skill's learnings log.

## What happened
- `@omars-lab/blog-ui@0.1.0` is **live in GitHub Packages** (published 2026-06-23T19:28:08Z via the `blog-ui-v0.1.0` tag → `publish-blog-ui.yml`, all steps green).
- This unblocks #50 (the getting-started consumer repo can now `yarn add` it).

## Lesson recorded
- Tag-triggered workflows only fire reliably when the workflow YAML is on the **default branch** — so merge the PR adding the workflow to `master` first, then tag from master.
- Verify with `gh api /users/omars-lab/packages/npm/blog-ui/versions` (omars-lab is a USER, not an org).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)