### PR TITLE
feat(blog-ui): question-set components — SectionBanner, Question + power badges, PowerLegend (v0.4.0)

### DIFF
--- a/.claude/skills/author-blog-post/SKILL.md
+++ b/.claude/skills/author-blog-post/SKILL.md
@@ -16,6 +16,12 @@ deploys cleanly. Pairs with `deploy-site` (ship) and `validate-deployment` (veri
 - `changelog/` — changelog entries (its own blog plugin instance).
 - `src/pages/` — standalone React pages (e.g. `changelog.tsx`).
 
+> **Question-set posts must be `.mdx`, not `.md`.** Any post tagged `question-set`
+> (the "What I Ask Myself: …" series) uses `<SectionBanner>` and `<Question>` JSX
+> components. Docusaurus only evaluates JSX in `.mdx` files — a `.md` file ignores
+> JSX silently or errors. Rename `YYYY-MM-DD-slug.md` → `YYYY-MM-DD-slug.mdx`
+> before adding these components.
+
 ## MDX pitfalls that FAIL the build (learned the hard way)
 
 Docusaurus 3 parses `.md`/`.mdx` as MDX. These break the build during static

--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -197,6 +197,106 @@ specific commit/line range in a sibling repo as proof. Validated by `validate-fo
 footnote without the Evidence component; `import-co-design` produces those. See an existing
 post that uses Evidence (e.g. the image-to-DSL Thoughts post) for the exact syntax.
 
+### SectionBanner (question-set section rationale)
+
+WHAT: a left-accent callout placed immediately under an H2 heading, explaining *why the
+questions in that section matter*. It renders as italic secondary-colored text with a
+3px primary-color left bar and a subtle surface background — quieter than an admonition,
+more like a narrator aside. WHEN: any post in the `question-set` tag class ("What I Ask
+Myself: …" series), or any post where H2 sections contain clustered questions that each
+need a one-sentence rationale. NOT for general docs or posts without clustered H2 sections.
+
+```mdx
+## Core purpose
+
+<SectionBanner why="These are the hardest questions to answer and the most important to keep asking. Most people live their whole lives without a clear answer -- and that gap shows up as restlessness, drift, and doing things for the wrong reasons." />
+
+<Question ...>…</Question>
+```
+
+- `why` is a 1-2 sentence rationale. No em-dashes (blocking hook). Write honestly, not generically.
+- Registered in `MDXComponents.tsx` — no import needed in `.mdx` blog posts.
+- The file must be `.mdx` (not `.md`) to use JSX components.
+
+### Question (introspective question card + detail modal + badges)
+
+WHAT: replaces a plain bullet-list question with a clickable card carrying glanceable
+**badges** (power icons + priority/frequency/depth pills). Clicking opens an app-wide
+modal showing the badges (labeled) plus per-question metadata: why it matters, how often
+to ask it, when to ask it, how often to record answers. Only rows/badges where the prop
+is set are rendered. WHEN: any `question-set` post where per-question metadata is
+available. NOT for questions in general docs — only introspective/journaling posts.
+
+```mdx
+<Question
+  power={['fire', 'anvil']}
+  priority="core"
+  frequency="Yearly"
+  depth="deep"
+  why="Without a clear answer, every decision defaults to what feels comfortable, not what's deepest."
+  howOften="Once per year, and any time you feel like you're going through the motions"
+  when="During quiet periods of reflection, journaling sessions, or spiritual retreats"
+  record="Write a paragraph-length answer; revisit it annually to see how your answer has shifted">
+  What is the purpose of your life?
+</Question>
+```
+
+- `children` = the question text (plain string in the card + modal heading).
+- **Badge props (all optional):**
+  - `power` — the "power of a question" charge(s). One value or an array. The taxonomy
+    (a forge metaphor, rendered with `react-icons/gi` SVG glyphs, theme-aware):
+    `'spark'` (GiLightningArc — a jolt that wakes you up),
+    `'fire'` (GiFlame — a burn that confronts you),
+    `'chisel'` (GiChisel — carves away what isn't you),
+    `'anvil'` (GiAnvil — reshapes who you become). Omit `power` for a calm/no-icon
+    question. A question may carry MULTIPLE (e.g. `power={['fire','anvil']}`).
+  - `priority` — `'core' | 'high' | 'medium' | 'low'` (colored pill; core/high stand out).
+  - `frequency` — short cadence label for the badge (e.g. `"Yearly"`, `"Monthly"`,
+    `"In hard stretches"`). The full sentence still goes in `howOften`.
+  - `depth` — `'quick' | 'moderate' | 'deep'` (how much reflection it demands).
+- All detail props (`why`, `howOften`, `when`, `record`) are optional; the modal renders
+  only the rows with values. A card opens the modal if it has ANY badge or detail.
+- Modal is pub/sub via `CustomEvent('bop:question-modal')`. The `QuestionModalHost` is
+  mounted once in `src/theme/Root.tsx` — already wired; don't add it again.
+- **MDX children extraction**: MDX wraps even plain-text children in React elements.
+  The component handles this with a `nodeToText()` helper — write the question as plain
+  text (no nested JSX) and it will extract cleanly.
+- Registered in `MDXComponents.tsx` — no import needed in `.mdx` blog posts.
+- The file must be `.mdx` (not `.md`).
+
+### PowerLegend (the canonical power-taxonomy legend)
+
+WHAT: renders the "power of a question" legend (spark/fire/chisel/anvil + calm) from the
+SAME `POWER_META` source the card badges use, so the reader-facing legend can never drift
+from the icons on the cards. WHEN: only in the **"What I Ask Myself" keystone post**
+(`blog/2026-01-24-what-i-ask-myself.mdx`) — that post is the single legend the whole
+series shares. Drop it in with no props:
+
+```mdx
+<PowerLegend />
+```
+
+- Do NOT hand-author the legend as a markdown table with approximate emoji — emoji render
+  per-OS and won't match the `react-icons` glyphs on the cards. Always use `<PowerLegend>`.
+- **LOCKSTEP RULE — taxonomy + legend post move together.** The `POWER_META` object in
+  `packages/blog-ui/src/components/Question/index.tsx` is the source of truth for the
+  power taxonomy. `<PowerLegend>` renders straight from it, so the *icons + glosses* stay
+  in sync automatically. BUT the keystone post also has **prose** describing the taxonomy
+  (the intro to the legend, the "a question can carry more than one" example). Whenever you
+  change the taxonomy (add/rename/recolor a power, change a gloss), update that post's prose
+  in the SAME change so the narrative doesn't drift from the icons. The component doc-comment
+  and this skill both point at that post as the canonical legend.
+
+### react-icons in blog-ui (bundling gotcha)
+
+The Question badges use `react-icons/gi`. `react-icons` is a **regular dependency** of
+`blog-ui` and tsup **bundles** it into `dist` (via `noExternal: ['react-icons']` in
+`tsup.config.ts`), tree-shaken to just the icons imported. This is REQUIRED: the blog
+consumes `blog-ui` via a `file:` ref and does NOT install react-icons, so if it were left
+external the runtime import resolves to nothing and Question crashes ("Element type is
+invalid"). If you add an icon from a new react-icons subpath, it's already covered by the
+`noExternal` glob — just rebuild + re-copy dist (see the build/copy workflow below).
+
 ### Timeline / Card / Tabs
 
 - `Timeline` + `TimelineItem` — sequenced events (retrospectives, phases).
@@ -238,6 +338,28 @@ post that uses Evidence (e.g. the image-to-DSL Thoughts post) for the exact synt
 
 ## Learnings log (newest first)
 
+- 2026-06-24 (later) — Added the **badge system** to `Question` (`power`/`priority`/
+  `frequency`/`depth`) + the `PowerLegend` component. The "power of a question" taxonomy is a
+  forge metaphor rendered with `react-icons/gi` SVG glyphs (spark=GiLightningArc,
+  fire=GiFlame, chisel=GiChisel, anvil=GiAnvil), `power` accepts a single value OR an array.
+  Two load-bearing gotchas: (1) `react-icons` must be BUNDLED into blog-ui's dist
+  (`noExternal: ['react-icons']` in tsup.config.ts) — the blog consumes via `file:` and
+  doesn't install it, so leaving it external crashes Question at runtime. Verify after build:
+  `grep -E 'from .react-icons' dist/index.js` should return NOTHING. (2) The reader-facing
+  legend is the `<PowerLegend>` component (renders from the same `POWER_META` source as the
+  cards) embedded in the "What I Ask Myself" keystone post — NEVER a hand-authored emoji table
+  (emoji render per-OS and won't match the SVG glyphs). Taxonomy changes + that post's prose
+  move in lockstep. Also created two companion posts: the keystone `what-i-ask-myself`
+  (carries the legend) and `how-i-ask-others-questions` (outward-facing prose).
+- 2026-06-24 — Added `SectionBanner` and `Question` catalog entries for the `question-set`
+  post class ("What I Ask Myself: …" series). Key gotcha: MDX wraps plain-text children in
+  React elements even for bare strings, so `typeof children === 'string'` is false; use the
+  `nodeToText()` recursive helper (already in `Question/index.tsx`) to extract the plain
+  question string for the modal. Yarn 1 `file:` protocol copies the package at install time
+  (not a symlink) -- after any `packages/blog-ui` rebuild, manually `cp -r packages/blog-ui/dist/
+  bytesofpurpose-blog/node_modules/@omars-lab/blog-ui/dist/` + clear webpack cache
+  (`rm -rf bytesofpurpose-blog/node_modules/.cache/webpack/`) + restart dev server from the
+  blog CWD.
 - 2026-06-22 — Created. Carved the component catalog out of import-co-design so enrichment is
   a reusable concern. Animated-diagram nuances (two-tier dashes+dot, `%% animate` directive,
   no hardcoded colors) are the most load-bearing entries; full reader writeup is the

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -19,6 +19,9 @@ import {
   Walkthrough,
   Assumption,
   Gif,
+  SectionBanner,
+  Question,
+  PowerLegend,
 } from '@omars-lab/blog-ui';
 import '@omars-lab/blog-ui/style.css';
 
@@ -51,4 +54,14 @@ export default {
   // Animated-media figure: a framed, captioned, accessible <Gif> for a recorded/synthesized
   // clip (terminal session, screen capture) — lazy, reduced-motion poster, play/pause toggle.
   Gif,
+  // Question-set post components — used in "What I Ask Myself" posts.
+  // SectionBanner: a quiet left-accent callout under each H2 explaining why the section matters.
+  SectionBanner,
+  // Question: a clickable card for an introspective question; click opens a modal with
+  // metadata (why/howOften/when/record). QuestionModalHost must be mounted in Root.tsx.
+  Question,
+  // PowerLegend: the canonical "power of a question" legend (spark/fire/chisel/anvil),
+  // rendered from the same source as the card badges so it can't drift. Used in the
+  // "What I Ask Myself" keystone post.
+  PowerLegend,
 };

--- a/bytesofpurpose-blog/src/theme/Root.tsx
+++ b/bytesofpurpose-blog/src/theme/Root.tsx
@@ -3,6 +3,7 @@ import DebugMenu from '@site/src/components/DebugMenu';
 import ToastHost from '@site/src/components/Toast';
 import SignInModalHost from '@site/src/components/SignInModal';
 import {AuthProvider} from '@site/src/lib/auth';
+import {QuestionModalHost} from '@omars-lab/blog-ui';
 
 // Swizzled @theme/Root: wraps the entire app (above the router, persists across
 // navigation). The default Root just renders its children; we additionally:
@@ -19,6 +20,7 @@ export default function Root({children}: {children: React.ReactNode}): React.JSX
       <DebugMenu />
       <ToastHost />
       <SignInModalHost />
+      <QuestionModalHost />
     </AuthProvider>
   );
 }

--- a/packages/blog-ui/package.json
+++ b/packages/blog-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@omars-lab/blog-ui",
-  "version": "0.3.0",
-  "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, Gif animated-media figure, DiagramWithFootnotes, and Assumption highlight.",
+  "version": "0.4.0",
+  "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, Gif animated-media figure, DiagramWithFootnotes, Assumption highlight, and the question-set set (SectionBanner, Question card+modal with power badges, PowerLegend).",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -19,8 +19,12 @@
     },
     "./style.css": "./dist/index.css"
   },
-  "files": ["dist"],
-  "sideEffects": ["**/*.css"],
+  "files": [
+    "dist"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -33,7 +37,8 @@
     "react-dom": ">=18"
   },
   "dependencies": {
-    "clsx": "^2.1.1"
+    "clsx": "^2.1.1",
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
     "@types/react": "^18 || ^19",

--- a/packages/blog-ui/src/components/Question/index.tsx
+++ b/packages/blog-ui/src/components/Question/index.tsx
@@ -1,0 +1,379 @@
+import React, {CSSProperties, ReactNode, useCallback, useEffect, useState} from 'react';
+import clsx from 'clsx';
+import {GiLightningArc, GiFlame, GiChisel, GiAnvil} from 'react-icons/gi';
+import type {IconType} from 'react-icons';
+import styles from './styles.module.css';
+
+/**
+ * Question — a clickable card for a single introspective question in a "What I Ask Myself"
+ * question-set post. The question text is the children. Optional props carry the per-question
+ * metadata (why, howOften, when, record) that appears in a modal when the card is clicked,
+ * plus glanceable BADGES (power, priority, frequency, depth) shown on the card AND modal.
+ *
+ * The modal is app-wide (single host, pub/sub) so it renders above everything. Mount
+ * <QuestionModalHost /> once in Root.tsx (or equivalent) alongside <SignInModalHost />.
+ *
+ *   <Question
+ *     power={['fire', 'anvil']} priority="core" frequency="Yearly" depth="deep"
+ *     why="This anchors every other question to an actual foundation."
+ *     howOften="Once per quarter or when you feel directionless"
+ *     when="During annual reviews, major life transitions"
+ *     record="Write a paragraph each time; compare across quarters">
+ *     What is the purpose of your life?
+ *   </Question>
+ *
+ * POWER TAXONOMY — the "power of a question" is the kind of CHARGE it carries (a forge
+ * metaphor: how the question works on you). A calm everyday question gets no icon. A
+ * question can carry MULTIPLE powers (pass an array); they render left-to-right.
+ *
+ *   - 'spark'  (GiLightningArc): a JOLT. Wakes you up, cuts through, sudden clarity.
+ *   - 'fire'   (GiFlame):        a BURN. Confronts you, uncomfortable, demands change.
+ *   - 'chisel' (GiChisel):       CARVES AWAY what isn't you; reveals who you already are.
+ *   - 'anvil'  (GiAnvil):        RESHAPES you over repeated blows; forges who you become.
+ *   - (none):                    a calm, everyday question. No icon.
+ *
+ * The canonical reader-facing legend for these lives in the "What I Ask Myself" keystone
+ * post. If you change this taxonomy, update that post's legend in the SAME change so the
+ * two never drift (see the upgrade-post skill).
+ */
+export type QuestionPower = 'spark' | 'fire' | 'chisel' | 'anvil';
+export type QuestionPriority = 'core' | 'high' | 'medium' | 'low';
+export type QuestionDepth = 'quick' | 'moderate' | 'deep';
+
+/** A single power may be passed as a bare string; multiple as an array. */
+export type QuestionPowerProp = QuestionPower | QuestionPower[];
+
+export interface QuestionProps {
+  children: ReactNode;
+  why?: string;
+  howOften?: string;
+  when?: string;
+  record?: string;
+  /** Charge(s) the question carries. Omit for a calm/no-icon question. See taxonomy above. */
+  power?: QuestionPowerProp;
+  /** Importance tier. Renders as a colored pill. */
+  priority?: QuestionPriority;
+  /** Short cadence label for the badge (e.g. "Yearly", "Daily"). The full sentence goes in howOften. */
+  frequency?: string;
+  /** How much reflection it demands. */
+  depth?: QuestionDepth;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export interface QuestionDetail {
+  text: string;
+  why?: string;
+  howOften?: string;
+  when?: string;
+  record?: string;
+  /** Normalized to an array before dispatch so the modal renders consistently. */
+  power?: QuestionPower[];
+  priority?: QuestionPriority;
+  frequency?: string;
+  depth?: QuestionDepth;
+}
+
+/**
+ * Power → {Icon, name, label} for the charge badge. Icon inherits currentColor (theme-aware).
+ * `name` is the title-case noun (Spark/Fire/Chisel/Anvil); `label` is the short gloss shown
+ * on the modal badge and in the legend. This object is the SINGLE SOURCE OF TRUTH for the
+ * taxonomy — the <PowerLegend> component renders straight from it, so the reader-facing legend
+ * can never drift from what the cards actually show.
+ */
+const POWER_META: Record<QuestionPower, {Icon: IconType; name: string; label: string}> = {
+  spark: {Icon: GiLightningArc, name: 'Spark', label: 'A jolt that wakes you up'},
+  fire: {Icon: GiFlame, name: 'Fire', label: 'A burn that confronts you'},
+  chisel: {Icon: GiChisel, name: 'Chisel', label: "Carves away what isn't you"},
+  anvil: {Icon: GiAnvil, name: 'Anvil', label: 'Reshapes who you become'},
+};
+
+/** Stable render order regardless of the order props are passed in. */
+const POWER_ORDER: QuestionPower[] = ['spark', 'fire', 'chisel', 'anvil'];
+
+const PRIORITY_META: Record<QuestionPriority, string> = {
+  core: 'Core',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+const DEPTH_META: Record<QuestionDepth, string> = {
+  quick: 'Quick',
+  moderate: 'Moderate',
+  deep: 'Deep',
+};
+
+function normalizePower(power: QuestionPowerProp | undefined): QuestionPower[] {
+  if (!power) return [];
+  const arr = Array.isArray(power) ? power : [power];
+  // de-dupe + apply a stable order so cards read consistently
+  return POWER_ORDER.filter((p) => arr.includes(p));
+}
+
+export const QUESTION_MODAL_EVENT = 'bop:question-modal';
+
+export function openQuestionModal(detail: QuestionDetail): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(QUESTION_MODAL_EVENT, {detail}));
+}
+
+function nodeToText(node: ReactNode): string {
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(nodeToText).join('');
+  if (React.isValidElement(node)) {
+    const el = node as React.ReactElement<{children?: ReactNode}>;
+    return nodeToText(el.props.children);
+  }
+  return '';
+}
+
+/* ── Badges (shared by card + modal) ─────────────────────────────────── */
+
+interface BadgesProps {
+  power: QuestionPower[];
+  priority?: QuestionPriority;
+  frequency?: string;
+  depth?: QuestionDepth;
+  /** 'card' is compact (icons only, terse pills); 'modal' shows labels. */
+  variant: 'card' | 'modal';
+}
+
+function QuestionBadges({power, priority, frequency, depth, variant}: BadgesProps): React.JSX.Element | null {
+  const hasAny = power.length > 0 || priority || frequency || depth;
+  if (!hasAny) return null;
+
+  return (
+    <span className={clsx(styles.badges, variant === 'modal' && styles.badgesModal)}>
+      {power.map((p) => {
+        const {Icon, label} = POWER_META[p];
+        return (
+          <span
+            key={p}
+            className={clsx(styles.powerBadge, styles[`power_${p}`])}
+            title={label}
+            aria-label={label}>
+            <Icon className={styles.powerIcon} aria-hidden="true" />
+            {variant === 'modal' && <span className={styles.powerLabel}>{label}</span>}
+          </span>
+        );
+      })}
+      {priority && (
+        <span
+          className={clsx(styles.pill, styles[`priority_${priority}`])}
+          title={`Priority: ${PRIORITY_META[priority]}`}>
+          {PRIORITY_META[priority]}
+        </span>
+      )}
+      {frequency && (
+        <span className={clsx(styles.pill, styles.pillFrequency)} title={`How often: ${frequency}`}>
+          {frequency}
+        </span>
+      )}
+      {depth && (
+        <span className={clsx(styles.pill, styles.pillDepth)} title={`Depth: ${DEPTH_META[depth]}`}>
+          {DEPTH_META[depth]}
+        </span>
+      )}
+    </span>
+  );
+}
+
+const Question: React.FC<QuestionProps> = ({
+  children,
+  why,
+  howOften,
+  when,
+  record,
+  power,
+  priority,
+  frequency,
+  depth,
+  className,
+  style,
+}) => {
+  const powers = normalizePower(power);
+  const hasBadges = powers.length > 0 || !!priority || !!frequency || !!depth;
+  const hasDetail = !!(why || howOften || when || record) || hasBadges;
+
+  const handleClick = useCallback(() => {
+    if (!hasDetail) return;
+    openQuestionModal({
+      text: nodeToText(children),
+      why,
+      howOften,
+      when,
+      record,
+      power: powers,
+      priority,
+      frequency,
+      depth,
+    });
+  }, [children, why, howOften, when, record, priority, frequency, depth, powers, hasDetail]);
+
+  const handleKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
+
+  return (
+    <button
+      type="button"
+      className={clsx(styles.card, className)}
+      style={style}
+      onClick={hasDetail ? handleClick : undefined}
+      onKeyDown={hasDetail ? handleKey : undefined}
+      aria-haspopup={hasDetail ? 'dialog' : undefined}>
+      <span className={styles.text}>{children}</span>
+      <span className={styles.cardRight}>
+        <QuestionBadges
+          power={powers}
+          priority={priority}
+          frequency={frequency}
+          depth={depth}
+          variant="card"
+        />
+        {hasDetail && (
+          <span className={styles.expandIcon} aria-hidden="true">
+            &#8250;
+          </span>
+        )}
+      </span>
+    </button>
+  );
+};
+
+export default Question;
+
+/* ── PowerLegend (canonical reader-facing legend) ────────────────────── */
+
+export interface PowerLegendProps {
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * PowerLegend — renders the canonical "power of a question" legend straight from POWER_META,
+ * using the SAME icons the cards show. Drop it into the "What I Ask Myself" keystone post so
+ * the reader-facing legend is generated from the source of truth and can never drift from the
+ * badges. (Do NOT hand-author the legend as a markdown table with approximate emoji — it will
+ * fall out of sync with the real icons.)
+ */
+export function PowerLegend({className, style}: PowerLegendProps): React.JSX.Element {
+  return (
+    <dl className={clsx(styles.legend, className)} style={style}>
+      {POWER_ORDER.map((p) => {
+        const {Icon, name, label} = POWER_META[p];
+        return (
+          <div key={p} className={styles.legendRow}>
+            <dt className={clsx(styles.legendIcon, styles[`power_${p}`])}>
+              <Icon className={styles.powerIcon} aria-hidden="true" />
+            </dt>
+            <dd className={styles.legendText}>
+              <span className={styles.legendName}>{name}</span>
+              <span className={styles.legendGloss}>{label}</span>
+            </dd>
+          </div>
+        );
+      })}
+      <div className={styles.legendRow}>
+        <dt className={clsx(styles.legendIcon, styles.legendNone)} aria-hidden="true">
+          ·
+        </dt>
+        <dd className={styles.legendText}>
+          <span className={styles.legendName}>Calm</span>
+          <span className={styles.legendGloss}>An everyday question. No charge, still worth asking.</span>
+        </dd>
+      </div>
+    </dl>
+  );
+}
+
+/* ── Modal host (mount once in Root.tsx) ─────────────────────────────── */
+
+interface ModalState {
+  open: boolean;
+  detail: QuestionDetail | null;
+}
+
+function QuestionModalImpl(): React.JSX.Element | null {
+  const [{open, detail}, setState] = useState<ModalState>({open: false, detail: null});
+
+  const close = useCallback(() => setState((s) => ({...s, open: false})), []);
+
+  useEffect(() => {
+    const onOpen = (e: Event) => {
+      const d = (e as CustomEvent<QuestionDetail>).detail;
+      setState({open: true, detail: d});
+    };
+    window.addEventListener(QUESTION_MODAL_EVENT, onOpen as EventListener);
+    return () => window.removeEventListener(QUESTION_MODAL_EVENT, onOpen as EventListener);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  if (!open || !detail) return null;
+
+  const meta: Array<{label: string; value: string | undefined; key: keyof QuestionDetail}> = [
+    {label: 'Why this question matters', value: detail.why, key: 'why'},
+    {label: 'How often to ask', value: detail.howOften, key: 'howOften'},
+    {label: 'When to ask it', value: detail.when, key: 'when'},
+    {label: 'How often to record answers', value: detail.record, key: 'record'},
+  ];
+
+  return (
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Question details"
+      onClick={close}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <button type="button" className={styles.closeBtn} aria-label="Dismiss" onClick={close}>
+          &times;
+        </button>
+        <p className={styles.question}>{detail.text || 'Question'}</p>
+        <QuestionBadges
+          power={detail.power ?? []}
+          priority={detail.priority}
+          frequency={detail.frequency}
+          depth={detail.depth}
+          variant="modal"
+        />
+        <ul className={styles.metaList}>
+          {meta
+            .filter((m) => m.value)
+            .map((m) => (
+              <li key={m.key} className={styles.metaItem}>
+                <span className={styles.metaLabel}>{m.label}</span>
+                <span className={styles.metaValue}>{m.value}</span>
+              </li>
+            ))}
+        </ul>
+        <button type="button" className={styles.dismissBtn} onClick={close}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function QuestionModalHost(): React.JSX.Element | null {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  return <QuestionModalImpl />;
+}

--- a/packages/blog-ui/src/components/Question/styles.module.css
+++ b/packages/blog-ui/src/components/Question/styles.module.css
@@ -1,0 +1,325 @@
+/* Question card + modal for "What I Ask Myself" question-set posts. */
+
+/* ── Card (closed state) ─────────────────────────────────────────────── */
+
+.card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.4rem 0;
+  padding: 0.65rem 0.85rem 0.65rem 1rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  background: var(--ifm-background-surface-color);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+.card:hover {
+  border-color: var(--ifm-color-primary-light);
+  box-shadow: var(--ifm-global-shadow-lw);
+}
+.card:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+.text {
+  flex: 1;
+  font-size: 0.97rem;
+  line-height: 1.5;
+  color: var(--ifm-font-color-base);
+  margin: 0;
+}
+
+.cardRight {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.expandIcon {
+  flex-shrink: 0;
+  color: var(--ifm-color-primary);
+  font-size: 1rem;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+.card:hover .expandIcon {
+  opacity: 1;
+}
+
+/* ── Badges (card + modal) ───────────────────────────────────────────── */
+
+.badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+/* On the modal, badges sit on their own row under the question with breathing room. */
+.badgesModal {
+  margin: 0 0 1.1rem;
+  gap: 0.5rem;
+}
+
+/* Power icon badges — the GiLightningArc/GiFlame/GiChisel/GiAnvil glyphs. */
+.powerBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  line-height: 1;
+}
+.powerIcon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex-shrink: 0;
+}
+/* Each power gets its own hue so the charge reads at a glance. */
+.power_spark .powerIcon {
+  color: #d9a300; /* amber-gold — electric jolt */
+}
+.power_fire .powerIcon {
+  color: #e2562a; /* ember orange — burn */
+}
+.power_chisel .powerIcon {
+  color: var(--ifm-color-emphasis-700); /* steel — carves away */
+}
+.power_anvil .powerIcon {
+  color: var(--ifm-color-primary); /* primary — forges who you become */
+}
+[data-theme='dark'] .power_spark .powerIcon {
+  color: #f3c34d;
+}
+[data-theme='dark'] .power_fire .powerIcon {
+  color: #ff7a4d;
+}
+
+/* On the modal, each power shows its label next to the icon. */
+.badgesModal .powerBadge {
+  padding: 0.2rem 0.55rem 0.2rem 0.45rem;
+  border-radius: 999px;
+  background: var(--ifm-color-emphasis-100);
+  font-size: 0.8rem;
+}
+.powerLabel {
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-800));
+  white-space: nowrap;
+}
+
+/* Generic metadata pills (priority / frequency / depth). */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-800);
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+.badgesModal .pill {
+  font-size: 0.78rem;
+  padding: 0.2rem 0.6rem;
+}
+
+/* Priority pill colors — core/high stand out, medium/low stay quiet. */
+.priority_core {
+  background: color-mix(in srgb, var(--ifm-color-primary) 16%, transparent);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
+  color: var(--ifm-color-primary-darker, var(--ifm-color-primary));
+}
+.priority_high {
+  background: color-mix(in srgb, #e2562a 14%, transparent);
+  border-color: color-mix(in srgb, #e2562a 38%, transparent);
+  color: #c2441e;
+}
+[data-theme='dark'] .priority_high {
+  color: #ff8a5f;
+}
+.priority_medium {
+  /* inherits the neutral .pill look */
+}
+.priority_low {
+  opacity: 0.75;
+}
+
+.pillFrequency {
+  font-weight: 500;
+}
+.pillDepth {
+  font-style: italic;
+  font-weight: 500;
+}
+
+/* ── PowerLegend ─────────────────────────────────────────────────────── */
+
+.legend {
+  margin: 1.25rem 0;
+  padding: 0.5rem 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.legendRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  margin: 0;
+}
+.legendIcon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 8px;
+  background: var(--ifm-color-emphasis-100);
+  margin: 0;
+}
+.legendIcon .powerIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+.legendNone {
+  color: var(--ifm-color-emphasis-500);
+  font-size: 1.3rem;
+  line-height: 1;
+}
+.legendText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  margin: 0;
+}
+.legendName {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ifm-heading-color);
+}
+.legendGloss {
+  font-size: 0.9rem;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-700));
+  line-height: 1.4;
+}
+
+/* ── Modal overlay ───────────────────────────────────────────────────── */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.5);
+  animation: fadeIn 0.15s ease;
+}
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal {
+  position: relative;
+  width: 100%;
+  max-width: 30rem;
+  padding: 2rem 1.75rem 1.5rem;
+  border-radius: 0.9rem;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  border-top: 4px solid var(--ifm-color-primary);
+  animation: popIn 0.18s ease;
+}
+@keyframes popIn {
+  from {
+    transform: translateY(8px) scale(0.98);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+.closeBtn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.6rem;
+  border: none;
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.2rem;
+}
+.closeBtn:hover {
+  color: var(--ifm-color-emphasis-900);
+}
+
+.question {
+  margin: 0 0 1.25rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--ifm-heading-color);
+}
+
+.metaList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.metaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.metaLabel {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-primary);
+}
+
+.metaValue {
+  font-size: 0.92rem;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-700));
+  line-height: 1.5;
+}
+
+.dismissBtn {
+  display: block;
+  width: 100%;
+  margin-top: 1.25rem;
+  padding: 0.5rem;
+  border: none;
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-align: center;
+}
+.dismissBtn:hover {
+  color: var(--ifm-color-emphasis-900);
+  text-decoration: underline;
+}

--- a/packages/blog-ui/src/components/SectionBanner/index.tsx
+++ b/packages/blog-ui/src/components/SectionBanner/index.tsx
@@ -1,0 +1,29 @@
+import React, {CSSProperties} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * SectionBanner — a quiet left-accent callout placed under an H2 heading to explain
+ * why that cluster of questions matters. Used in "What I Ask Myself" question-set posts.
+ *
+ * Softer than a Docusaurus admonition (no colored background, no title chip) — it reads
+ * as a narrator aside, not a warning or tip. The `why` prop is a 1-2 sentence rationale
+ * written by the author for that specific section.
+ *
+ *   ## Core purpose
+ *   <SectionBanner why="Purpose questions force you to articulate the why beneath your daily choices." />
+ *   <Question ...>What is the purpose of your life?</Question>
+ */
+export interface SectionBannerProps {
+  why: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const SectionBanner: React.FC<SectionBannerProps> = ({why, className, style}) => (
+  <div className={clsx(styles.banner, className)} style={style}>
+    <p className={styles.text}>{why}</p>
+  </div>
+);
+
+export default SectionBanner;

--- a/packages/blog-ui/src/components/SectionBanner/styles.module.css
+++ b/packages/blog-ui/src/components/SectionBanner/styles.module.css
@@ -1,0 +1,22 @@
+/* SectionBanner — a quiet narrator-aside under a section heading explaining why this
+   cluster of questions matters. Softer than an admonition; just a left-accent callout. */
+
+.banner {
+  margin: 0.75rem 0 1.25rem;
+  padding: 0.65rem 1rem 0.65rem 1.1rem;
+  border-left: 3px solid var(--ifm-color-primary);
+  border-radius: 0 4px 4px 0;
+  background: var(--ifm-background-surface-color);
+}
+
+.text {
+  margin: 0;
+  font-style: italic;
+  color: var(--ifm-color-content-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+[data-theme='dark'] .banner {
+  background: color-mix(in srgb, var(--ifm-background-surface-color) 60%, transparent);
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -20,3 +20,22 @@ export type {DiagramWithFootnotesProps} from './components/DiagramWithFootnotes'
 
 export {default as Assumption} from './components/Assumption';
 export type {AssumptionProps} from './components/Assumption';
+
+export {default as SectionBanner} from './components/SectionBanner';
+export type {SectionBannerProps} from './components/SectionBanner';
+
+export {
+  default as Question,
+  QuestionModalHost,
+  PowerLegend,
+  openQuestionModal,
+} from './components/Question';
+export type {
+  QuestionProps,
+  QuestionDetail,
+  QuestionPower,
+  QuestionPowerProp,
+  QuestionPriority,
+  QuestionDepth,
+  PowerLegendProps,
+} from './components/Question';

--- a/packages/blog-ui/tsup.config.ts
+++ b/packages/blog-ui/tsup.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   sourcemap: false, // no .map files in the published tarball — consumers don't need them
   clean: true,
   external: ['react', 'react-dom'],
+  // Bundle react-icons INTO the dist (tree-shaken to just the icons we import). The blog
+  // consumes this package via a `file:` ref and does NOT install react-icons, so it must
+  // ship inside our bundle — otherwise the runtime import resolves to nothing and the
+  // Question component crashes ("Element type is invalid").
+  noExternal: ['react-icons'],
   injectStyle: false, // emit a separate dist/index.css instead of injecting at runtime
   // tsup uses esbuild's CSS-modules support: *.module.css → scoped class names + one css file.
   loader: {'.css': 'local-css'},

--- a/packages/blog-ui/yarn.lock
+++ b/packages/blog-ui/yarn.lock
@@ -506,6 +506,11 @@ react-dom@^19.0.0:
   dependencies:
     scheduler "^0.27.0"
 
+react-icons@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.6.0.tgz#27bcc4acbc836e762548d76041cf9b9fef4e3837"
+  integrity sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==
+
 react@^19.0.0:
   version "19.2.7"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.7.tgz#1f47a1bfc06f8ec885752c6f4af14369a9f8260b"


### PR DESCRIPTION
## What

Adds the **component layer** for the "What I Ask Myself" question-set post class. (Content posts that consume these ship in a follow-up PR.)

- **`SectionBanner`** — a quiet left-accent callout under each H2 explaining why that cluster of questions matters.
- **`Question`** — a clickable card replacing a bullet-list question. Carries glanceable **badges** and opens an app-wide modal (pub/sub via `CustomEvent`, host mounted once in `Root.tsx`) with full per-question metadata (why / how often / when / record).
- **`PowerLegend`** — renders the canonical legend straight from the same `POWER_META` source the cards use, so the reader-facing legend can never drift from the badges.

### The "power of a question" taxonomy

A forge metaphor, rendered with `react-icons/gi` SVG glyphs (theme-aware, OS-independent). `power` accepts one value or an **array**; a calm question gets no icon.

| Power | Icon | Meaning |
|---|---|---|
| `spark` | GiLightningArc | A jolt that wakes you up |
| `fire` | GiFlame | A burn that confronts you |
| `chisel` | GiChisel | Carves away what isn't you |
| `anvil` | GiAnvil | Reshapes who you become |
| (none) | — | A calm everyday question |

Plus `priority` (core/high/medium/low), `frequency` (short cadence label), `depth` (quick/moderate/deep) — all shown only when set, on the card **and** in the modal.

## Key gotcha

`react-icons` is **bundled into dist** (`noExternal` in `tsup.config.ts`). The blog consumes `blog-ui` via a `file:` ref and does **not** install react-icons, so leaving it external crashes `Question` at runtime ("Element type is invalid"). Verified: `grep 'from .react-icons' dist/index.js` returns nothing.

## Verification

- `yarn build` in `packages/blog-ui` ✓ (38 KB dist, icons tree-shaken + bundled)
- Production `yarn build` of the blog ✓ — `[SUCCESS] Generated static files` (server/SSR compile passes, the gate that catches the "Element type is invalid" crash)
- Visual check in dev (`:3000`): cards render colored power icons, modal opens with labeled badges + metadata, `<PowerLegend>` renders the full legend with the same glyphs. Light + dark mode hold.

## Skills updated

- `upgrade-post` — badge catalog, power taxonomy, `PowerLegend` entry, react-icons bundling gotcha, **lockstep rule** (taxonomy + keystone-post legend move together), learnings log.
- `author-blog-post` — `.mdx` requirement for question-set posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)