### PR TITLE
Walkthrough multi-custom-scene + storefront opens on a store-scan

### DIFF
--- a/.claude/skills/author-walkthrough/SKILL.md
+++ b/.claude/skills/author-walkthrough/SKILL.md
@@ -80,6 +80,20 @@ Claude opens the tool, the human reviews in the browser, Claude continues on the
 The two scenes grid-stack in one viewport cell, so a Claude beat REPLACES the app in place
 (never stacked under it).
 
+## Multiple custom scenes (app → A → B → …)
+
+Beyond the built-in `app` (children) and `claude` scenes, you can supply your OWN scenes and
+crossfade across several of them:
+- **One** extra scene: `customScene={<Mockup>…</Mockup>}`, reached by `{type:'scene', to:'custom'}`.
+- **Several**: `customScenes={[sceneA, sceneB]}`, each reached by `{type:'scene', to:'custom', index:N}`
+  (`index` defaults to 0). They grid-stack in the same cell; only the active index shows.
+
+This is how the storefront walkthrough opens on a live **store-scan** (the app scene, with the
+weak section flagged) then crossfades to the **dashboard** (`index:0`) and the **BI projection**
+(`index:1`). GOTCHA: `move`/`highlight`/`dragSelect`/`type` targets are resolved against the
+**app scene only** (the engine queries the children) — a custom scene can't be the target of a
+cursor step, so let its caption carry the beat, or put the interactive bits in the app scene.
+
 ## Cursor + timeline
 
 - The cursor is a **teal pointer in a translucent halo** (`--wt-cursor`), deliberately a

--- a/bytesofpurpose-blog/designs/_mockups/self-healing-storefront.mdx
+++ b/bytesofpurpose-blog/designs/_mockups/self-healing-storefront.mdx
@@ -18,8 +18,44 @@ export default function Mockups() {
     </div>
   );
 
-  // The dashboard the agent runs on (app scene). It carries a "new critical issue" row the
-  // walkthrough points at, which then flips to Shipped.
+  // OPENING scene (app): the live storefront as the agent scans it. The mobile checkout
+  // section is flagged with an "issue identified" warning, the weak spot the agent finds
+  // first, before any dashboard or projection.
+  const storeScan = (
+    <Mockup chrome="browser" title="acme-shop.com" url="acme-shop.com/checkout" caption="The agent scans the live store and flags the weak spot: a slow mobile checkout.">
+      <div style={{fontFamily: 'var(--ifm-font-family-base)', position: 'relative'}}>
+        {/* faux storefront header */}
+        <div style={{display: 'flex', alignItems: 'center', gap: '0.6rem', padding: '0.6rem 0.85rem', borderBottom: '1px solid var(--ifm-color-emphasis-200)'}}>
+          <div style={{fontWeight: 800, fontSize: '0.9rem'}}>ACME</div>
+          <div style={{marginLeft: 'auto', display: 'flex', gap: '0.8rem', fontSize: '0.72rem', color: 'var(--ifm-color-emphasis-700)'}}>
+            <span>Shop</span><span>About</span><span>🛒 Cart (2)</span>
+          </div>
+        </div>
+        {/* scanning banner */}
+        <div style={{display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.4rem 0.85rem', fontSize: '0.7rem', color: 'var(--ifm-color-emphasis-700)', background: 'var(--ifm-color-emphasis-100)'}}>
+          <span style={{display: 'inline-block', width: '0.5rem', height: '0.5rem', borderRadius: '999px', background: '#4a9b8e'}} /> Agent scanning store · 12 pages crawled
+        </div>
+        {/* product strip (healthy) */}
+        <div style={{display: 'flex', gap: '0.5rem', padding: '0.7rem 0.85rem'}}>
+          {['Tee','Mug','Cap'].map((p) => (
+            <div key={p} style={{flex: 1, border: '1px solid var(--ifm-color-emphasis-200)', borderRadius: '8px', padding: '0.5rem', textAlign: 'center', fontSize: '0.7rem'}}>
+              <div style={{height: '34px', background: 'var(--ifm-color-emphasis-200)', borderRadius: '5px', marginBottom: '0.3rem'}} />
+              {p}
+            </div>
+          ))}
+        </div>
+        {/* the flagged checkout section */}
+        <div id="sf-scan-issue" style={{margin: '0.3rem 0.85rem 0.85rem', border: '2px solid #e0a000', borderRadius: '9px', padding: '0.6rem 0.7rem', background: 'rgba(224,160,0,0.06)', position: 'relative'}}>
+          <span style={{position: 'absolute', top: '-0.65rem', left: '0.6rem', background: '#e0a000', color: '#fff', fontWeight: 800, fontSize: '0.6rem', padding: '0.1rem 0.45rem', borderRadius: '999px'}}>⚠ Issue identified</span>
+          <div style={{fontWeight: 700, fontSize: '0.78rem', marginTop: '0.2rem'}}>Mobile checkout</div>
+          <div style={{fontSize: '0.72rem', color: 'var(--ifm-color-emphasis-700)'}}>Loads in <strong style={{color: '#c0473a'}}>8.2s on mobile</strong> · 3-step form · cart abandonment 71%</div>
+        </div>
+      </div>
+    </Mockup>
+  );
+
+  // CUSTOM A: the dashboard the agent runs on. Carries a "new critical issue" row that flips
+  // to Shipped, the same checkout issue, now being addressed.
   const dashboard = (
     <Mockup chrome="browser" title="Storefront Agent" url="storefront-agent.app/wins" caption="The agent watches the store, ships fixes within guardrails, and reports the dollar lift.">
       <div style={{fontFamily: 'var(--ifm-font-family-base)'}}>
@@ -45,7 +81,7 @@ export default function Mockups() {
     </Mockup>
   );
 
-  // BI projection scene: two diverging conversion lines over 6 months, the agent's
+  // CUSTOM B: BI projection scene. Two diverging conversion lines over 6 months, the agent's
   // cumulative changes vs the do-nothing baseline. A small theme-aware inline SVG.
   const months = ['M1','M2','M3','M4','M5','M6'];
   const withAgent = [2.0, 2.15, 2.35, 2.5, 2.7, 2.85];   // % conversion, compounding
@@ -85,16 +121,16 @@ export default function Mockups() {
       <h2>What it looks like</h2>
 
       <Walkthrough
-        customScene={biScene}
+        customScenes={[dashboard, biScene]}
         steps={[
-          {type: 'move', target: '#sf-issue', say: 'The agent watches the store and finds a new critical issue'},
-          {type: 'highlight', target: '#sf-issue', say: 'slow mobile checkout, hurting conversion'},
-          {type: 'highlight', target: '#sf-issue', say: 'within its guardrails, it ships a fix to a holdback', hold: 1400},
-          {type: 'scene', to: 'custom', say: 'Each shipped win compounds the conversion curve', hold: 2200},
-          {type: 'scene', to: 'app', say: 'and the dollar lift lands back on the dashboard', hold: 1200},
+          {type: 'move', target: '#sf-scan-issue', say: 'The agent scans the live store'},
+          {type: 'highlight', target: '#sf-scan-issue', say: 'and identifies a weak spot: an 8.2s mobile checkout', hold: 1800},
+          {type: 'scene', to: 'custom', index: 0, say: 'it logs the issue on the dashboard and, within guardrails, ships a fix to a holdback', hold: 2200},
+          {type: 'scene', to: 'custom', index: 1, say: 'each shipped win compounds the conversion curve', hold: 2200},
+          {type: 'scene', to: 'app', say: 'and the agent keeps scanning for the next one', hold: 1400},
         ]}
       >
-        {dashboard}
+        {storeScan}
       </Walkthrough>
     </>
   );

--- a/packages/blog-ui/src/components/Walkthrough/index.tsx
+++ b/packages/blog-ui/src/components/Walkthrough/index.tsx
@@ -58,6 +58,8 @@ export type WalkStep =
   | {
       type: 'scene';
       to: 'app' | 'claude' | 'custom';
+      /** which custom scene to show when `to: 'custom'` (index into `customScenes`); default 0 */
+      index?: number;
       prompt?: string; // claude beats: the typed prompt line
       intro?: string; // claude beats: a human assistant line shown BEFORE the tools
       tools?: ClaudeTool[]; // claude beats: the streamed tool-use lines
@@ -68,8 +70,17 @@ export type WalkStep =
 export interface WalkthroughProps {
   children: ReactNode; // the app scene (a <Mockup>)
   steps: WalkStep[];
-  /** an optional SECOND scene (e.g. a BI chart) crossfaded to via {type:'scene', to:'custom'} */
+  /**
+   * A single extra scene (e.g. a BI chart), crossfaded to via {type:'scene', to:'custom'}.
+   * For more than one custom scene, use `customScenes` instead. (Kept for back-compat.)
+   */
   customScene?: ReactNode;
+  /**
+   * Multiple extra scenes, addressed by {type:'scene', to:'custom', index:N} (default 0).
+   * Takes precedence over `customScene` when provided. Lets a story crossfade across several
+   * author-supplied scenes, e.g. store-scan → dashboard → projection.
+   */
+  customScenes?: ReactNode[];
   stepHold?: number;
   autoPlay?: boolean;
   className?: string;
@@ -80,17 +91,28 @@ const Walkthrough: React.FC<WalkthroughProps> = ({
   children,
   steps,
   customScene,
+  customScenes,
   stepHold = 1000,
   autoPlay = true,
   className,
   style,
 }) => {
+  // Normalize the custom scene(s) into one array: `customScenes` wins; else the single
+  // `customScene` becomes a 1-element array; else none. Existing single-scene sidecars keep
+  // working unchanged (they hit index 0).
+  const scenesList: ReactNode[] =
+    customScenes && customScenes.length
+      ? customScenes
+      : customScene
+        ? [customScene]
+        : [];
   const rootRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<HTMLDivElement>(null);
   const [cursor, setCursor] = useState({x: 24, y: 24, clicking: false});
   const [hl, setHl] = useState<{x: number; y: number; w: number; h: number} | null>(null);
   const [typed, setTyped] = useState<{sel: string; text: string} | null>(null);
   const [scene, setScene] = useState<'app' | 'claude' | 'custom'>('app');
+  const [customIndex, setCustomIndex] = useState(0);
   const [claudePrompt, setClaudePrompt] = useState('');
   const [claudeIntro, setClaudeIntro] = useState('');
   const [claudeTools, setClaudeTools] = useState<ClaudeTool[]>([]);
@@ -143,7 +165,8 @@ const Walkthrough: React.FC<WalkthroughProps> = ({
       setCaption(step.say || '');
 
       if (step.type === 'scene') {
-        // crossfade scenes
+        // crossfade scenes; for a custom scene, select which one by index (default 0)
+        if (step.to === 'custom') setCustomIndex(step.index ?? 0);
         setScene(step.to);
         await wait(450);
         if (step.to === 'claude') {
@@ -332,17 +355,19 @@ const Walkthrough: React.FC<WalkthroughProps> = ({
           </div>
         </div>
 
-        {/* CUSTOM scene (e.g. a BI projection chart), supplied by the author */}
-        {customScene && (
+        {/* CUSTOM scene(s) (e.g. a store-scan, a dashboard, a BI projection), supplied by the
+            author. All are grid-stacked in the same cell; only the active index is shown. */}
+        {scenesList.map((node, i) => (
           <div
+            key={i}
             className={clsx(
               styles.scene,
-              scene === 'custom' ? styles.shown : styles.hidden
+              scene === 'custom' && customIndex === i ? styles.shown : styles.hidden
             )}
-            aria-hidden={scene !== 'custom'}>
-            {customScene}
+            aria-hidden={!(scene === 'custom' && customIndex === i)}>
+            {node}
           </div>
-        )}
+        ))}
       </div>
 
       {/* timeline: a continuous rail with one dot per step at an even position; a fill


### PR DESCRIPTION
Extends the `@omars-lab/blog-ui` Walkthrough to support multiple author-supplied scenes, and uses it so the **self-healing-storefront** design opens on a live store-scan (the ask in the storefront-walkthrough task).

## Component change (backward-compatible)
- New `customScenes?: ReactNode[]` prop (the existing `customScene?` still works — single-scene sidecars are unaffected).
- A scene step gains `index?: number`: `{type:'scene', to:'custom', index:N}` selects `customScenes[N]` (default 0). All custom scenes grid-stack; only the active index shows.

## Storefront sidecar
- Now **opens on a live store-scan** app scene (`acme-shop.com/checkout`): healthy product strip + a gold-bordered **Mobile checkout** block with a **⚠ Issue identified** badge (8.2s on mobile, 71% abandonment) and a "scanning store" banner — the weak spot the agent finds first.
- Flow: **scan (app) → dashboard (custom 0) → BI projection (custom 1) → keep scanning.**

## Proof
Playwright on the dev server: all three scenes become visible in sequence, the warning badge renders, the cursor moves to the flagged section, **0 real console errors** (the CF `/api/me` CORS line is the known dev premium-auth artifact). Opening-scan screenshot captured.

The `author-walkthrough` skill documents the multi-scene API + the app-scene-only-target gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)