### PR TITLE
Dev-only VS Code edit link on draft badge + theme the in-content tab/callout boxes

### DIFF
--- a/bytesofpurpose-blog/docs/craft/companies/mental-models/skills/understanding-desireable-leadership-skills.md
+++ b/bytesofpurpose-blog/docs/craft/companies/mental-models/skills/understanding-desireable-leadership-skills.md
@@ -12,24 +12,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-`}</style>
-
 # Understanding Leadership Principles: Beyond the Job Description
 
 A comprehensive guide to understanding what leadership principles companies actually evaluate, why they matter, and how to demonstrate them effectively in interviews.

--- a/bytesofpurpose-blog/docs/craft/companies/mental-models/skills/understanding-desireable-soft-skills.md
+++ b/bytesofpurpose-blog/docs/craft/companies/mental-models/skills/understanding-desireable-soft-skills.md
@@ -12,24 +12,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-`}</style>
-
 # Understanding Soft Skills: What Companies Actually Evaluate
 
 A comprehensive guide to the soft skills companies evaluate in interviews, including specific concerns, strengths, and behavioral indicators for stakeholder management, dealing with ambiguity, and decision making.

--- a/bytesofpurpose-blog/docs/craft/companies/mental-models/skills/understanding-desireable-tech-skills.md
+++ b/bytesofpurpose-blog/docs/craft/companies/mental-models/skills/understanding-desireable-tech-skills.md
@@ -12,24 +12,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-`}</style>
-
 # Understanding Technical Skills: What Companies Actually Evaluate
 
 A comprehensive guide to the technical skills companies evaluate in interviews, including specific concerns, strengths, and progression expectations for different SDE levels.

--- a/bytesofpurpose-blog/docs/craft/interview-prep/preparing/preparing-for-coding-questions.mdx
+++ b/bytesofpurpose-blog/docs/craft/interview-prep/preparing/preparing-for-coding-questions.mdx
@@ -12,40 +12,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-  
-  .checklist {
-    background-color: #e8f5e8;
-    border-left: 4px solid #28a745;
-    padding: 16px;
-    margin: 16px 0;
-  }
-  
-  .checklist h4 {
-    color: #155724;
-    margin-top: 0;
-  }
-  
-  .checklist ul {
-    margin-bottom: 0;
-  }
-`}</style>
-
 # Preparing for Coding Questions
 
 A comprehensive guide to preparing for coding interviews with systematic approach, data structures, algorithms, and problem-solving strategies.

--- a/bytesofpurpose-blog/docs/craft/interview-prep/preparing/preparing-for-system-design-questions.mdx
+++ b/bytesofpurpose-blog/docs/craft/interview-prep/preparing/preparing-for-system-design-questions.mdx
@@ -12,40 +12,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-  
-  .checklist {
-    background-color: #e8f5e8;
-    border-left: 4px solid #28a745;
-    padding: 16px;
-    margin: 16px 0;
-  }
-  
-  .checklist h4 {
-    color: #155724;
-    margin-top: 0;
-  }
-  
-  .checklist ul {
-    margin-bottom: 0;
-  }
-`}</style>
-
 # System Design Interview Guide
 
 A comprehensive guide to answering system design questions with systematic approach, background knowledge, and evaluation criteria.

--- a/bytesofpurpose-blog/docs/craft/productivity/processes/process-execution.mdx
+++ b/bytesofpurpose-blog/docs/craft/productivity/processes/process-execution.mdx
@@ -11,48 +11,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-  
-  .process-step {
-    background-color: #e8f5e8;
-    border-left: 4px solid #28a745;
-    padding: 16px;
-    margin: 16px 0;
-  }
-  
-  .process-step h4 {
-    color: #155724;
-    margin-top: 0;
-  }
-  
-  .definition-box {
-    background-color: #fff3cd;
-    border-left: 4px solid #ffc107;
-    padding: 16px;
-    margin: 16px 0;
-  }
-  
-  .definition-box h4 {
-    color: #856404;
-    margin-top: 0;
-  }
-`}</style>
-
 # My Personal Execution Process: From Ideas to Results
 
 

--- a/bytesofpurpose-blog/docs/craft/productivity/processes/process-interview.mdx
+++ b/bytesofpurpose-blog/docs/craft/productivity/processes/process-interview.mdx
@@ -11,48 +11,6 @@ draft: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-<style>{`
-  .tabs-container {
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    padding: 16px;
-    margin: 16px 0;
-    border: 1px solid #e9ecef;
-  }
-  
-  .tabs-container .tabs {
-    background-color: transparent;
-  }
-  
-  .tabs-container .tabItem {
-    background-color: transparent;
-  }
-  
-  .process-step {
-    background-color: #e8f5e8;
-    border-left: 4px solid #28a745;
-    padding: 16px;
-    margin: 16px 0;
-  }
-  
-  .process-step h4 {
-    color: #155724;
-    margin-top: 0;
-  }
-  
-  .insider-tip {
-    background-color: #fff3cd;
-    border-left: 4px solid #ffc107;
-    padding: 16px;
-    margin: 16px 0;
-  }
-  
-  .insider-tip h4 {
-    color: #856404;
-    margin-top: 0;
-  }
-`}</style>
-
 # The Complete Technical Interview Process: From Application to Offer
 
 A comprehensive guide to understanding the technical interview process from both candidate and company perspectives, including preparation, execution, and decision-making.

--- a/bytesofpurpose-blog/docusaurus.config.js
+++ b/bytesofpurpose-blog/docusaurus.config.js
@@ -55,6 +55,12 @@ const rehypePremiumEncrypt = require('./plugins/rehype-premium-encrypt');
       // Test-only: opt out of PostHog's bot/UA filter so e2e (Playwright) events
       // reach ingestion. Never set in production builds.
       posthogTestMode: process.env.POSTHOG_TEST_MODE === '1',
+      // Absolute site dir, ONLY in dev — used by the dev-only "open in VS Code"
+      // link on the draft badge to build a vscode://file/<abs-path> URI. Empty in
+      // production builds so the local filesystem path never ships to the public
+      // bundle (the link is also gated to localhost + non-prod client-side).
+      siteDirDev:
+        process.env.NODE_ENV !== 'production' ? __dirname : '',
     },
     // gtag-guard MUST come before posthog (and before the gtag plugin's own
     // client module): it stubs window.gtag so the plugin's unguarded route-change

--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -697,3 +697,57 @@ html[data-theme='dark'] .large-table .markdown table tbody tr:nth-child(even),
 html[data-theme='dark'] .markdown table.large-table tbody tr:nth-child(even) {
   background: rgba(255, 255, 255, 0.035);
 }
+
+/* ==========================================================================
+   In-content callout containers used across the interview/process/skills docs
+   (`<div class="tabs-container|process-step|insider-tip">`). These were authored
+   with a hardcoded inline <style> per page using cold Bootstrap grays/greens/
+   yellows (#f8f9fa / #e8f5e8 / #fff3cd) that clashed with the warm cream paper
+   and ignored dark mode. Centralized here on theme tokens so they match both
+   themes; the per-page <style> blocks were removed. Accent the process/tip rails
+   with the brand coral + the premium gold rather than stock green/amber.
+   ========================================================================== */
+.tabs-container {
+  background-color: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  padding: 16px;
+  margin: 16px 0;
+}
+.tabs-container .tabs,
+.tabs-container .tabItem {
+  background-color: transparent;
+}
+
+/* process-step + checklist share one treatment (both were the same green box). */
+.process-step,
+.checklist {
+  background-color: var(--ifm-color-primary-contrast-background);
+  border-left: 4px solid var(--ifm-color-primary);
+  border-radius: 0 var(--ifm-global-radius) var(--ifm-global-radius) 0;
+  padding: 16px;
+  margin: 16px 0;
+}
+.process-step h4,
+.checklist h4 {
+  color: var(--ifm-color-primary);
+  margin-top: 0;
+}
+.checklist ul {
+  margin-bottom: 0;
+}
+
+.insider-tip {
+  background-color: var(--premium-gold-wash, rgba(201, 162, 39, 0.1));
+  border-left: 4px solid var(--premium-gold-bright, #d4af37);
+  border-radius: 0 var(--ifm-global-radius) var(--ifm-global-radius) 0;
+  padding: 16px;
+  margin: 16px 0;
+}
+.insider-tip h4 {
+  color: var(--premium-gold-strong, #7a5f12);
+  margin-top: 0;
+}
+html[data-theme='dark'] .insider-tip h4 {
+  color: var(--premium-gold-bright, #d4af37);
+}

--- a/bytesofpurpose-blog/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -2,10 +2,26 @@ import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import ShareButton from '@site/src/components/ShareButton';
 import {isLocalhost} from '@site/src/experiments';
 import {DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
 import styles from './styles.module.css';
+
+// Build a vscode://file/<abs-path> URI from the post's aliased source path
+// (e.g. "@site/designs/2026-06-22-foo.mdx") + the dev-only absolute site dir.
+// Returns null unless both are present (so prod, where siteDirDev is empty,
+// yields no link). The path is URL-encoded per segment so spaces etc. survive.
+function vscodeUriForSource(
+  source: string | undefined,
+  siteDir: string | undefined,
+): string | null {
+  if (!source || !siteDir) return null;
+  const rel = source.replace(/^@site\//, '');
+  const abs = `${siteDir.replace(/\/$/, '')}/${rel}`;
+  const encoded = abs.split('/').map(encodeURIComponent).join('/');
+  return `vscode://file/${encoded}`;
+}
 
 // Swizzled @theme/BlogPostItem/Header/Title: re-implements the upstream Title
 // and mounts the inline <ShareButton> beside the H1, but ONLY on the blog post
@@ -30,16 +46,42 @@ export default function BlogPostItemHeaderTitle({
   className?: string;
 }): React.JSX.Element {
   const {metadata, frontMatter, isBlogPostPage} = useBlogPost();
+  const {siteConfig} = useDocusaurusContext();
   const {permalink, title} = metadata;
   const shareDescription =
     (frontMatter?.description as string | undefined) || metadata.description;
   const isDraft = useIsDraftPost(frontMatter);
   const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
 
+  // Dev-only: when a post is a draft, make its "D" badge a link that opens the
+  // source file in VS Code (vscode://file/<abs-path>). Only renders when a draft
+  // (so already localhost + non-prod) AND siteDirDev is set (empty in prod).
+  const vscodeUri = isDraft
+    ? vscodeUriForSource(
+        (metadata as {source?: string}).source,
+        siteConfig.customFields?.siteDirDev as string | undefined,
+      )
+    : null;
+
+  const badge = isDraft ? (
+    vscodeUri ? (
+      <a
+        href={vscodeUri}
+        className={styles.draftEditLink}
+        title="Open this draft's source in VS Code"
+        aria-label="Open draft source in VS Code"
+        onClick={(e) => e.stopPropagation()}>
+        <DraftBadge />
+      </a>
+    ) : (
+      <DraftBadge />
+    )
+  ) : null;
+
   const heading = (
     <TitleHeading className={clsx(styles.title, className)}>
       {isBlogPostPage ? title : <Link to={permalink}>{title}</Link>}
-      {isDraft && <DraftBadge />}
+      {badge}
     </TitleHeading>
   );
 

--- a/bytesofpurpose-blog/src/theme/BlogPostItem/Header/Title/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/BlogPostItem/Header/Title/styles.module.css
@@ -18,3 +18,14 @@
   gap: 0.75rem;
   flex-wrap: wrap;
 }
+
+/* Dev-only "open in VS Code" wrapper around the draft "D" badge. Keep it inline so
+   the pill stays beside the title; the badge carries its own styling. */
+.draftEditLink {
+  text-decoration: none;
+  cursor: pointer;
+}
+.draftEditLink:hover {
+  text-decoration: none;
+  filter: brightness(0.95);
+}


### PR DESCRIPTION
Two small, independent dev/UX improvements.

## 1. Draft "D" badge → opens source in VS Code (dev only)
On localhost, a draft post's "D" badge (in its h1/h2 title) becomes a `vscode://file/<abs-path>` link that opens the source `.mdx` in VS Code — one click from "this draft looks wrong" to editing it.

- `docusaurus.config.js`: inject `siteDirDev` customField = `__dirname`, but **only** when `NODE_ENV !== 'production'` (empty string in prod) so the local filesystem path never ships.
- `BlogPostItem/Header/Title`: builds the URI from `metadata.source` + `siteDirDev`; wraps `<DraftBadge>` in the link. No link unless both present → prod renders the plain badge.

**Prod no-op proven:** `siteDirDev:""` → zero generated vscode links; drafts excluded from prod anyway. (Pre-existing `vscode://` strings in built output are authored content in habits/website-blog docs, not this feature.)

## 2. Theme the in-content tab / callout boxes
`.tabs-container` (+ `.process-step` / `.checklist` / `.insider-tip`) were styled by a hardcoded inline `<style>` block **duplicated across 7 docs**, using cold Bootstrap colors (`#f8f9fa` gray, `#e8f5e8` green, `#fff3cd` yellow) that clashed with the warm cream theme and stayed light in dark mode.

Moved them to global `custom.css` on theme tokens (cream card surface, coral tint for steps/checklist, premium-gold wash for tips) and deleted the 7 duplicated inline blocks. Net −207/+114 lines.

## Verification
- Both verified in light + dark on the dev server (tab container: `#f4f0e8` light / `#211d1a` dark — was stuck `#f8f9fa`; VS Code link resolves to the correct absolute `.mdx` path).
- `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)