### PR TITLE
docs(productivity): restructure organizing/analyzing notes into requirements vs examples

### DIFF
--- a/bytesofpurpose-blog/docs/craft/productivity/analyzing/analyzing-popularity.mdx
+++ b/bytesofpurpose-blog/docs/craft/productivity/analyzing/analyzing-popularity.mdx
@@ -1,13 +1,104 @@
 ---
 slug: /productivity/analyzing/analyzing-popularity
 title: '🔍 Analyzing Popularity'
-description: 'Techniques for analyzing popularity and trends using tools like Amazon, Google Trends, and keyword tracking'
+description: 'How to gauge the popularity of a website, trend, concept, or topic using search, traffic, social, and community signals.'
 authors: [oeid]
 tags: [analysis, popularity, trends, google-trends, amazon, keywords, research]
 date: 2025-01-31T10:00
 draft: true
 ---
 
+# Analyzing Popularity
+
+"Is this popular?" is rarely one number. Whether the subject is a **website**, a **trend**,
+a **concept**, or a **topic**, popularity shows up as several independent signals, and the
+honest read comes from triangulating across them rather than trusting any single tool. This
+page lays out the signals, the tools that read each one, and how to interpret what they say.
+
+## The signals
+
+Popularity is the sum of a few distinct things. Decide which ones matter for your subject
+before you start measuring:
+
+| Signal | The question it answers | Best for |
+| --- | --- | --- |
+| **Search demand** | How many people actively look for this? | Trends, concepts, topics, products |
+| **Traffic** | How many people land on this site? | Websites you don't own |
+| **Direct analytics** | Who actually visits, from where, doing what? | A site you own |
+| **Social signal** | How much is this shared and talked about? | Trends, topics, brands |
+| **Community size** | How many people gather around this? | Concepts, tools, niches |
+| **Authority / backlinks** | How much does the rest of the web vouch for it? | Websites, sources |
+| **Commercial demand** | How many people buy or rank it? | Products, books |
+
+## Search demand
+
+The most general signal: what people type into a search box. It works for almost any
+subject because it measures intent directly.
+
+- **Google Trends** shows relative interest over time and by region, and lets you compare
+  several terms head-to-head. It is the fastest way to see whether a topic is rising,
+  flat, seasonal, or fading. Note it shows *relative* interest, not absolute counts.
+- **Keyword tools** (Google Keyword Planner, and third-party tools like Ahrefs or
+  Semrush) give actual monthly search volume and related queries, so you can size demand
+  and find the language people actually use.
+
+For a trend or concept, this is usually where to start: rising search demand is the
+clearest early sign that something is catching on.
+
+## Traffic (a site you don't own)
+
+When the subject is a website you have no analytics access to, use traffic estimators.
+Tools like Similarweb or Ahrefs estimate visits, top traffic sources, and audience
+geography. Treat the absolute numbers as rough; the **relative comparison** between two
+sites and the **trend direction** are more trustworthy than the exact figure.
+
+## Direct analytics (a site you own)
+
+If you own the site, you get the ground truth instead of an estimate. See the companion
+page on [leveraging Google Analytics](/craft/productivity/analyzing/leveraging-google-analytics)
+for setup, real-time dashboards, and event tracking. Direct analytics answer who visits,
+from where, on what device, and which content actually holds attention.
+
+## Social and community signals
+
+Some subjects live more in conversation than in search:
+
+- **Social platforms** reveal share counts, hashtag volume, and sentiment. A topic can be
+  hugely discussed before it shows up in search volume.
+- **Community size** is a strong popularity proxy for concepts, tools, and niches: members
+  in a relevant subreddit or Discord, stars on a GitHub repo, followers on a newsletter.
+  These are slower to game than a single viral spike, so they read "real" adoption well.
+
+## Authority and backlinks
+
+For websites and sources, how much the rest of the web links to a thing is a durable
+popularity-and-trust signal. Backlink tools (Ahrefs, Moz, Semrush) count referring domains
+and rank authority. Many links from credible sites is harder to fake than raw traffic.
+
+## Commercial demand
+
+When the subject is something people buy or rank, marketplaces are a built-in popularity
+meter. **Amazon** is the obvious one: best-seller rank, review counts, and review velocity
+all proxy how many people actually want a product or book right now.
+
+## How to read it
+
+A few habits keep the read honest:
+
+1. **Triangulate.** One green tool is a hypothesis; agreement across search, social, and
+   community is a conclusion.
+2. **Prefer trend over snapshot.** Direction over time tells you more than today's number,
+   and is less sensitive to a single tool's estimation error.
+3. **Watch for relative vs. absolute.** Google Trends and most third-party estimators are
+   relative or approximate; only analytics on a site you own are exact.
+4. **Match the signal to the subject.** Backlinks suit a website; search demand suits a
+   concept; community size suits a niche tool. Using the wrong signal gives a confident
+   wrong answer.
+
+## Raw notes
+
+> Original brain-dump, kept verbatim for provenance.
+
 * [ ] I need a techniques for popularity analysis!
 * [ ] amazon, google trends, etc
-* [ ] use google keywords to track popularity / interest in items 
+* [ ] use google keywords to track popularity / interest in items

--- a/bytesofpurpose-blog/docs/craft/productivity/analyzing/leveraging-google-analytics.mdx
+++ b/bytesofpurpose-blog/docs/craft/productivity/analyzing/leveraging-google-analytics.mdx
@@ -10,8 +10,49 @@ draft: false
 
 # Leveraging Google Analytics
 
-## Configuring Google Analytics
-- [ ] Setup Google Analytics on Blog >2022-04-19 
+How I set up Google Analytics on this blog, where the live dashboard is, and the tools I
+use to debug tracking. The reference links from my original setup notes are organized below
+by what they help you do; the raw checklist is preserved at the bottom under
+[Raw notes](#raw-notes).
+
+## Setting it up
+
+The path from "no analytics" to "tracked blog" has three layers, from most
+Docusaurus-specific to most general:
+
+1. **Wire it into Docusaurus.** The
+   [`@docusaurus/plugin-google-gtag`](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag)
+   plugin is the supported way to add gtag.js to a Docusaurus site.
+2. **Add gtag.js to any site.** Google's own guides cover the general install and the
+   single-page-app case (relevant because Docusaurus is an SPA):
+   [gtag.js collection](https://developers.google.com/analytics/devguides/collection/gtagjs)
+   and
+   [single-page applications](https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications).
+3. **Track custom events.** To go beyond pageviews and log button clicks, these show how to
+   run a globally-defined script inside a React component and fire events:
+   [react-component-depot example](https://github.com/codegeous/react-component-depot/blob/master/src/pages/_layouts/Home/index.js),
+   a [walkthrough video](https://www.youtube.com/watch?v=MEsm6SUED4I), and a
+   [Pluralsight guide](https://www.pluralsight.com/guides/how-to-use-a-globally-defined-script-inside-a-react-component).
+
+## Viewing the data
+
+- [Real-time overview dashboard](https://analytics.google.com/analytics/web/#/p286298793/realtime/overview?params=_u..nav%3Dmaui)
+  in Google Analytics.
+
+## Debugging tracking
+
+When events aren't showing up, verify the tags are firing before changing code:
+
+- [Tag Assistant Companion](https://chrome.google.com/webstore/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm)
+  (Chrome extension)
+- [Tag Assistant](https://tagassistant.google.com/) (web)
+
+## Raw notes
+
+> Original brain-dump, kept verbatim for provenance.
+
+### Configuring Google Analytics
+- [ ] Setup Google Analytics on Blog `>2022-04-19`
     - [ ] Configuring the blog with google analytics
         - [ ] [Docusaurus: Plugin Google Gtag](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag)
     - [ ] Try adding a button with a custom event ...
@@ -22,7 +63,7 @@ draft: false
         - [developers.google.com: Gtagjs](https://developers.google.com/analytics/devguides/collection/gtagjs)
         - [developers.google.com: Single Page Applications](https://developers.google.com/analytics/devguides/collection/gtagjs/single-page-applications)
 
-# Dashboard
+### Dashboard
 - [analytics.google.com: Web](https://analytics.google.com/analytics/web/#/p286298793/realtime/overview?params=_u..nav%3Dmaui)
 
 - [ ] Debugging Google Analytics

--- a/bytesofpurpose-blog/docs/craft/productivity/organizing/linking.mdx
+++ b/bytesofpurpose-blog/docs/craft/productivity/organizing/linking.mdx
@@ -8,17 +8,73 @@ date: 2021-10-25T10:00
 draft: true
 ---
 
+The goal: make links between my notes, files, and tools work like first-class
+connections, so I can jump straight to the right file (or recurring question) and trust
+that the links don't rot. This page separates what such a system has to do (the
+**requirements**) from the concrete link formats that satisfy each one (the
+**examples**). The original brain-dump is preserved at the bottom under
+[Raw notes](#raw-notes).
+
+## Requirements
+
+What a custom-linking system for my notes must do:
+
+1. **Deep links into files**: a link should open a specific file at a specific line in my
+   editor, not just point at a web page.
+2. **Embed links to recurring questions**: questions I revisit across many notes should be
+   reachable by a stable link I can drop anywhere.
+3. **Generate links automatically**: a script should mint the editor deep-link for a file
+   rather than me hand-writing the URL each time.
+4. **Detect broken references**: a script should scan notes for links and flag any that no
+   longer resolve, so renames and moves don't silently break things.
+5. **Bridge external tools to local files**: a link clicked in a web tool (e.g. Jira)
+   should resolve to the matching local file, via URL rewriting rather than manual copying.
+
+## Link examples
+
+Concrete formats that satisfy the requirements above:
+
+| Link | Requirement | What it does |
+| --- | --- | --- |
+| `vscode://file/Users/omareid/Workspace/git/blueprints/initiatives/tinker-react.md:1` | Deep links into files | Opens that file at line 1 in VS Code (the `:1` is the line number). |
+| A generated `vscode://file/...:<line>` URL | Generate links automatically | A script emits the deep-link so I don't hand-write the path each time. |
+| An `https://` Jira URL rewritten to an `x-callback` URL | Bridge external tools | Jira opens an `https` link that gets redirected to the local-file callback. |
+
+### Bridging Jira to local files
+
+Jira can only store `https` links, so the bridge is a redirect: the `https` URL opens, then
+a rewrite sends it to the `x-callback` (or `vscode://`) URL that opens the local file. Two
+ways to do the rewrite:
+
+- A Tampermonkey userscript that rewrites matching URLs on the page before I click.
+- A redirector extension page, e.g.
+  `chrome-extension://ocgpenflpmgnfapjedencafcfakcekcd/redirector.html`, where the
+  match/replace rules live.
+
+## Open questions
+
+- How will I embed links to recurring questions across my notes (what's the stable
+  anchor)?
+- Should the Jira-to-local rewrite happen automatically via a Tampermonkey plugin, or stay
+  a manual redirect rule?
+
+## Raw notes
+
+> Original brain-dump, kept verbatim for provenance.
+
 * [ ] How will I embed links to recurring questions across my notes?
 
 Links
 * [ ] Make a script to generate vscode xcallback ...
-* [ ] Script to detect links and notes and make sure no broken refs >2021-10-25 
+* [ ] Script to detect links and notes and make sure no broken refs `>2021-10-25`
 
-# Emedding XCallback URLs into Jira ...
+### Embedding XCallback URLs into Jira ...
+
 - [ ] Use URL re-writing ... jira opens an https url ... gets redirected to xcallback ...
 	- [ ] Should I automatically rewrite urls like this with a tampermonkey plugin?
 
-	- [ ] Edit redirects here ... chrome-extension://ocgpenflpmgnfapjedencafcfakcekcd/redirector.html
+	- [ ] Edit redirects here ... `chrome-extension://ocgpenflpmgnfapjedencafcfakcekcd/redirector.html`
 
-vscode://file/Users/omareid/Workspace/git/blueprints/initiatives/tinker-react.md:1
+`vscode://file/Users/omareid/Workspace/git/blueprints/initiatives/tinker-react.md:1`
+
 [vscode: Tinker React.Md:1](https://vscode/file/Users/omareid/Workspace/git/blueprints/initiatives/tinker-react.md:1)

--- a/bytesofpurpose-blog/docs/craft/productivity/organizing/tagging.mdx
+++ b/bytesofpurpose-blog/docs/craft/productivity/organizing/tagging.mdx
@@ -8,35 +8,100 @@ date: 2022-04-05T10:00
 draft: true
 ---
 
-* [ ] I have abstract roles that span other roles / other roles inherit from ... I need special hashtags to these roles to link the too ... things like skill building - #skill++ #24/7
+The goal: a small set of **custom tags** I can drop into my notes that scripts then act on
+automatically. This page separates what such a system has to do (the **requirements**)
+from the concrete tags that satisfy each one (the **examples**). The original
+brain-dump is preserved at the bottom under [Raw notes](#raw-notes).
+
+## Requirements
+
+What a custom-tag system for my notes must do:
+
+1. **Auto-expanding date tags**: a tag written once should expand into a concrete date,
+   and date-bearing tasks should surface on the right day instead of being pre-created.
+2. **Recurring tasks**: a tag should make a task repeat (daily, weekly) until an optional
+   end date, created on demand rather than pre-populated.
+3. **A task mover**: pull dated/`today` tasks into the daily file, preserving the
+   task/subtask hierarchy and tallying older dates so the backlog stays legible.
+4. **Freshening**: bump stale dates on un-done tasks forward so old work doesn't rot.
+5. **Archiving**: move larger notes into daily files, surviving note renames.
+6. **Abstract / inheritable role tags**: tags that stand for a category of work and that
+   other roles can inherit from, so one tag links many related notes.
+7. **Auto-tagging**: categories of work get tagged automatically rather than by hand.
+8. **Run-on-use, not on a schedule**: expansion/mover scripts should run when I actually
+   open my notes (via an x-callback trigger), not blindly every day on cron.
+
+## Tag examples
+
+Concrete syntax that satisfies the requirements above:
+
+| Tag | Requirement | What it does |
+| --- | --- | --- |
+| `>2022-01-12` | Auto-expanding date | Expands to that date; in calendar files it moves to `today`. |
+| `>this-week` | Auto-expanding date | Expands once a week (the weekly analogue of `expand-today`). |
+| `>today` | Task mover | Marks a task to be pulled into the current daily file. |
+| `#repeat(until=date)` | Recurring tasks | Repeats a task daily until the given date. |
+| `#skill++` | Abstract / inheritable role | An abstract role other roles inherit from (skill-building). |
+| `#24/7` | Abstract / inheritable role | An always-on role tag, paired with `#skill++`. |
+| `@done(2022-04-05 10:21 PM)` | Task mover / freshening | Completion stamp; the mover ignores done tasks. |
+
+### Mover detail
+
+The today-mover should **tally older dates and aggregate by 5**, keeping the oldest dates
+so a long tail of overdue work collapses instead of flooding the daily file. For example,
+it collapses `>today >2022-04-04 >2022-03-31 >2022-03-12 >2022-03-11` rather than listing
+each one.
+
+### Trigger detail
+
+Rather than a daily cron, bind expansion to opening NotePlan: an x-callback (wired through
+Shortcuts) that **runs the expand/move script first, then opens the app**. The `sed`
+in-place pass skips lines that already carry `today` and rewrites the rest.
+
+## Open questions
+
+- For abstract roles that span other roles, what's the cleanest inheritance syntax
+  (`#skill++`, `#24/7`)?
+- For auto-tagging categories of work, can it be fully automatic, or is a manual nudge
+  unavoidable?
+- Backlog file vs. in-place dating: do I keep a single backlog note, or keep dating tasks
+  in the file where I naturally write them?
+- Should I go back to driving NotePlan edits through shell commands?
+
+## Raw notes
+
+> Original brain-dump, kept verbatim for provenance.
+
+* [ ] I have abstract roles that span other roles / other roles inherit from ... I need special hashtags to these roles to link the too ... things like skill building - `#skill++` `#24/7`
 
 
-# Autoexpanding Special Tags
+### Autoexpanding Special Tags
 
 - [ ] When it comes to tagging categories of work, how will I do these?
 	- [ ] Can I auto tag stuff?
 
-# Task Management
-* [ ] Similar to `expand-today`, I should have a >this-week tag and expand it once a week ...
-* [x] Make script to move things to today ... @done(2022-04-05 10:21 PM)
+### Task Management
+
+* [ ] Similar to `expand-today`, I should have a `>this-week` tag and expand it once a week ...
+* [x] Make script to move things to today ... `@done(2022-04-05 10:21 PM)`
 * [ ] To do the sed task today moving thingy ... I almost need to transform all subtasks ... into one line with the main task ...
 	* [ ] But this way ... I wouldn't be handling subtasks appropriately ...
-	* [ ] today needs to be at the top level ... 
-* [ ] I need to write a script to keep on repeating this ... until ...#repeat(until=date)
+	* [ ] today needs to be at the top level ...
+* [ ] I need to write a script to keep on repeating this ... until ... `#repeat(until=date)`
 	* [ ] Don't pre-create ... create every day based on when I login in / cron runs!
 	* [ ] Can use the sed in place ... ignore lines that already have today ... and replace those with a repeat less than ..
-* [ ] Script to freshen any old tasks! Sed >date with fresher date! >2021-10-26 
-* [ ] I should make a script to auto expand >2022-01-12 with the date ... in note files ...
+* [ ] Script to freshen any old tasks! Sed `>date` with fresher date! `>2021-10-26`
+* [ ] I should make a script to auto expand `>2022-01-12` with the date ... in note files ...
 	* [ ] if its in calendar files ... it should expand and move to today ...
-	* [ ] Or should I have a "backlog" file ... with all the things to do .... 
+	* [ ] Or should I have a "backlog" file ... with all the things to do ....
 		* [ ] But I naturally mark put stuff I need to do today in the today file ...
 		* [ ] Can I auto tag the date ... based on file ..?
 * [ ] Should I go back to a shell command to track todos / edit Noteplan through shell commands ...?
-* [ ] I need repeat/ constant functionality ... to repeat daily tasks 
+* [ ] I need repeat/ constant functionality ... to repeat daily tasks
 - [ ] I need archive functionality ... that knows how to move bigger notes into the daily files ... but if I change name ... daily file name changes too!
 * [ ] for today mover, I should tally older dates and agg by 5 ... and keep oldest dates
 * [ ] I don't want the expand-today script to run every day ...
 	* [ ] I only want it to run when I use note plan ...
 	* [ ] Should make an Xxcallback to w/ shortcuts to open note plan .... But before doing so ... it should run the script!
 
-* [ ] Figure out how to tally older days when moving things over to today ... >today >2022-04-04 >2022-03-31 >2022-03-12 >2022-03-11
+* [ ] Figure out how to tally older days when moving things over to today ... `>today >2022-04-04 >2022-03-31 >2022-03-12 >2022-03-11`


### PR DESCRIPTION
## What

Cleaned up four raw checkbox brain-dumps in `craft/productivity` into structured docs. Each separates **requirements** (what the system must do) from **examples** (concrete syntax/tools), and preserves the original notes verbatim under a **Raw notes** archive heading so nothing is lost.

| Doc | Change |
|---|---|
| `organizing/tagging` | 8 requirements + a tag-examples table (`>date`, `>today`, `#repeat(until=date)`, `#skill++`, `#24/7`, `@done`) + mover/trigger detail + open questions |
| `organizing/linking` | 5 requirements + a link-examples table + a Jira→local-file bridge detail (Tampermonkey / redirector) |
| `analyzing/analyzing-popularity` | **Expanded** the 3-line stub into a real guide generalized beyond websites to any trend/concept/topic: a signals table + a tool section per signal (Google Trends, keyword tools, Similarweb, GA, community size, backlinks, Amazon rank) + a "How to read it" section |
| `analyzing/leveraging-google-analytics` | Reorganized the published link-dump into **Setting it up / Viewing the data / Debugging tracking** (kept every link) |

## Notes

- `tagging`, `linking`, `analyzing-popularity` stay `draft: true`; `leveraging-google-analytics` is `draft: false` (already published).
- For the em-dash hook, the bold-lead-in list items use a **colon** per the chosen convention.

## Verification

- ✅ `make check` passes — all 439 MDX files compile.
- ✅ Em-dash-clean (the blocking content hook passes on all four).

🤖 Generated with [Claude Code](https://claude.com/claude-code)