### PR TITLE
docs: Actions-Pages-deploy design post + thoughts companion

### DIFF
--- a/bytesofpurpose-blog/blog/2026-06-23-shipping-a-component-package.md
+++ b/bytesofpurpose-blog/blog/2026-06-23-shipping-a-component-package.md
@@ -1,0 +1,47 @@
+---
+slug: shipping-a-component-package
+title: '📦 Shipping a Component Package, and Proving It Works'
+description: "How I extracted my blog's React components into a published package, proved it consumable from a second repo, and gave that repo a CI-built Pages deploy that installs it."
+authors: [oeid]
+tags: [system-design, devops, github-actions, generative-ai, claude]
+date: 2026-06-23T10:00
+draft: true
+---
+
+My blog had grown a small library of custom React components for design posts: an animated UX `Walkthrough`, a `Mockup` frame, a footnoted diagram, an assumption highlight. They were good enough that I wanted to use them in other projects too. The honest test of "reusable" is not whether the code looks clean. It is whether a *different* repo can actually install it and render it. So I set out to make that true, end to end.
+
+<!-- truncate -->
+
+## From components to a package
+
+The first step was extracting the four components into a real package, `@omars-lab/blog-ui`, published to GitHub Packages. That meant a proper build (an ES module plus type declarations plus a bundled stylesheet), a release pipeline (tag, build, publish on a GitHub Actions workflow), and a dress rehearsal step so I could see exactly what would ship before it shipped. The blog itself consumes the package locally, so any breaking change shows up in the blog's build immediately.
+
+Publishing was the easy half. The interesting half was proving the package was genuinely usable somewhere else.
+
+## Proving it from a second repo
+
+I have a separate teaching project, a "getting started with Claude agents" guide, that ships a simple web page. I rebuilt that page as a Vite app whose only job, for the purposes of this exercise, was to `yarn add @omars-lab/blog-ui` from GitHub Packages, import a component, and render it. If a real bundler in a real second repo could resolve the package, pull in its styles, and put a working `Walkthrough` on screen, then "reusable" was no longer an aspiration.
+
+It worked: the bundler resolved the package, the component's scoped styles landed in the output, and the page rendered the animated walkthrough. That was the proof I wanted.
+
+## The quieter problem: how does it deploy?
+
+Proving the build works locally is one thing. Getting that site *deployed* is another, because the build now depended on a package behind authentication. The site published to GitHub Pages, and the existing setup served a committed copy of the built files. That has a sharp edge: if the source changes and nobody rebuilds and commits, the live site silently drifts from the source.
+
+So I moved the deploy into CI, where every publish is a fresh build of the current source. The wrinkle is that the CI build has to install the private package, which needs a token. The neat part: because the package and the deploying repo are owned by the same account, the repository's built-in Actions token can read it directly, no personal access token, no stored secret. The build authenticates with a credential that already exists.
+
+I wrote that migration up as a design doc, including the same-owner auth trick, the two-job build-and-deploy pattern, and how I validate the workflow before it runs:
+
+👉 **[Building a Pages Deploy That Consumes a Private Package](/designs/design-actions-pages-deploy)**
+
+## What I leaned on
+
+A few first-party sources did the heavy lifting, and they are worth bookmarking if you are wiring up the same thing:
+
+- [Using custom workflows with GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages) for the build-and-deploy model.
+- [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact) and [actions/deploy-pages](https://github.com/actions/deploy-pages) for the two-job handoff.
+- [actionlint](https://github.com/rhysd/actionlint) for catching workflow mistakes before they ever run in CI.
+
+## The takeaway
+
+"Reusable" is a claim you can actually test. Extract the code into a package, publish it, then make a *different* repo install and render it, and deploy that repo from source so the proof keeps holding. The components I started with are now a thing other projects can depend on, and there is a second site standing on them to show it.

--- a/bytesofpurpose-blog/designs/2026-06-23-actions-pages-deploy.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-23-actions-pages-deploy.mdx
@@ -1,0 +1,157 @@
+---
+slug: design-actions-pages-deploy
+sidebar_position: 14
+title: Building a Pages Deploy That Consumes a Private Package
+description: >-
+  How to deploy a Vite app to GitHub Pages from source in CI when it depends on
+  a package published to GitHub Packages, the same-owner auth trick, and the
+  two-job build/deploy pattern.
+authors:
+  - oeid
+tags:
+  - system-design
+  - ci-cd
+  - github-actions
+  - github-pages
+  - devops
+kind: system-design
+draft: true
+---
+
+When I extracted my blog's reusable React components into a published package
+(`@omars-lab/blog-ui` on GitHub Packages), I wanted a second repo to prove the package was
+truly consumable from the outside. So I rebuilt a separate project's site, the
+[getting-started-with-claude-agents](https://github.com/omars-lab/getting-started-with-claude-agents)
+guide, as a Vite app that installs that package and renders it. That worked. But it left a
+quieter problem: how does that site actually deploy, when its build now depends on a package
+that lives behind authentication?
+
+{/* truncate */}
+
+## The problem with the old deploy
+
+The guide had been a single self-contained `index.html`, served by GitHub Pages straight from
+the `main` branch (the "deploy from a branch" model). When I converted it to a Vite app, I kept
+that model: a `make build` step ran the build locally, copied the output to the repo root, and
+committed it. Pages served those committed files.
+
+That works, but it has a sharp edge: **the committed build output can silently drift from the
+source.** If someone edits `web/src/` and forgets to rebuild and commit, Pages keeps serving the
+stale bundle. The source and the live site disagree, and nothing tells you.
+
+The fix is to make CI the only thing that builds, so the published site is always a fresh build
+of the current source. That means moving from "deploy from a branch" to a custom GitHub Actions
+workflow, the model GitHub documents under
+[using custom workflows with GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages).
+
+## The catch: the build needs a private dependency
+
+Here is what makes this more than a copy-paste workflow. The build runs `yarn install`, and one
+of those dependencies, `@omars-lab/blog-ui`, lives on **GitHub Packages**, which requires
+authentication to install. Even though the package is public, the npm registry on GitHub
+Packages does not allow anonymous installs. So the CI build needs a token with `read:packages`.
+
+The reflex is to mint a personal access token and store it as a repo secret. But that is not
+necessary here, and avoiding it is the cleaner design. The key facts:
+
+- The package is owned by the same account (`omars-lab`) that owns the deploying repo.
+- A repository's built-in Actions token (`GITHUB_TOKEN`) can read packages owned by that same
+  account, given the job declares `permissions: packages: read`.
+
+So the build authenticates with the **default Actions token**, no PAT, no stored secret. It is
+wired through `setup-node`, which writes an `.npmrc` pointing the `@omars-lab` scope at the
+GitHub Packages registry and uses the token for auth:
+
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: 20
+    registry-url: https://npm.pkg.github.com
+    scope: '@omars-lab'
+- run: yarn install --frozen-lockfile
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## The shape: a build job and a deploy job
+
+The modern Pages deploy splits into two jobs. The build job produces the static site and
+uploads it as a Pages artifact; the deploy job publishes that artifact. GitHub's first-party
+actions, [`actions/upload-pages-artifact`](https://github.com/actions/upload-pages-artifact)
+and [`actions/deploy-pages`](https://github.com/actions/deploy-pages), handle the handoff.
+
+```yaml
+permissions:
+  contents: read
+  packages: read   # install @omars-lab/blog-ui
+  pages: write     # publish to Pages
+  id-token: write  # OIDC: prove the deploy came from this workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # ... setup-node + yarn install (above) ...
+      - run: yarn build              # Vite, into dist-site/
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist-site
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment
+```
+
+Two details that are easy to get wrong: the deploy job needs both `pages: write` and
+`id-token: write` (the OIDC token is how GitHub verifies the deployment came from your
+workflow), and it must target the `github-pages` environment. GitHub's docs recommend pinning
+`deploy-pages@v4`.
+
+## Keeping a manual path
+
+CI on every push is the primary deploy, but I still wanted a one-command manual deploy. Since
+Pages now builds from the workflow (not a branch), "deploy by hand" cannot mean "commit and
+push the build". Instead, the manual path simply **triggers the same workflow**:
+
+```makefile
+deploy: validate-config
+	gh workflow run deploy-pages.yml --ref main
+```
+
+One pipeline, two ways to start it (a push, or `gh workflow run`), and no second code path that
+could behave differently from CI.
+
+## Validating the config before it runs
+
+A workflow that only fails when it runs in CI is a slow feedback loop. So the manual deploy
+validates the workflow first, using [actionlint](https://github.com/rhysd/actionlint), a static
+checker that understands the Actions schema deeply: it type-checks `${{ }}` expressions,
+verifies action inputs against each action's real input list, and flags security issues, well
+beyond a plain YAML parse.
+
+```makefile
+validate-config:
+	actionlint   # lints .github/workflows/ ; deploy depends on this (fail-closed)
+```
+
+It earns its place: pointed at a workflow with a misspelled `actions/checkout` input, it names
+the bad input and prints the full list of valid ones. The deploy target depends on it, so a
+broken config never makes it to a triggered run.
+
+## What this buys
+
+The source is the single source of truth. Every deploy is a fresh build of the current
+`web/src`, authenticated with a token that already exists, validated before it runs. There is no
+committed build output to drift, no secret to rotate, and no second deploy path to keep in sync.
+
+### Sources
+
+- [Using custom workflows with GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+- [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)
+- [actions/deploy-pages](https://github.com/actions/deploy-pages)
+- [actionlint](https://github.com/rhysd/actionlint)


### PR DESCRIPTION
The writeup of the Actions-based Pages deploy work, as a two-surface pair (matching the co-design pattern).

## What's here
- **`/designs/design-actions-pages-deploy`** (design doc) — the technical design: the drift problem with committed build output, building from source in CI, the same-owner GitHub Packages auth via the default Actions token (no PAT), the `upload-pages-artifact@v4` + `deploy-pages@v4` two-job pattern, the single manual `make deploy`, and actionlint config validation. Ends with a Sources section.
- **`/thoughts/shipping-a-component-package`** (companion post) — the first-person story tying it to the package arc: extract `@omars-lab/blog-ui` → publish → prove it consumable from a second repo → give that repo a CI-built deploy. Links to the design post + the same sources.

Both are `draft: true` (dev-only until published).

## Validated
- Em-dash-free (the voice hook passes).
- Both MDX files compile and serve (dev routes return 200); the thoughts→design internal link resolves; source links render.
- Source links checked against the live pages: [GitHub Docs custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages), [upload-pages-artifact](https://github.com/actions/upload-pages-artifact), [deploy-pages](https://github.com/actions/deploy-pages), [actionlint](https://github.com/rhysd/actionlint).

Pairs with getting-started PR #3 (the actual workflow this documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)