### PR TITLE
docs(skills): add serve-locally skill for running the blog on localhost

### DIFF
--- a/.claude/skills/serve-locally/SKILL.md
+++ b/.claude/skills/serve-locally/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: serve-locally
+description: Run the Bytes of Purpose blog locally for development/preview — the dev server (`make start`, :3000, drafts visible), prod-parity preview (`make serve`, the built site, drafts excluded), and the #1 gotcha (a long-running dev server has a STALE route table, so newly added/moved/merged routes 404 until you restart). Use when asked to "deploy/run/serve/preview the blog locally", run the dev server, or when a local page 404s after an edit/merge.
+---
+
+# Serve the Bytes of Purpose blog locally
+
+"Deploy the blog locally" = run it on your machine, NOT ship to production. For
+production deploy (gh-pages) see `deploy-site`; for post-deploy live checks see
+`validate-deployment`.
+
+## The three local modes
+
+| Command | What it runs | Port | Drafts? | Use it to… |
+|---|---|---|---|---|
+| `make start` | Dev server (`docusaurus start`, HMR) | 3000 | **Visible** (dev-only) | Author/preview content, incl. `draft: true` pages |
+| `make start-prod` | Dev server, `NODE_ENV=production` | 3000 | Visible | Catch prod-mode-only dev issues |
+| `make serve` | Serves the **built** static site (`build` first) | 3000 | **Excluded** | Verify the REAL prod build (drafts/transforms as shipped) |
+
+- Override the port: `make start PORT=8080`.
+- `make start` builds Storybook first (so `/storybook/` works) and runs the `prestart`
+  hook (regenerates changelog/ideas/logo data) — so the first boot takes a minute or two.
+- **Drafts render ONLY on the dev server** (`make start` / `make start-prod`), with a
+  "DRAFT PAGE" banner and a `D` sidebar badge. They are excluded from `make build`/
+  `make serve` and from production. So if you're previewing a `draft: true` page, you MUST
+  use `make start` — `make serve` (or curl-ing the prod build) will 404 it correctly.
+
+## 🔴 Gotcha #1 — stale route table → phantom 404 (this is why the skill exists)
+
+A **long-running dev server has an in-memory route table from when it booted.** When you
+add a new doc, change a `slug:`, move a file, or pull/merge a branch that did any of
+those, the running server **does not pick up the new route** — the page renders as a
+404 / "Page Not Found" even though the file exists and `.docusaurus/routes.js` lists it.
+
+**Fix: restart the dev server.** Kill it and re-run `make start`:
+
+```bash
+pkill -f "docusaurus start --port 3000"   # or kill the specific PID
+make start                                 # fresh route table; new/moved routes resolve
+```
+
+After restart, the dev server compiles a route **on first request** (lazy), so the very
+first hit to a page can take a few seconds before content appears — that's normal, not a
+failure.
+
+## 🔴 Gotcha #2 — `curl` gives a FALSE 200 / can't see content; verify in the BROWSER
+
+The Docusaurus **dev server always returns HTTP 200** with a generic SPA shell
+(`<title>Bytes of Purpose</title>`), then renders the real page **client-side via JS**.
+So:
+
+- `curl -o /dev/null -w "%{http_code}"` returns **200 even for a missing/stale route** —
+  it is NOT a validity check on the dev server.
+- `curl ... | grep "<your heading>"` returns **nothing even for a working page**, because
+  the body is JS-rendered, not in the raw HTML.
+
+To confirm a dev page actually renders, **open it in the browser** (or use the
+`claude-in-chrome` tools to screenshot it). The real signals are the tab title becoming
+`<Page Title> | Bytes of Purpose` and the content being on screen. The prod build
+(`make serve`) DOES server-render content into the HTML, so curl/grep works there — but
+that build has no drafts.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| New/moved/merged page 404s locally, but the `.mdx` exists | Stale dev-server route table (Gotcha #1) | Restart `make start` |
+| `draft: true` page 404s | You're on `make serve`/prod build (drafts excluded) | Use `make start` to preview drafts |
+| `curl` says 200 but browser shows 404 | Dev server returns SPA shell at 200 (Gotcha #2) | Trust the browser, not curl |
+| First hit to a page hangs a few seconds | Dev compiles the route lazily on first request | Wait; it caches after |
+| Weird stale render after a big change | Webpack/`.docusaurus` cache | `make clear`, then `make start` |
+| Storybook missing at `/storybook/` | Started without the Storybook prebuild | `make start` (it builds Storybook first) |
+
+## Related
+
+- `deploy-site` — ship to production (gh-pages); the REAL deploy.
+- `validate-deployment` — verify the LIVE site after a prod deploy.
+- `author-blog-post` — MDX pitfalls; `make check` (MDX lint) and `yarn build` as the
+  pre-deploy gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ via the root `Makefile`. Secrets in the gitignored root `.env`.
 | Mobile-experience audit | `audit-mobile-experience` | confirm the site is a TRUE mobile experience from the MOBILE user's perspective (on-the-go, one-handed, touch): tap targets, thumb reach, content parity, no horizontal overflow, ≥16px text, working touch, mobile perf/a11y — not a shrunk desktop; chrome-devtools MCP on the prod build (:4173) + a MANDATORY visual-rubric screenshot pass → prioritized P0/P1/P2 report (report-only) |
 | Desktop-experience audit | `audit-desktop-experience` | sibling of the above from the DESKTOP user's perspective (seated, mouse+keyboard, wide screen, deep reading): readable line length (~≤80ch), content not lost in whitespace on wide/ultrawide, working hover/focus, good structure — the inverse failure modes (over-stretch / under-fill); same prod-build + visual-rubric method → prioritized report (report-only) |
 | Link hygiene | `validate-links` | lint source for bare/long/tracking/generic links (`make validate-links`) |
+| Serve locally | `serve-locally` | run the blog on your machine: `make start` (:3000, drafts visible) vs `make serve` (built site, no drafts); the stale-route-table 404 gotcha (restart fixes it) + curl-false-200 |
 | Publish | `publish-site` | triage draft-readiness → un-draft approved → deploy; wraps `deploy-site` |
 | Deploy | `deploy-site` | secret-scan → build (PostHog env) → gh-pages → verify |
 | Verify live | `validate-deployment` | post-deploy 200/Access/PostHog-beacon checks |


### PR DESCRIPTION
## What

Adds a new **`serve-locally`** skill — the local-dev/preview workflow had no owning skill. Triggered by a real phantom-404 we hit: a page merged to master 404'd on the local dev server because the server had been running since before the merge (stale route table).

## Contents

- **`serve-locally/SKILL.md`** — the three local modes (`make start` :3000 drafts-visible · `make start-prod` · `make serve` built-site no-drafts), and two gotchas as a troubleshooting table:
  - **Stale route table** → new/moved/merged routes 404 until you restart `make start`.
  - **curl false-200** → the dev server returns 200 + SPA shell for any URL and renders client-side; verify in the browser, not via curl.
- **`CLAUDE.md`** — a "Serve locally" row added to the skills map (before Publish/Deploy).

## Notes

- Docs-only / skill-only change; no site content or build behavior affected.
- Cross-links to `deploy-site` (real prod deploy) and `validate-deployment` (live checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)