### PR TITLE
fix(ci): gitleaks-action GITHUB_TOKEN for PR scans

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,6 +10,12 @@ on:
     branches: ['**']
   pull_request:
 
+# gitleaks-action reads the PR's commits via the API, so the job token needs read access
+# to repo contents + pull requests. (Least-privilege: only what the scan requires.)
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -22,4 +28,8 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml
+          # gitleaks-action v2 REQUIRES GITHUB_TOKEN to scan pull requests (it reads the PR's
+          # commits via the API). Without it the `scan` job fails with "GITHUB_TOKEN is now
+          # required to scan pull requests". The automatically-provided token is sufficient.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # GITLEAKS_LICENSE is only needed for org-account scanning; this is a user repo.


### PR DESCRIPTION
## What

`gitleaks/gitleaks-action@v2` made `GITHUB_TOKEN` **mandatory** for pull-request scans (it now reads the PR's commits via the GitHub API). Without it the `scan` job fails:

> 🛑 GITHUB_TOKEN is now required to scan pull requests.

Seen on [run 28112136936](https://github.com/omars-lab/omars-lab.github.io/actions/runs/28112136936) (PR #52). This affects **every** PR, not just the question-set work.

## Fix

- Pass the auto-provided `GITHUB_TOKEN` to the gitleaks step.
- Add least-privilege `permissions:` (`contents: read`, `pull-requests: read`) so the token can read PR commits.

Push scans (branch pushes) were already working and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)