### PR TITLE
chore(blog-ui): bump to v0.2.0 (multi-custom-scene)

### DIFF
--- a/.claude/skills/publish-blog-ui/SKILL.md
+++ b/.claude/skills/publish-blog-ui/SKILL.md
@@ -35,6 +35,8 @@ by the `.github/workflows/publish-blog-ui.yml` workflow on a version tag.
    `yarn build`, verifies `dist/` artifacts exist, then `npm publish`es to GitHub Packages using
    the repo's `GITHUB_TOKEN` (no manual creds). It runs from `packages/blog-ui`. (`npm publish`
    also runs `prepublishOnly` → `yarn build`, so the tarball can never ship a stale `dist`.)
+5. **Verify:** the repo's **Packages** tab (github.com/omars-lab/omars-lab.github.io → Packages)
+   shows the new version, or `npm view @omars-lab/blog-ui version --registry=https://npm.pkg.github.com`.
 
 ### Manual publish (if you can't / don't want to push a tag)
 
@@ -47,8 +49,6 @@ yarn simulate-publish   # dress-rehearse first
 npm publish             # prepublishOnly rebuilds; publishConfig points at GitHub Packages
 ```
 Same result as the tag-triggered workflow; the version still can't be republished once taken.
-5. **Verify:** the repo's **Packages** tab (github.com/omars-lab/omars-lab.github.io → Packages)
-   shows the new version, or `npm view @omars-lab/blog-ui version --registry=https://npm.pkg.github.com`.
 
 ## Semver
 

--- a/packages/blog-ui/package.json
+++ b/packages/blog-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omars-lab/blog-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, DiagramWithFootnotes, and Assumption highlight.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump + release prep for **@omars-lab/blog-ui v0.2.0**.

- `packages/blog-ui` → **0.2.0** (minor: the new backward-compatible `Walkthrough` `customScenes[]` + scene `index` prop, which shipped in the multi-custom-scene PR).
- Fixes a `publish-blog-ui` SKILL.md numbered-list ordering glitch (the "Manual publish" subsection had been inserted between steps 4 and 5, detaching the Verify step).

Dress rehearsal (`yarn simulate-publish`): **v0.2.0**, 5 files, 10.4 kB, no `.map` files, the 3 expected dist artifacts.

**After merge:** tag `blog-ui-v0.2.0` from master → the publish workflow ships it to GitHub Packages (merge-first ordering). The blog consumes via `file:` (automatic); getting-started can bump its range if it wants the new API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)