### PR TITLE
feat(voice): catch the "--" em-dash-hook bypass anti-pattern

### DIFF
--- a/.claude/hooks/em-dash-voice-hook.sh
+++ b/.claude/hooks/em-dash-voice-hook.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# PostToolUse hook for Edit|Write: BLOCK when user-facing content gains an em-dash ("—").
+# PostToolUse hook for Edit|Write: BLOCK when user-facing content gains an em-dash ("—")
+# OR a "--" double-hyphen used as a sentence dash (the em-dash-hook BYPASS anti-pattern).
 #
 # WHY: a literal em-dash in prose is a strong tell of AI-generated voice. On this blog,
 # reader-facing copy should sound human, so an em-dash is treated as a flag to STOP and
@@ -8,18 +9,25 @@
 # AskUserQuestion tool and offer per-occurrence rephrasings (comma / colon / period-split /
 # parentheses / keep). The human picks; Claude applies.
 #
+# ANTI-PATTERN ALSO CAUGHT: typing "--" (double hyphen) as a stand-in for an em-dash to
+# DODGE this hook. That is a workaround, not a fix — it reads as a typo and still carries
+# the same AI-dash cadence. So a "--" used as a clause/sentence dash is flagged the same
+# way. (Legitimate "--" is NOT flagged: CLI flags like --port, YAML/markdown "---" rules,
+# HTML "<!-- -->" comments, and anything inside a fenced ``` code block.)
+#
 # SCOPE: user-facing content only —
 #   - prose: bytesofpurpose-blog/{docs,blog,designs,changelog}/**.{md,mdx}
 #   - markup: any *.html (rendered output / embedded pages — all user-facing)
-#   - components: bytesofpurpose-blog/src/**.{tsx,jsx} — but ONLY when the em-dash is in a
+#   - components: bytesofpurpose-blog/src/**.{tsx,jsx} — but ONLY when the dash is in a
 #     USER-FACING STRING (JSX text or a quoted literal), not in a // comment or /* */ block.
-# Code, config, CSS, skills, plans, and CLAUDE.md are intentionally NOT scoped: em-dashes
+# Code, config, CSS, skills, plans, and CLAUDE.md are intentionally NOT scoped: dashes
 # there are not reader-facing.
 #
-# Detection is on the FILE'S CURRENT CONTENT (post-edit), so it catches an em-dash however
+# Detection is on the FILE'S CURRENT CONTENT (post-edit), so it catches a dash however
 # it arrived. It reports the line numbers + snippets so Claude can target the ask.
 #
-# NOTE: only the em-dash U+2014 ("—") is flagged. The en-dash (–) and hyphen (-) are fine.
+# NOTE: the em-dash U+2014 ("—") and the "--" bypass are flagged. The en-dash (–) and a
+# lone hyphen (-) are fine.
 
 input=$(cat)
 file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
@@ -44,22 +52,68 @@ case "$file_path" in
 esac
 [ -n "$in_scope" ] || exit 0
 
-# --- Find em-dashes in user-facing positions --------------------------------------------
+# --- Find em-dashes AND "--" bypasses in user-facing positions --------------------------
 # For prose + html: any em-dash counts. For components: exclude lines that are purely
 # comments (// … or * … or /* …), since those aren't reader-facing. (A heuristic — a string
 # literal AND a trailing comment on the same line still flags, which is the safe default.)
+#
+# The "--" bypass: flagged when used as a prose dash. To avoid false positives we
+#   - track fenced ``` code blocks and skip lines inside them,
+#   - skip a markdown/YAML horizontal rule or frontmatter delimiter (a line of only dashes),
+#   - strip inline `code` spans and <!-- html comments --> before scanning,
+#   - require the "--" to look like a sentence dash: " -- " (spaced), or attached to a word
+#     on one side with a space on the other ("word-- " or " --word"), NOT a CLI flag
+#     ("--port" has no leading space-or-start boundary that we treat as prose, and we
+#     explicitly skip "--" immediately followed by a letter when preceded by a non-space).
 hits=$(awk -v mode="$in_scope" '
-  index($0, "\xE2\x80\x94") > 0 {
+  BEGIN { infence=0 }
+  {
     line=$0
-    if (mode == "component") {
-      t=line; sub(/^[[:space:]]+/, "", t)
-      # skip lines that are entirely a line- or block-comment
-      if (t ~ /^\/\// || t ~ /^\*/ || t ~ /^\/\*/) next
+    raw=$0
+
+    # toggle fenced code blocks (``` or ~~~ at line start, allowing indentation)
+    t=line; sub(/^[[:space:]]+/, "", t)
+    if (t ~ /^(```|~~~)/) { infence = !infence; next }
+    if (infence) next
+
+    flagged=0; reason=""
+
+    # 1) em-dash U+2014
+    if (index(line, "\xE2\x80\x94") > 0) { flagged=1; reason="em-dash" }
+
+    # 2) "--" bypass — scan a SANITIZED copy of the line
+    s=line
+    # drop inline code spans `...`
+    gsub(/`[^`]*`/, "", s)
+    # drop html comments <!-- ... -->
+    gsub(/<!--/, "", s); gsub(/-->/, "", s)
+    # a line that is only dashes/space (--- rule, frontmatter, table sep) is not prose
+    tt=s; gsub(/[[:space:]]/, "", tt)
+    is_rule = (tt ~ /^-+$/)
+    if (!is_rule) {
+      # spaced sentence dash:  " -- " (both sides space). NOT "---". This is the dominant
+      # bypass form and never matches a CLI flag (flags are "--word", no space after "--").
+      if (s ~ /[^-] -- [^-]/ || s ~ /^-- [^-]/ || s ~ /[^-] --$/) {
+        flagged=1; reason=(reason=="" ? "\"--\" bypass" : reason " + \"--\"")
+      }
+      # punctuation-attached-before dash: "word-- " / "word--," (attached to the PRECEDING
+      # token, space/punct after). Catches "Quarterly-- objectives". A CLI flag has a space
+      # BEFORE "--", so requiring an alnum/punct immediately before excludes flags.
+      else if (s ~ /[[:alnum:],.;:!?\x27\x22)]-- +[[:alnum:]]/) {
+        flagged=1; reason=(reason=="" ? "\"--\" bypass" : reason " + \"--\"")
+      }
     }
-    # trim leading whitespace for a compact snippet
-    snip=line; sub(/^[[:space:]]+/, "", snip)
+
+    if (!flagged) next
+
+    if (mode == "component") {
+      c=line; sub(/^[[:space:]]+/, "", c)
+      if (c ~ /^\/\// || c ~ /^\*/ || c ~ /^\/\*/) next
+    }
+
+    snip=raw; sub(/^[[:space:]]+/, "", snip)
     if (length(snip) > 120) snip=substr(snip,1,117) "..."
-    printf "  L%d: %s\n", NR, snip
+    printf "  L%d [%s]: %s\n", NR, reason, snip
   }
 ' "$file_path")
 
@@ -69,16 +123,18 @@ rel="${file_path##*/}"
 count=$(printf '%s\n' "$hits" | grep -c .)
 
 {
-  echo "BLOCKED — em-dash (\"—\") found in user-facing content: $rel ($count occurrence(s))."
-  echo "An em-dash in reader-facing copy reads as AI voice. Do NOT just rewrite it silently."
+  echo "BLOCKED — em-dash (\"—\") or \"--\" bypass found in user-facing content: $rel ($count occurrence(s))."
+  echo "An em-dash reads as AI voice; \"--\" is the same anti-pattern wearing a disguise (it dodges"
+  echo "this hook but reads as a typo). Do NOT just swap one for the other and do NOT rewrite silently."
   echo
-  echo "Occurrence(s):"
+  echo "Occurrence(s) (tag shows what was found):"
   printf '%s\n' "$hits"
   echo
   echo "REQUIRED next step: use the AskUserQuestion tool to ask the user how to handle EACH"
   echo "occurrence, offering: replace with a comma · a colon · split into two sentences"
   echo "(period) · parentheses · keep as-is. Apply the user's choice, then continue."
-  echo "(Only U+2014 \"—\" is flagged; en-dash and hyphen are fine.)"
+  echo "(Flagged: U+2014 \"—\" and \"--\" used as a sentence dash. A lone hyphen, en-dash,"
+  echo " CLI flags like --port, \"---\" rules, <!-- comments -->, and fenced code are NOT flagged.)"
 } >&2
 
 exit 2

--- a/.claude/skills/review-reader-experience/SKILL.md
+++ b/.claude/skills/review-reader-experience/SKILL.md
@@ -52,6 +52,18 @@ user** (AskUserQuestion) how to handle each occurrence — replace with a comma 
 split into two sentences · parentheses · keep as-is — then apply their choice. Don't
 auto-rewrite; the human decides whether each dash stays.
 
+**The `--` bypass is the SAME anti-pattern (also blocked).** Swapping a forbidden `—` for
+`--` (double hyphen) does not fix the AI-voice tell — it dodges the hook while still reading
+as the same em-dash cadence (and now as a typo). So the hook **also blocks `--` used as a
+sentence/clause dash** in the same scoped files, with the same AskUserQuestion flow. The
+matcher is deliberately narrow to avoid false positives: it flags `--` only when it reads as
+prose punctuation (` -- ` spaced, or `word-- ` attached-before), and it **skips** legitimate
+`--`: CLI flags (`--port`), markdown/YAML `---` rules and frontmatter delimiters, HTML
+`<!-- -->` comments, and anything inside a fenced ```` ``` ```` code block. If you genuinely
+need a literal `--` in prose (e.g. showing `git checkout -- file`), wrap it in inline code
+(backticks) or a code fence and the hook leaves it alone. **Never "fix" an em-dash by typing
+`--`** — that just trades one flagged form for another; pick real punctuation instead.
+
 **Repo-wide scanner (the standing gate the hook lacks).** The hook only fires on files
 Claude *edits* — it never sweeps the existing corpus, so em-dashes that predate the hook (or
 arrive via a human edit / bulk script / git) go uncaught. `make validate-em-dash`

--- a/bytesofpurpose-blog/scripts/validate-em-dash.js
+++ b/bytesofpurpose-blog/scripts/validate-em-dash.js
@@ -14,10 +14,14 @@
  *   - prose:      bytesofpurpose-blog/{docs,blog,designs,changelog}/**.{md,mdx}
  *   - components: bytesofpurpose-blog/src/**.{tsx,jsx}
  *
- * POLICY: flag EVERYTHING — every em-dash in scope, including those inside fenced
- * code blocks / inline-code spans (a deliberate decision: keep the scan dead-simple
- * and let a human keep any genuinely-literal one rather than silently exempt code).
- * Only U+2014 ("—") is flagged; en-dash (–) and hyphen (-) are fine.
+ * POLICY: flag the em-dash EVERYWHERE in scope (including inside code) — keep that scan
+ * dead-simple. ALSO flag the "--" double-hyphen BYPASS (typing "--" to dodge the em-dash
+ * rule is the same AI-voice anti-pattern wearing a disguise). The "--" matcher mirrors the
+ * hook: it flags "--" only when it reads as a prose dash (" -- " spaced, or "word-- "
+ * attached-before) and SKIPS legitimate "--": CLI flags (--port), "---" rules / frontmatter
+ * delimiters, "<!-- -->" comments, and fenced ``` code blocks. (The em-dash check stays
+ * code-inclusive; the "--" check is code-aware because "--" is common+legitimate in code.)
+ * Only U+2014 ("—") and the "--" bypass are flagged; en-dash (–) and a lone hyphen (-) are fine.
  *
  * Usage:
  *   node scripts/validate-em-dash.js                 # scan (default scope) — file:line:snippet
@@ -74,6 +78,21 @@ const files = [];
 for (const r of roots) walk(path.resolve(r), files);
 files.sort();
 
+// "--" bypass: does this (code-sanitized, non-rule) line use "--" as a prose dash?
+// Mirrors em-dash-voice-hook.sh.
+function hasDashBypass(line) {
+  let s = line;
+  s = s.replace(/`[^`]*`/g, ''); // drop inline code spans
+  s = s.replace(/<!--/g, '').replace(/-->/g, ''); // drop html comment markers
+  const collapsed = s.replace(/\s/g, '');
+  if (/^-+$/.test(collapsed)) return false; // a pure "---" rule / frontmatter delimiter
+  // spaced sentence dash " -- " (both sides space, not "---"); never a CLI flag
+  if (/[^-] -- [^-]/.test(s) || /^-- [^-]/.test(s) || /[^-] --$/.test(s)) return true;
+  // attached-before "word-- " (CLI flags have a space BEFORE "--", so this excludes them)
+  if (/[\w,.;:!?'")]-- +\w/.test(s)) return true;
+  return false;
+}
+
 const findings = [];
 for (const file of files) {
   let text;
@@ -82,17 +101,27 @@ for (const file of files) {
   } catch {
     continue;
   }
-  if (!text.includes(EM_DASH)) continue;
   const lines = text.split('\n');
+  let inFence = false;
   lines.forEach((line, i) => {
-    if (!line.includes(EM_DASH)) return;
-    const count = line.split(EM_DASH).length - 1;
+    // track fenced code blocks (for the "--" check only; em-dash stays code-inclusive)
+    const trimmed = line.trimStart();
+    const isFenceToggle = /^(```|~~~)/.test(trimmed);
+
+    const emCount = line.includes(EM_DASH) ? line.split(EM_DASH).length - 1 : 0;
+    const dashBypass = !inFence && !isFenceToggle && hasDashBypass(line);
+
+    if (isFenceToggle) inFence = !inFence;
+
+    if (emCount === 0 && !dashBypass) return;
     let snip = line.trim();
     if (snip.length > 120) snip = snip.slice(0, 117) + '...';
+    const kind = emCount > 0 && dashBypass ? 'em-dash + "--"' : emCount > 0 ? 'em-dash' : '"--" bypass';
     findings.push({
       file: path.relative(SITE_ROOT, file),
       line: i + 1,
-      count,
+      count: emCount + (dashBypass ? 1 : 0),
+      kind,
       snippet: snip,
     });
   });
@@ -105,13 +134,13 @@ if (asJson) {
   console.log(JSON.stringify({ total, files: fileCount, findings }, null, 2));
 } else {
   for (const f of findings) {
-    console.log(`${f.file}:${f.line}: ${f.snippet}`);
+    console.log(`${f.file}:${f.line} [${f.kind}]: ${f.snippet}`);
   }
   if (total === 0) {
-    console.log('✓ em-dash: no em-dashes (—) in public-facing content.');
+    console.log('✓ em-dash: no em-dashes (—) or "--" bypasses in public-facing content.');
   } else {
     console.error(`\n✗ em-dash: ${total} occurrence(s) across ${fileCount} file(s).`);
-    console.error('An em-dash (—) in reader-facing copy reads as AI voice. Rephrase: comma · colon · period-split · parentheses.');
+    console.error('An em-dash (—) or "--" bypass reads as AI voice. Rephrase: comma · colon · period-split · parentheses.');
   }
 }
 


### PR DESCRIPTION
## Why

The em-dash hook blocks a literal `—` in reader-facing copy (an AI-voice tell). But you can dodge it by typing `--`, which reads as the **same** em-dash cadence (now disguised as a typo). That's an anti-pattern, so the guard should catch it too.

## What

Both the live hook and the standing scanner now flag `--` used as a sentence/clause dash:

- **`em-dash-voice-hook.sh`** (PostToolUse `Write|Edit`) — blocks `--` prose dashes alongside `—`, same AskUserQuestion-to-rephrase flow.
- **`validate-em-dash.js`** (`make validate-em-dash`) — the repo-wide corpus gate reports `--` bypasses too, with a `[kind]` tag per finding.

## Narrow by design (no false positives)

A `--` is flagged **only** as a prose dash (`" -- "` spaced, or `"word-- "` attached-before) and **skipped** for legitimate uses:
- CLI flags (`--port`, `--no-open`)
- markdown/YAML `---` rules + frontmatter delimiters
- `<!-- -->` HTML comments
- fenced ` ``` ` code blocks

Verified against a battery of true/false-positive cases (CLI flags, code fences, frontmatter, table separators all pass clean; ` -- ` and `word-- ` get flagged). Documented in the `review-reader-experience` skill: never "fix" an em-dash by typing `--`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)