### PR TITLE
fix(thoughts): re-date question-set posts to their true 2017 git origin

### DIFF
--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-aligning-actions-with-ambitions.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-aligning-actions-with-ambitions.md
@@ -4,7 +4,7 @@ title: "Questions for Aligning Your Actions With Your Ambitions"
 description: "The questions I return to when I want to check whether my actions match my ambitions, and decide what to stop, start, or do more of."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-challenging-your-own-assumptions.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-challenging-your-own-assumptions.md
@@ -4,7 +4,7 @@ title: "Questions for Challenging Your Own Assumptions"
 description: "A set of prompts for interrogating your own thinking: surfacing assumptions, hunting for discomforting evidence, and steelmanning the other side."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-discovering-your-interests.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-discovering-your-interests.md
@@ -4,7 +4,7 @@ title: "Questions for Discovering Your Interests"
 description: "You can't list your interests on command. But you can infer them from what you do. A taxonomy of prompts for reverse-engineering what actually intrigues you."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-26
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-facing-your-fears.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-facing-your-fears.md
@@ -4,7 +4,7 @@ title: "Questions for Facing Your Fears"
 description: "A curated set of questions for naming what you're afraid of, examining what threatens you, and building the courage to act anyway."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-26
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-finding-your-purpose.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-finding-your-purpose.mdx
@@ -4,7 +4,7 @@ title: "What I Ask Myself: To Find Purpose"
 description: "The questions I return to when I want to understand why I exist, what gives life meaning, and how I want to be remembered."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-growing-yourself.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-growing-yourself.md
@@ -4,7 +4,7 @@ title: "Questions for Growing Yourself"
 description: "A taxonomy of the questions I return to when I want to check whether I'm actually growing, investing in myself, and reaching my potential."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-27
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-improving-how-you-operate.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-improving-how-you-operate.md
@@ -4,7 +4,7 @@ title: "Questions for Improving How You Operate"
 description: "A set of prompts for examining the how of your life: your processes, problem-solving techniques, and the systems you operate by."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-what-you-want.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-what-you-want.md
@@ -4,7 +4,7 @@ title: "Questions for Knowing What You Want"
 description: "A curated set of questions for getting honest about what you want, what you're chasing, and what you'd regret not pursuing."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-who-you-are.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-who-you-are.md
@@ -4,7 +4,7 @@ title: "Questions for Knowing Who You Are"
 description: "Why do others often know us better than we know ourselves? A taxonomy of prompts for examining your character, values, beliefs, and the forces that shape your identity."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-making-better-decisions.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-making-better-decisions.md
@@ -4,7 +4,7 @@ title: "Questions for Making Better Decisions"
 description: "A taxonomy of the questions I use to look back on decisions, spot my patterns, learn from outcomes, and make peace with the ones I can't undo."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-28
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-managing-your-emotions.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-managing-your-emotions.md
@@ -4,7 +4,7 @@ title: "Questions for Managing Your Emotions"
 description: "Introspective questions for regulating your emotional state — which feelings to fuel, which to overcome, and how to stay optimistic."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-27
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-measuring-your-progress.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-measuring-your-progress.md
@@ -4,7 +4,7 @@ title: "Questions for Measuring Your Progress"
 description: "The questions I return to when I want to know whether I'm actually winning, reaching my potential, and closing the gap to my dreams."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-what-youre-learning.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-what-youre-learning.md
@@ -4,7 +4,7 @@ title: "Questions for Reflecting on What You're Learning"
 description: "A set of prompts for checking whether you're learning the right things, whether it aligns with your purpose, and where you still need to grow."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-priorities.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-priorities.md
@@ -4,7 +4,7 @@ title: "Questions for Reflecting on Your Priorities"
 description: "The questions I sit with to check whether my time and energy are actually going to what matters most right now."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-26
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-worth.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-worth.md
@@ -4,7 +4,7 @@ title: "Questions for Reflecting on Your Worth"
 description: "A taxonomy of the questions I return to when I want to take honest stock of my value, my skills, and the impact I have on the people around me."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-understanding-your-inaction.md
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-understanding-your-inaction.md
@@ -4,7 +4,7 @@ title: "Questions for Understanding Your Inaction"
 description: "The questions I sit with when I want to understand why I haven't started something, what's holding me back, and how to break the loop."
 authors: [oeid]
 tags: [self-reflection, question-set]
-date: 2026-01-25
+date: 2017-02-11
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-capturing-what-you-could-do.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-capturing-what-you-could-do.md
@@ -4,7 +4,7 @@ title: "Questions for Capturing What You Could Do"
 description: "Introspective questions for brainstorming and organizing everything you could do — goals, commitments, challenges, and the things you want to create."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-28
+date: 2017-02-13
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-deciding-what-to-learn.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-deciding-what-to-learn.md
@@ -4,7 +4,7 @@ title: "Questions for Deciding What to Learn"
 description: "Introspective questions for choosing what to learn next, building a curriculum, and managing your learning commitments."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-27
+date: 2017-02-13
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-finding-where-to-improve.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-finding-where-to-improve.md
@@ -4,7 +4,7 @@ title: "Questions for Finding Where to Improve"
 description: "Introspective questions for spotting your gaps and weaknesses, finding growth opportunities, and deciding what to work on next."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-27
+date: 2017-02-13
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-how-you-learn.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-how-you-learn.md
@@ -4,7 +4,7 @@ title: "Questions for How You Learn"
 description: "Introspective questions for understanding and refining your own learning process, style, and methods for seeking knowledge."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-27
+date: 2017-02-13
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-managing-your-tasks.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-managing-your-tasks.md
@@ -4,7 +4,7 @@ title: "Questions for Managing Your Tasks"
 description: "Introspective questions for capturing, tracking, and automating the tasks that make up your work — including dependencies, triggers, and recurring tasks."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-28
+date: 2017-02-13
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-planning-across-horizons.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-planning-across-horizons.md
@@ -4,7 +4,7 @@ title: "Questions for Planning Across Horizons"
 description: "Introspective questions for turning priorities into time-bound plans — from daily and weekly all the way out to a lifetime timeline."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-28
+date: 2017-02-13
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-prioritizing-your-work.md
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-prioritizing-your-work.md
@@ -4,7 +4,7 @@ title: "Questions for Prioritizing Your Work"
 description: "A set of introspective questions for deciding what to work on now — prioritization factors, deprioritizing, and building a roadmap."
 authors: [oeid]
 tags: [productivity, question-set]
-date: 2026-01-28
+date: 2017-02-13
 draft: true
 ---
 


### PR DESCRIPTION
## What

Re-dates the 23 imported question-set posts from the **2026 reorg commit date** to their **true Feb 2017 git origin**.

These posts were dated to 2026 because `git --follow` dead-ends at the Jan-2026 "reorganizing skills" commit — the questions were **reworded** during that reorg, so rename detection can't trace them back to the original notes. But the content genuinely dates to the **Feb 2017 `questions/` notes** (same era as the existing `2017-02-24-the-questions-i-want-to-answer` post).

## How (deterministic, evidence-based)

A new origins-aware dating pipeline in the **notes repo** (committed separately there):
- Each reorganized source skill now declares an **`origins:`** frontmatter list naming the original note(s) its questions came from (even though reworded).
- **`blog-source-date.sh`** reads `origins:` and returns the oldest `--follow` date across the file ∪ its origins.
- **`blog-apply-source-date.sh`** rewrites each post's `date:` + filename prefix from that origin date.

Result:
- **16 introspective posts** (Self Reflector + Self Master) → `2017-02-11`
- **7 planning/learning posts** (Manager + Learner) → `2017-02-13`

## Safety

- **Slugs unchanged** → permalinks/URLs preserved (only the filename date prefix + frontmatter `date:` changed; all 23 are `git mv` renames so history follows).
- Filename date == frontmatter date verified for all 23.
- Dev render confirmed: the purpose post now shows **"February 11, 2017"**.
- All posts remain `draft: true` (dev-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)