### PR TITLE
feat(blog-ui): <Gif> animated-media component + terminal-GIF generator (v0.3.0)

### DIFF
--- a/.claude/skills/author-terminal-gif/SKILL.md
+++ b/.claude/skills/author-terminal-gif/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: author-terminal-gif
+description: Generate a synthesized Claude Code terminal-session GIF (no live recording) from a small JSON spec, to feed the <Gif> component on a blog/design post. Covers the generator script (Pillow frames + gifsicle), the spec format (folder/model/progress + a transcript of promptbar/line/gap/spinner entries with colored bold segments), where to put the output, and how to wire it into <Gif frame="terminal">. Use when a post wants to show a Claude Code session in motion (the agent running, tool calls streaming, a shortlist appearing) without recording a real terminal. Pairs with upgrade-post (the <Gif> catalog entry) and author-walkthrough (the live-scripted alternative).
+---
+
+# Author a synthesized terminal-session GIF
+
+When a post wants to show a Claude Code session *in motion* (the prompt typing, the `●` turns,
+`└` tool calls streaming, a shortlist appearing, the `✻` spinner) but you do not want to record
+a real terminal, generate one. The generator is **reproducible** (same spec → same gif, no live
+session) and the output drops straight into the `<Gif frame="terminal">` component.
+
+This is the recorded/synthesized-motion sibling of `author-walkthrough`: a `<Walkthrough>` is a
+live, scripted DOM animation; a terminal GIF is a baked clip that reads as a genuine CLI session.
+
+## Generate it
+
+```bash
+python3 bytesofpurpose-blog/scripts/make-terminal-gif.py <spec.json> \
+  --out bytesofpurpose-blog/static/img/<post>/session.gif
+```
+
+It writes the gif AND a `<post>/session-poster.png` (the final frame) for the `<Gif poster=…>`
+reduced-motion / paused still. It optimizes with `gifsicle` if installed (`brew install
+gifsicle`), typically cutting the gif to well under 100 KB. Needs Pillow (`pip install Pillow`).
+
+## The spec
+
+A JSON file. `scripts/terminal-gif.sample.json` is a complete worked example. Shape:
+
+```json
+{
+  "folder": "my-project",          // status-line folder name
+  "model": "Opus 4.8",             // status-line model
+  "progress": "▓░░░░░░░ ~10%",     // status-line progress
+  "transcript": [
+    {"kind": "promptbar", "text": "the user's prompt"},
+    {"kind": "gap"},
+    {"kind": "line", "segments": [
+        {"t": "● ", "c": "ink"},
+        {"t": "Claude's reply prose…", "c": "muted"}]},
+    {"kind": "line", "indent": 2, "segments": [
+        {"t": "└ ", "c": "muted"},
+        {"t": "Bash", "c": "ink", "b": true},
+        {"t": "(a command …)", "c": "muted"}]},
+    {"kind": "spinner", "segments": [
+        {"t": "Stewing… ", "c": "orange"},
+        {"t": "(28s · ↓ 636 tokens)", "c": "muted"}]}
+  ]
+}
+```
+
+- **Entry kinds:** `promptbar` (the grey user-input bar with a `›` chevron; if it is FIRST, the
+  gif opens by TYPING it letter-by-letter), `line` (a transcript line; optional `indent` in
+  half-character steps), `gap` (a blank half-line), `spinner` (an orange `✻` line that animates
+  through a few glyph cycles at the end).
+- **Segments** `{t, c, b}`: `t` = text, `c` = color (`ink` / `muted` / `orange` / `blue`), `b` =
+  bold. Match real Claude Code: bold `ink` for tool names + tickers, `muted` for prose/paths,
+  `blue` for file paths Claude opened, `orange` for the spinner + credits.
+- **Animation is automatic:** prompt types in, transcript reveals line by line, the spinner (if
+  present) cycles then holds. You only write the content.
+
+## Wire it into the post
+
+```mdx
+<Gif src="/img/<post>/session.gif" poster="/img/<post>/session-poster.png"
+     alt="Claude Code running the <agent> agent: the prompt, tool calls, and a shortlist"
+     frame="terminal" title="claude code"
+     caption={<><b>A real session.</b> The agent runs its skills, then pauses for approval.</>} />
+```
+
+See the `<Gif>` entry in `upgrade-post` for the component props. `alt` is required; `poster` is
+strongly recommended (it is the reduced-motion + paused still).
+
+## Verify (always prove)
+
+The gif is a static asset, so a build is not needed to check it, but confirm it RENDERS:
+
+```bash
+python3 -c "from PIL import Image; g=Image.open('<out>.gif'); print(g.format, g.n_frames, g.size)"
+# expect: GIF, dozens of frames, your WxH
+```
+
+Then view the post on the dev server and confirm the `<Gif>` shows the frame, the gif plays,
+and the play/pause toggle swaps to the poster.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Glyphs render as boxes (emoji, ✻) | the monospace font lacks the glyph | the script uses SF Mono / Menlo (mac); the folder emoji is drawn as a rect on purpose. Stick to the ✻ spinner set + ASCII. |
+| Gif is large (>200 KB) | gifsicle not installed, or too many colors | `brew install gifsicle`; it re-runs with `--colors 80`. Keep the canvas at the default 900×620. |
+| Text clipped at the bottom | transcript taller than the canvas | trim lines or raise `"height"` in the spec; the bottom ~96px is reserved for the input box + status line. |
+| Fonts differ on Linux/CI | the mac font paths are absent | run the generator locally (mac) and commit the gif; it is a build artifact you check in, not generated in CI. |
+
+## Files
+
+- `bytesofpurpose-blog/scripts/make-terminal-gif.py` — the parameterized generator (engine).
+- `bytesofpurpose-blog/scripts/terminal-gif.sample.json` — a complete worked spec.
+- `packages/blog-ui/src/components/Gif/` — the `<Gif>` component the output feeds.
+
+## Learnings log (newest first)
+
+- 2026-06-23 — Created by parameterizing the getting-started-with-claude-agents onboarding-guide
+  generator: the rendering engine (palette/fonts/segments/chrome/typing+reveal+spinner) was
+  generic; only the transcript + status-line folder were project-specific, so they moved into a
+  JSON spec. Output is a checked-in asset (mac fonts, not reproduced in CI). Pairs with the new
+  `<Gif>` component (the presentation half).

--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -10,7 +10,7 @@ skill is the **catalog + decision guide**: what each component is, when it earns
 the MDX to drop in, and what bites. It is content-origin-agnostic — use it on any
 `blog/`, `designs/`, or `docs/` page.
 
-> **Where the components live:** Walkthrough, Mockup, DiagramWithFootnotes, and Assumption
+> **Where the components live:** Walkthrough, Mockup, Gif, DiagramWithFootnotes, and Assumption
 > now ship from the published **`@omars-lab/blog-ui`** package (source in `packages/blog-ui/`).
 > Import them as `import {Mockup, Walkthrough} from '@omars-lab/blog-ui'`. The blog registers
 > them + imports the bundled styles (`@omars-lab/blog-ui/style.css`) once in
@@ -122,6 +122,30 @@ import {Mockup} from '@omars-lab/blog-ui';
   `mockups: ./_mockups/<name>.mdx`. The importer injects `import Mockups … <Mockups/>` after
   the truncate marker and **preserves it across re-imports**, and never regenerates the
   sidecar. See `import-co-design`.
+
+### Gif (animated media — show it in MOTION)
+
+WHAT: a framed, captioned, accessible figure for an animated GIF (or short clip) — a recorded
+or synthesized terminal session, a screen capture. WHEN: you want to show real motion that a
+scripted `<Walkthrough>` can't (an actual CLI run, a screen recording). Unlike a bare
+`<img src="*.gif">`, it lazy-loads, frames the media to match `<Mockup>` (a `terminal` frame
+reads as a CLI on any theme), and is motion-accessible: it starts on a static `poster` for
+`prefers-reduced-motion` and gives everyone a play/pause toggle (a GIF can't pause natively, so
+it swaps to the poster). HOW:
+
+```mdx
+import {Gif} from '@omars-lab/blog-ui';
+
+<Gif src="/img/<post>/session.gif" poster="/img/<post>/session-poster.png"
+     alt="Claude Code running the stock-analyzer agent" frame="terminal" title="claude code"
+     caption={<><b>A real session.</b> The agent runs its skills, then pauses for approval.</>} />
+```
+
+- Put the `.gif` (and a `poster` first-frame `.png`, recommended) under `static/img/<post>/` and
+  reference by absolute path, or `import` it in a sidecar. `alt` is required; `poster` is what
+  reduced-motion users see.
+- To GENERATE a synthesized Claude-Code-session gif (no live recording), see the
+  `author-terminal-gif` skill — it feeds straight into this component.
 
 ### Admonitions (callouts)
 

--- a/bytesofpurpose-blog/scripts/make-terminal-gif.py
+++ b/bytesofpurpose-blog/scripts/make-terminal-gif.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Render a synthesized Claude Code terminal-session GIF from a small spec — no live
+recording needed, fully reproducible. The output feeds the <Gif> component (frame="terminal").
+
+Matched to how Claude Code actually renders: a cream/light UI, the user prompt in a grey
+rounded bar with a › chevron, Claude's turn as a ● line, indented └ tool calls, an orange
+✻ spinner, and a bottom input box + status line.
+
+The ENGINE here is generic; the CONTENT comes from a JSON spec, so any post can generate its
+own session gif without editing this file. (Ported + parameterized from the
+getting-started-with-claude-agents onboarding-guide generator.)
+
+Usage:
+    python3 scripts/make-terminal-gif.py <spec.json> [--out static/img/<post>/session.gif]
+
+The spec (see scripts/terminal-gif.sample.json) is:
+    {
+      "folder": "my-project",            # shown in the status line
+      "model": "Opus 4.8",               # status line model name
+      "progress": "▓░░░░░░░ ~10%",       # status line progress
+      "width": 900, "height": 620,       # optional canvas size
+      "transcript": [                    # rendered in order, revealed line by line
+        {"kind": "promptbar", "text": "what stocks are worth considering today"},
+        {"kind": "gap"},
+        {"kind": "line", "segments": [{"t": "● ", "c": "ink"},
+                                       {"t": "I'll survey the market…", "c": "muted"}]},
+        {"kind": "line", "indent": 2, "segments": [{"t": "└ ", "c": "muted"},
+                                                    {"t": "Bash", "c": "ink", "b": true},
+                                                    {"t": "(ls -la)", "c": "muted"}]},
+        {"kind": "spinner", "segments": [{"t": "Stewing… ", "c": "orange"},
+                                          {"t": "(28s)", "c": "muted"}]}
+      ]
+    }
+
+A segment is {"t": text, "c": color-name, "b": bold?}. Colors: ink, muted, orange, blue.
+Also writes a poster PNG (the final frame) next to the gif, for the <Gif> poster= prop.
+"""
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+
+from PIL import Image, ImageDraw, ImageFont
+
+# --- palette, matched to real Claude Code screenshots ----------------------
+COLORS = {
+    "ink": (51, 49, 46),        # #33312E primary text / bold
+    "muted": (107, 105, 96),    # #6B6960 dim prose, paths, Running…
+    "orange": (200, 116, 46),   # #C8742E spinner, $, /passes
+    "blue": (91, 127, 176),     # #5B7FB0 model name, underlined paths
+}
+BG = (251, 244, 228)       # #FBF4E4 cream
+BAR = (218, 216, 210)      # #DAD8D2 grey prompt bar
+RULE = (227, 220, 201)     # #E3DCC9 hairlines
+CURSOR = (107, 105, 96)
+
+PADX = 26
+LINE_H = 26
+FS = 16
+
+
+def load_font(size, bold=False):
+    cands = [
+        "/System/Library/Fonts/SFNSMono.ttf",
+        "/System/Library/Fonts/Menlo.ttc",
+        "/System/Library/Fonts/Monaco.ttf",
+    ]
+    for c in cands:
+        if pathlib.Path(c).exists():
+            try:
+                if c.endswith(".ttc"):
+                    return ImageFont.truetype(c, size, index=1 if bold else 0)
+                return ImageFont.truetype(c, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+FONT = load_font(FS)
+FONT_B = load_font(FS, bold=True)
+
+
+def seg_tuple(s):
+    """Spec segment {t,c,b} -> (text, rgb, font)."""
+    color = COLORS.get(s.get("c", "ink"), COLORS["ink"])
+    return (s["t"], color, FONT_B if s.get("b") else FONT)
+
+
+def draw_segments(d, x, y, segments):
+    for text, color, font in segments:
+        d.text((x, y), text, font=font, fill=color)
+        x += d.textlength(text, font=font)
+    return x
+
+
+def draw_chrome(d, W, H, spec):
+    """The persistent bottom input box + status line."""
+    d.line([(PADX, H - 96), (W - PADX, H - 96)], fill=RULE)
+    d.text((PADX, H - 78), "›", font=FONT, fill=COLORS["muted"])
+    d.rectangle([PADX + 22, H - 80, PADX + 34, H - 60], fill=CURSOR)
+    d.line([(PADX, H - 44), (W - PADX, H - 44)], fill=RULE)
+    sy = H - 32
+    x = draw_segments(d, PADX, sy, [(spec.get("model", "Opus 4.8"), COLORS["blue"], FONT),
+                                    ("  |  ", COLORS["muted"], FONT)])
+    # a small folder glyph (the monospace font can't render the color emoji)
+    fx = x
+    d.rectangle([fx, sy + 5, fx + 17, sy + 16], fill=(214, 178, 92))
+    d.rectangle([fx, sy + 3, fx + 8, sy + 7], fill=(214, 178, 92))
+    x = fx + 23
+    draw_segments(d, x, sy, [(spec.get("folder", "project"), COLORS["muted"], FONT),
+                             ("  |  ", COLORS["muted"], FONT),
+                             (spec.get("progress", ""), COLORS["muted"], FONT)])
+
+
+SPINNER_GLYPHS = ["✻", "✺", "✹", "✸"]
+
+
+def render(spec, visible, W, H, spinner_phase=0, typed=None):
+    img = Image.new("RGB", (W, H), BG)
+    d = ImageDraw.Draw(img)
+    y = 28
+    for entry in visible:
+        kind = entry["kind"]
+        if kind == "gap":
+            y += LINE_H // 2 + 4
+            continue
+        if kind == "promptbar":
+            d.rounded_rectangle([PADX - 8, y - 4, W - PADX, y + 24], radius=7, fill=BAR)
+            draw_segments(d, PADX, y, [("› ", COLORS["muted"], FONT),
+                                       (entry["text"], COLORS["ink"], FONT)])
+            y += LINE_H + 6
+            continue
+        if kind == "spinner":
+            glyph = SPINNER_GLYPHS[spinner_phase % 4]
+            segs = [(glyph + " ", COLORS["orange"], FONT)] + [seg_tuple(s) for s in entry["segments"]]
+            draw_segments(d, PADX, y, segs)
+            y += LINE_H
+            continue
+        # normal line
+        indent = entry.get("indent", 0) * 8
+        draw_segments(d, PADX + indent, y, [seg_tuple(s) for s in entry["segments"]])
+        y += LINE_H
+
+    if typed is not None:
+        text, n = typed
+        d.rounded_rectangle([PADX - 8, 24, W - PADX, 52], radius=7, fill=BAR)
+        x = draw_segments(d, PADX, 28, [("› ", COLORS["muted"], FONT)])
+        shown = text[:n]
+        d.text((x, 28), shown, font=FONT, fill=COLORS["ink"])
+        cw = d.textlength(shown, font=FONT)
+        d.rectangle([x + cw + 1, 30, x + cw + 11, 48], fill=CURSOR)
+
+    draw_chrome(d, W, H, spec)
+    return img
+
+
+def build_frames(spec):
+    W = spec.get("width", 900)
+    H = spec.get("height", 620)
+    transcript = spec["transcript"]
+    frames, durations = [], []
+
+    # 1) type the prompt (if the first entry is a promptbar)
+    start = 0
+    if transcript and transcript[0]["kind"] == "promptbar":
+        text = transcript[0]["text"]
+        for n in range(0, len(text) + 1):
+            frames.append(render(spec, [], W, H, typed=(text, n)))
+            durations.append(40 if n < len(text) else 450)
+        start = 1
+
+    # 2) reveal the rest line by line
+    for i in range(start, len(transcript)):
+        visible = transcript[: i + 1]
+        frames.append(render(spec, visible, W, H))
+        durations.append(120 if transcript[i]["kind"] == "gap" else 300)
+
+    # 3) animate the spinner (if any) a few cycles, then hold
+    has_spinner = any(e["kind"] == "spinner" for e in transcript)
+    if has_spinner:
+        for phase in range(8):
+            frames.append(render(spec, transcript, W, H, spinner_phase=phase))
+            durations.append(180)
+        for _ in range(4):
+            frames.append(render(spec, transcript, W, H, spinner_phase=7))
+            durations.append(400)
+    else:
+        for _ in range(4):
+            frames.append(render(spec, transcript, W, H))
+            durations.append(400)
+    return frames, durations
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Synthesize a Claude Code terminal-session GIF.")
+    ap.add_argument("spec", help="path to the JSON spec")
+    ap.add_argument("--out", help="output gif path (default: alongside the spec, <spec>.gif)")
+    args = ap.parse_args()
+
+    spec_path = pathlib.Path(args.spec)
+    spec = json.loads(spec_path.read_text())
+    out = pathlib.Path(args.out) if args.out else spec_path.with_suffix(".gif")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    frames, durations = build_frames(spec)
+    frames[0].save(
+        out, save_all=True, append_images=frames[1:],
+        duration=durations, loop=0, optimize=True, disposal=2,
+    )
+    # a poster PNG (final frame) for the <Gif poster=…> reduced-motion / paused still
+    poster = out.with_name(out.stem + "-poster.png")
+    frames[-1].save(poster)
+    print(f"wrote {out} ({out.stat().st_size // 1024} KB, {len(frames)} frames)")
+    print(f"wrote {poster} (poster)")
+
+    if shutil.which("gifsicle"):
+        subprocess.run(["gifsicle", "-O3", "--colors", "80", "-o", str(out), str(out)], check=True)
+        print(f"optimized -> {out.stat().st_size // 1024} KB")
+    else:
+        print("gifsicle not found - skipped optimization (brew install gifsicle)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/bytesofpurpose-blog/scripts/terminal-gif.sample.json
+++ b/bytesofpurpose-blog/scripts/terminal-gif.sample.json
@@ -1,0 +1,25 @@
+{
+  "folder": "getting-started-with-claude-agents",
+  "model": "Opus 4.8",
+  "progress": "▓░░░░░░░ ~10%",
+  "transcript": [
+    {"kind": "promptbar", "text": "what stocks are worth considering today"},
+    {"kind": "gap"},
+    {"kind": "line", "segments": [{"t": "● ", "c": "ink"}, {"t": "I'll survey the market for stocks worth a closer look today. Let me", "c": "muted"}]},
+    {"kind": "line", "segments": [{"t": "  launch the ", "c": "muted"}, {"t": "stock-analyzer", "c": "muted", "b": true}, {"t": " agent to do this properly.", "c": "muted"}]},
+    {"kind": "gap"},
+    {"kind": "line", "segments": [{"t": "stock-analyzer", "c": "ink", "b": true}, {"t": "(Find stocks worth considering today)", "c": "muted"}]},
+    {"kind": "line", "indent": 2, "segments": [{"t": "└ ", "c": "muted"}, {"t": "Bash", "c": "ink", "b": true}, {"t": "(ls -la .claude/ && find .claude -name \"*.md\" …)", "c": "muted"}]},
+    {"kind": "line", "indent": 4, "segments": [{"t": "Running…", "c": "muted"}]},
+    {"kind": "line", "indent": 4, "segments": [{"t": "Read", "c": "ink", "b": true}, {"t": "(.claude/skills/ensure-deps/SKILL.md)", "c": "blue"}]},
+    {"kind": "line", "indent": 4, "segments": [{"t": "… +1 tool use (ctrl+o to expand)", "c": "muted"}]},
+    {"kind": "gap"},
+    {"kind": "line", "segments": [{"t": "● ", "c": "ink"}, {"t": "Here's a shortlist worth a closer look today. Approve it before I", "c": "muted"}]},
+    {"kind": "line", "segments": [{"t": "  spend analysis time going deeper:", "c": "muted"}]},
+    {"kind": "line", "indent": 4, "segments": [{"t": "NVDA", "c": "ink", "b": true}, {"t": "  data-center guidance raised after hours", "c": "muted"}]},
+    {"kind": "line", "indent": 4, "segments": [{"t": "AVGO", "c": "ink", "b": true}, {"t": "  custom-silicon 8-K filed pre-market", "c": "muted"}]},
+    {"kind": "line", "indent": 4, "segments": [{"t": "LLY", "c": "ink", "b": true}, {"t": "   PDUFA decision due this week", "c": "muted"}]},
+    {"kind": "gap"},
+    {"kind": "spinner", "segments": [{"t": "Stewing… ", "c": "orange"}, {"t": "(28s · ↓ 636 tokens)", "c": "muted"}]}
+  ]
+}

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -18,6 +18,7 @@ import {
   Mockup,
   Walkthrough,
   Assumption,
+  Gif,
 } from '@omars-lab/blog-ui';
 import '@omars-lab/blog-ui/style.css';
 
@@ -47,4 +48,7 @@ export default {
   Walkthrough,
   // Yellow inline highlight for [Assumption: …] markers (unvalidated premises to review).
   Assumption,
+  // Animated-media figure: a framed, captioned, accessible <Gif> for a recorded/synthesized
+  // clip (terminal session, screen capture) — lazy, reduced-motion poster, play/pause toggle.
+  Gif,
 };

--- a/packages/blog-ui/README.md
+++ b/packages/blog-ui/README.md
@@ -8,6 +8,8 @@ Reusable React components for design/blog posts, extracted from
   terminal scene (or any custom scene), with a step timeline. 
 - **`Mockup`** — a framed, theme-aware wrapper (browser / window / phone chrome) that turns
   live HTML into a UI mockup.
+- **`Gif`** — a framed, captioned, accessible animated-media figure for a GIF or clip (recorded
+  or synthesized terminal session, screen capture): lazy-load, reduced-motion poster, play/pause.
 - **`DiagramWithFootnotes`** — a diagram + a generated numbered legend (①②③) tied to notes.
 - **`Assumption`** — an amber inline highlight for "[Assumption: …]" markers to flag for review.
 

--- a/packages/blog-ui/package.json
+++ b/packages/blog-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@omars-lab/blog-ui",
-  "version": "0.2.0",
-  "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, DiagramWithFootnotes, and Assumption highlight.",
+  "version": "0.3.0",
+  "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, Gif animated-media figure, DiagramWithFootnotes, and Assumption highlight.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/blog-ui/src/components/Gif/index.tsx
+++ b/packages/blog-ui/src/components/Gif/index.tsx
@@ -1,0 +1,116 @@
+import React, {CSSProperties, ReactNode, useEffect, useRef, useState} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * Gif — a captioned, theme-aware, accessible figure for an animated GIF (or short looping
+ * video clip). A static screenshot shows a moment; a Gif shows the motion, a real recorded
+ * terminal session, a screen capture, a synthesized walkthrough, without the scripting a live
+ * <Walkthrough> needs.
+ *
+ * Why a component and not a bare <img src="*.gif">:
+ *   - GIFs autoplay and CANNOT be paused natively, which fails prefers-reduced-motion and
+ *     gives the reader no control. This shows a static POSTER frame by default for reduced-
+ *     motion users, and gives everyone a play/pause toggle (it swaps the animated source for
+ *     the poster to "pause", since a GIF can't truly pause).
+ *   - It lazy-loads, frames the media to match <Mockup>, and captions it consistently.
+ *
+ * Usage in MDX:
+ *
+ *   <Gif src={require('./demo.gif').default} poster={require('./demo-poster.png').default}
+ *        alt="Claude Code running the stock-analyzer agent" frame="terminal"
+ *        caption={<><b>A real session.</b> Claude launches the agent and pauses at a shortlist.</>} />
+ *
+ * `poster` is optional but recommended: it is what reduced-motion users see, and the "paused"
+ * state. Without it, reduced-motion users still see the (animated) gif but with a hint to play.
+ */
+
+export type GifFrame = 'terminal' | 'browser' | 'window' | 'none';
+
+export interface GifProps {
+  /** The animated GIF (or video) source URL. */
+  src: string;
+  /** Required alt text describing what the animation shows. */
+  alt: string;
+  /** A static image (first/representative frame) shown for reduced-motion + the paused state. */
+  poster?: string;
+  /** Frame chrome around the media. 'terminal' = dark bar titled "terminal"; matches <Mockup>. */
+  frame?: GifFrame;
+  /** Title shown in the terminal/window bar. */
+  title?: string;
+  /** Caption under the frame. */
+  caption?: ReactNode;
+  /** Max width of the figure. */
+  maxWidth?: number | string;
+  /** Start playing immediately (ignored under prefers-reduced-motion, which starts paused). */
+  autoPlay?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const Gif: React.FC<GifProps> = ({
+  src,
+  alt,
+  poster,
+  frame = 'none',
+  title,
+  caption,
+  maxWidth,
+  autoPlay = true,
+  className,
+  style,
+}) => {
+  // Start paused for reduced-motion users (and only flip to playing after mount, so SSR is
+  // deterministic). If there's no poster we can't show a still, so reduced-motion falls back
+  // to the animated gif but starts in the "paused"-labelled state where possible.
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    const reduce =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (autoPlay && !reduce) setPlaying(true);
+  }, [autoPlay]);
+
+  // "Pause" a gif by swapping to the poster (a gif can't be paused in place). If there's no
+  // poster, leave the gif animating but reflect intent in the toggle label.
+  const showAnimated = playing || !poster;
+  const mediaSrc = showAnimated ? src : (poster as string);
+
+  const barTitle = title || (frame === 'terminal' ? 'terminal' : title);
+
+  const frameStyle: CSSProperties = {
+    ...(maxWidth ? {maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth} : {}),
+    ...style,
+  };
+
+  return (
+    <figure className={clsx(styles.gif, styles[`frame_${frame}`], className)} style={frameStyle}>
+      <div className={styles.frame}>
+        {(frame === 'terminal' || frame === 'window' || frame === 'browser') && (
+          <div className={clsx(styles.bar, frame === 'terminal' && styles.barDark)}>
+            <span className={styles.dots} aria-hidden="true">
+              <i /><i /><i />
+            </span>
+            {barTitle && <span className={styles.barTitle}>{barTitle}</span>}
+          </div>
+        )}
+        <div className={styles.media}>
+          <img src={mediaSrc} alt={alt} loading="lazy" decoding="async" className={styles.img} />
+          <button
+            type="button"
+            className={styles.toggle}
+            aria-label={playing ? 'Pause animation' : 'Play animation'}
+            aria-pressed={playing}
+            onClick={() => setPlaying((p) => !p)}>
+            {playing ? '❚❚' : '▶'}
+          </button>
+        </div>
+      </div>
+      {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
+    </figure>
+  );
+};
+
+export default Gif;

--- a/packages/blog-ui/src/components/Gif/styles.module.css
+++ b/packages/blog-ui/src/components/Gif/styles.module.css
@@ -1,0 +1,109 @@
+/* Gif — a framed, captioned animated-media figure. Theme-aware via --ifm tokens.
+   Matches <Mockup>'s frame language so gifs and mockups read as the same family. */
+
+.gif {
+  margin: 1.75rem auto;
+  width: 100%;
+}
+
+.frame {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+}
+
+/* --- chrome bar (shared with Mockup's look) --- */
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.75rem;
+  background: color-mix(in srgb, var(--ifm-color-emphasis-200) 60%, var(--ifm-background-surface-color));
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+/* terminal frame: a dark bar so it reads as a CLI regardless of site theme */
+.barDark {
+  background: #2b2a28;
+  border-bottom-color: #11100f;
+}
+.barDark .barTitle { color: #c9c6bf; }
+
+.dots {
+  display: inline-flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.dots i {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--ifm-color-emphasis-400);
+}
+.dots i:nth-child(1) { background: #e06c5e; }
+.dots i:nth-child(2) { background: #e6b04a; }
+.dots i:nth-child(3) { background: #79b46a; }
+
+.barTitle {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+}
+
+/* --- the media + the play/pause affordance --- */
+.media {
+  position: relative;
+  line-height: 0; /* kill the inline-image gap */
+  background: var(--ifm-background-color);
+}
+.img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.toggle {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(20, 19, 18, 0.62);
+  color: #fff;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.55;
+  transition: opacity 0.15s, transform 0.15s;
+  backdrop-filter: blur(2px);
+}
+.media:hover .toggle,
+.toggle:focus-visible {
+  opacity: 1;
+}
+.toggle:hover {
+  transform: scale(1.06);
+}
+
+.caption {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+  text-align: center;
+}
+
+/* bare frame: keep the rounded frame but no bar */
+.frame_none .frame {
+  border-radius: 10px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* the component already starts paused (poster) for these users; nothing animates here */
+  .toggle { transition: none; }
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -12,6 +12,9 @@ export type {
 export {default as Mockup} from './components/Mockup';
 export type {MockupProps, MockupChrome} from './components/Mockup';
 
+export {default as Gif} from './components/Gif';
+export type {GifProps, GifFrame} from './components/Gif';
+
 export {default as DiagramWithFootnotes, circledNumber} from './components/DiagramWithFootnotes';
 export type {DiagramWithFootnotesProps} from './components/DiagramWithFootnotes';
 


### PR DESCRIPTION
Brings getting-started's GIF approach into the blog as a reusable component **and** a generator, and releases it as blog-ui v0.3.0.

## What's here
- **`<Gif>` component** (`@omars-lab/blog-ui`) — a framed, captioned, accessible animated-media figure for a GIF/clip (recorded or synthesized terminal session, screen capture). Unlike a bare `<img src="*.gif">`: motion-accessible (starts on a static `poster` under `prefers-reduced-motion`; play/pause toggle that swaps gif↔poster, since a gif can't pause natively), lazy-loads, and frames the media to match `<Mockup>` (a `terminal` frame reads as a CLI on any theme). Wired into the package barrel + the blog's MDXComponents.
- **Terminal-GIF generator** (`scripts/make-terminal-gif.py`) — the getting-started Pillow→gifsicle session-GIF renderer, **parameterized**: content comes from a JSON spec (`scripts/terminal-gif.sample.json`), so any post generates its own session gif. Emits a poster PNG for the `<Gif poster=…>` still.
- **`author-terminal-gif` skill** — generate → spec → wire into `<Gif>` → verify. `upgrade-post` catalogs `<Gif>` and forward-links it.
- **v0.3.0 bump** (new backward-compatible component).

## Proven
- `<Gif>` renders on the dev server: terminal frame + gif (loaded) + working play/pause toggle (Pause↔Play), 0 console errors; screenshot captured.
- Generator: ran the sample spec → a real animated GIF (54 frames, 85 kB after gifsicle, 900×620) + poster; poster shows a faithful Claude Code session.
- `simulate-publish`: v0.3.0, 5 files, 12 kB, no `.map`.

**After merge:** tag `blog-ui-v0.3.0` from master → the publish workflow ships it (merge-first ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)