### PR TITLE
feat(blog-ui): cron cadence badge + per-badge Tooltip (v0.5.0)

### DIFF
--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-finding-your-purpose.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-finding-your-purpose.mdx
@@ -18,14 +18,14 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 ## Core purpose
 
-<SectionBanner why="These are the hardest questions to answer and the most important to keep asking. Most people live their whole lives without a clear answer -- and that gap shows up as restlessness, drift, and doing things for the wrong reasons." />
+<SectionBanner why="These are the hardest questions to answer and the most important to keep asking. Most people live their whole lives without a clear answer, and that gap shows up as restlessness, drift, and doing things for the wrong reasons." />
 
 <Question
   power={['fire', 'anvil']}
   priority="core"
-  frequency="Yearly"
+  cron="yearly"
   depth="deep"
-  why="Without a clear answer, every decision defaults to what feels comfortable or what others expect. This question is the foundation -- everything else you build on top of it inherits its quality."
+  why="Without a clear answer, every decision defaults to what feels comfortable or what others expect. This question is the foundation. Everything else you build on top of it inherits its quality."
   howOften="Once per year, and any time you feel like you're going through the motions"
   when="During quiet periods of reflection, journaling sessions, or spiritual retreats"
   record="Write a paragraph-length answer; revisit it annually to see how your answer has shifted">
@@ -35,10 +35,10 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 <Question
   power="chisel"
   priority="high"
-  frequency="Quarterly"
+  cron="quarterly"
   depth="moderate"
   why="'Purpose' and 'objective' aren't the same thing. Your objective is what you're working toward right now; your purpose is the reason any of it matters. Knowing the difference keeps you from confusing activity with meaning."
-  howOften="Quarterly -- objectives change; purpose should be more stable"
+  howOften="Quarterly: objectives change; purpose should be more stable"
   when="At the start of a new season, a new role, or when you feel scattered"
   record="Keep it in one sentence. Update it when you genuinely believe it has changed.">
   What is your main objective?
@@ -47,26 +47,26 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 <Question
   power={['spark', 'fire']}
   priority="core"
-  frequency="2x / year"
+  cron="yearly"
   depth="deep"
-  why="'Meaning' is the word that survives the reduction -- when you strip away achievement, status, and comfort, what's left that still matters to you? This question goes deeper than purpose; it asks what you'd still care about if you lost everything else."
+  why="'Meaning' is the word that survives the reduction: when you strip away achievement, status, and comfort, what's left that still matters to you? This question goes deeper than purpose; it asks what you'd still care about if you lost everything else."
   howOften="Once or twice a year, especially after loss or disruption"
   when="After a major failure, a transition, or any moment that forces perspective"
-  record="Write freely without editing -- the first answer is often the truest">
+  record="Write freely without editing; the first answer is often the truest">
   What's the meaning of your life?
 </Question>
 
 ## What gives you meaning
 
-<SectionBanner why="Knowing what drives you is a navigational tool. When you can name your motivators specifically, you can design your life to include more of them -- and notice faster when they're missing." />
+<SectionBanner why="Knowing what drives you is a navigational tool. When you can name your motivators specifically, you can design your life to include more of them, and notice faster when they're missing." />
 
 <Question
   power="spark"
   priority="medium"
-  frequency="Monthly"
+  cron="monthly"
   depth="moderate"
-  why="These four words point to different things. What gives you meaning is bigger than what motivates you today. Separating them reveals the layers -- and shows you which ones are deep roots versus temporary fuel."
-  howOften="Monthly -- your answer will shift as your circumstances change"
+  why="These four words point to different things. What gives you meaning is bigger than what motivates you today. Separating them reveals the layers, and shows you which ones are deep roots versus temporary fuel."
+  howOften="Monthly: your answer will shift as your circumstances change"
   when="When you feel energized, note what caused it. When you feel drained, note what's missing."
   record="Keep a running list of specific situations where you felt genuinely driven; the pattern IS the answer">
   What gives you meaning? What drives you? What motivates you? What moves you?
@@ -75,10 +75,10 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 <Question
   power="fire"
   priority="high"
-  frequency="In hard stretches"
+  cron="adhoc"
   depth="deep"
-  why="This question finds your anchor point. When everything is hard, what is the thing that keeps you going? The answer is usually connected to something larger than yourself -- a person, a belief, a commitment."
-  howOften="Ask this in difficult stretches, not just in calm ones -- the honest answer emerges under pressure"
+  why="This question finds your anchor point. When everything is hard, what is the thing that keeps you going? The answer is usually connected to something larger than yourself: a person, a belief, a commitment."
+  howOften="Ask this in difficult stretches, not just in calm ones; the honest answer emerges under pressure"
   when="When you're tired, discouraged, or seriously considering quitting something"
   record="Note it in moments of real difficulty; revisit when you need to remind yourself">
   What gives you the strength to keep going forward?
@@ -86,19 +86,19 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 ## Why you do what you do
 
-<SectionBanner why="Most people act on autopilot -- their reasons are inherited, unconscious, or borrowed from someone else. These questions surface the actual drivers so you can decide whether to keep them." />
+<SectionBanner why="Most people act on autopilot: their reasons are inherited, unconscious, or borrowed from someone else. These questions surface the actual drivers so you can decide whether to keep them." />
 
 <Question
-  why="Reasons matter because they determine sustainability. You can do anything for a while out of fear, pressure, or habit -- but only the things you can articulate real reasons for will survive the hard stretches."
+  why="Reasons matter because they determine sustainability. You can do anything for a while out of fear, pressure, or habit, but only the things you can articulate real reasons for will survive the hard stretches."
   howOften="Every six months, and any time you make a significant choice"
-  when="Before starting a new project, relationship, or commitment -- and when evaluating whether to continue one"
+  when="Before starting a new project, relationship, or commitment, and when evaluating whether to continue one"
   record="Write the honest answer, not the socially acceptable one">
   Why do you do what you do? What are your reasons?
 </Question>
 
 <Question
-  why="Beliefs and values are the code your decisions run on. Most people never examine this code -- they just execute it. Making it explicit lets you update it intentionally instead of being quietly governed by values you inherited by accident."
-  howOften="Once a year -- values shift slowly, but they do shift"
+  why="Beliefs and values are the code your decisions run on. Most people never examine this code; they just execute it. Making it explicit lets you update it intentionally instead of being quietly governed by values you inherited by accident."
+  howOften="Once a year. Values shift slowly, but they do shift"
   when="During annual reflection, after a major change in perspective, or when you notice a conflict between what you say you believe and how you act"
   record="Write them out as a list; compare across years to see what's deepened and what's faded">
   What are your beliefs? What are your values?
@@ -106,7 +106,7 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <Question
   why="This is the ROI question for your inner life. Goals, values, convictions, decisions, and plans are only worth what they actually produce in your character and your world. Asking the question forces an honest audit."
-  howOften="Annually -- this is a year-in-review question"
+  howOften="Annually. This is a year-in-review question"
   when="At the end of a year, a chapter, or a long-running commitment"
   record="Write the honest answer. If the answer is 'not much,' that's the most valuable data you can have.">
   What are your goals, values, convictions, decisions, and plans worth?
@@ -117,24 +117,24 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 <SectionBanner why="Legacy questions are useful not because you should live for posterity, but because they clarify what actually matters to you when you zoom out far enough to escape the noise of the immediate." />
 
 <Question
-  why="The refusal to be forgotten is often the most honest signal of what you think your life was for. But it's worth interrogating -- do you want to be remembered for who you were, or for what you did? The answer shapes everything."
+  why="The refusal to be forgotten is often the most honest signal of what you think your life was for. But it's worth interrogating: do you want to be remembered for who you were, or for what you did? The answer shapes everything."
   howOften="Once a year; answers often change across decades of life"
   when="During deep reflection periods, after experiencing the death of someone you admired"
-  record="Write it down and date it -- your answer at 30 will be different from your answer at 50">
+  record="Write it down and date it. Your answer at 30 will be different from your answer at 50">
   Why do you want to be remembered? Why do you refuse to be forgotten?
 </Question>
 
 <Question
   why="Wanting to be great is natural. But the reason behind that want determines whether it makes you better or just more anxious. Greatness for its own sake is a treadmill. Greatness in service of something real is a foundation."
   howOften="Annually, or when you notice competitive impulses driving your choices"
-  when="When you feel the pull of status or recognition -- ask why it matters to you"
+  when="When you feel the pull of status or recognition, ask why it matters to you"
   record="Write the honest answer, not the humble one">
   Why do you want to be great? Why do you want to be known?
 </Question>
 
 <Question
-  why="Blessings -- time, talent, opportunity, faith, relationships -- aren't neutral gifts. They carry responsibility. This question reframes your life as stewardship rather than ownership, which changes how you evaluate your choices."
-  howOften="Quarterly -- your blessings change as your life changes"
+  why="Blessings (time, talent, opportunity, faith, relationships) aren't neutral gifts. They carry responsibility. This question reframes your life as stewardship rather than ownership, which changes how you evaluate your choices."
+  howOften="Quarterly. Your blessings change as your life changes"
   when="When taking stock of what you have, especially after periods of growth or provision"
   record="List the blessings first, then write what difference you're actually making with each one">
   What difference will you make with the blessings you've been given?
@@ -142,37 +142,37 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 ## Vision and story
 
-<SectionBanner why="You are writing a story whether you intend to or not. These questions ask you to become the author rather than just a character -- to choose the arc, not just react to the events." />
+<SectionBanner why="You are writing a story whether you intend to or not. These questions ask you to become the author rather than just a character: to choose the arc, not just react to the events." />
 
 <Question
-  why="A vision without a story is just a wish. Your story gives your vision context -- where it came from, what it cost, who it's for. Most people have neither; the ones who lead something tend to have both."
-  howOften="Annually -- your vision should evolve, and your story should deepen"
+  why="A vision without a story is just a wish. Your story gives your vision context: where it came from, what it cost, who it's for. Most people have neither; the ones who lead something tend to have both."
+  howOften="Annually. Your vision should evolve, and your story should deepen"
   when="During long periods of reflection, writing retreats, or when preparing to share your work with others"
-  record="Write a narrative version, not a bulleted list -- the story form reveals things the list hides">
+  record="Write a narrative version, not a bulleted list. The story form reveals things the list hides">
   What is your vision? What is your own story?
 </Question>
 
 <Question
-  why="Most people have stories that happened TO them. This question asks you to take the author's chair -- to decide what the next chapter is, how the conflicts resolve, and what the ending means. Design is an act of agency."
+  why="Most people have stories that happened TO them. This question asks you to take the author's chair: to decide what the next chapter is, how the conflicts resolve, and what the ending means. Design is an act of agency."
   howOften="Once a year, as a dedicated writing exercise"
-  when="At major transitions -- a new decade, a career change, a season ending"
+  when="At major transitions: a new decade, a career change, a season ending"
   record="Write it as a story, not a plan. The narrative form forces honesty about what you actually want.">
   How will you design your story? How does your story end?
 </Question>
 
 <Question
-  why="Having a vision for humanity sounds ambitious, but it's actually clarifying. It tells you what problem you think is worth solving at the largest scale. Even a small answer is better than no answer -- it gives you a direction to point your work."
+  why="Having a vision for humanity sounds ambitious, but it's actually clarifying. It tells you what problem you think is worth solving at the largest scale. Even a small answer is better than no answer; it gives you a direction to point your work."
   howOften="Once a year; this should deepen over time as you learn more about the world"
   when="During big-picture reflection, when reading about history or social change, or when deciding what to commit to"
-  record="Write it in one or two sentences -- if you can't compress it, you haven't found it yet">
+  record="Write it in one or two sentences. If you can't compress it, you haven't found it yet">
   What vision do you have for humanity? Have you found your vision?
 </Question>
 
 <Question
-  why="Believing your story is a form of self-respect. If you don't believe it -- if you secretly think it's less important than other people's -- you'll constantly underinvest in it. This question checks for that quiet undermining."
+  why="Believing your story is a form of self-respect. If you don't believe it, if you secretly think it's less important than other people's, you'll constantly underinvest in it. This question checks for that quiet undermining."
   howOften="Ask this whenever you catch yourself minimizing your work or path"
   when="When comparing yourself to others, when you feel like your story isn't 'enough'"
-  record="A yes/no with a sentence of honest explanation -- the explanation is what matters">
+  record="A yes/no with a sentence of honest explanation; the explanation is what matters">
   Do you believe your story? Is it as valuable as you think it is?
 </Question>
 
@@ -182,31 +182,31 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <Question
   why="Most people act as though they have unlimited time. They don't, and deep down they know it. This question confronts the gap between knowing time is limited and actually living that way."
-  howOften="Monthly -- keep it present, not just as a once-a-year thought"
-  when="At the start of any significant period -- a new year, a new month, a new project"
+  howOften="Monthly. Keep it present, not just as a once-a-year thought"
+  when="At the start of any significant period: a new year, a new month, a new project"
   record="Write a short answer and check whether your current week reflects it">
   Life is temporary: what will you do with the time you have?
 </Question>
 
 <Question
-  why="Death isn't depressing when you use it as a teacher. It clarifies priorities faster than any other lens -- things that feel urgent stop feeling urgent, and things you've been postponing suddenly seem urgent in a better way."
-  howOften="A few times a year -- enough to keep it alive, not so often that it becomes abstract"
+  why="Death isn't depressing when you use it as a teacher. It clarifies priorities faster than any other lens. Things that feel urgent stop feeling urgent, and things you've been postponing suddenly seem urgent in a better way."
+  howOften="A few times a year. Enough to keep it alive, not so often that it becomes abstract"
   when="When you're stuck on small decisions, when you're anxious about what others think, when you feel like you've lost perspective"
   record="Write a paragraph on what it changes when you hold this in mind">
   You will die. How does that shape what matters?
 </Question>
 
 <Question
-  why="The one-year constraint strips away social expectation, comfort-seeking, and long-game rationalization. What remains is what you actually care about. It's not a morbid exercise -- it's a clarifier."
+  why="The one-year constraint strips away social expectation, comfort-seeking, and long-game rationalization. What remains is what you actually care about. It's not a morbid exercise; it's a clarifier."
   howOften="Once a year, as a dedicated thought experiment"
   when="During annual reflection, or any time you feel like you're living someone else's priorities"
-  record="Write the answer seriously -- not what you think sounds right, but what you'd actually do">
+  record="Write the answer seriously. Not what you think sounds right, but what you'd actually do">
   What would you do if you knew you only had one year left?
 </Question>
 
 <Question
   why="Most people say they know time is limited, but they don't behave that way. This question checks for the gap between belief and behavior. The answer is usually uncomfortable, which makes it useful."
-  howOften="Monthly -- check it against your current calendar and commitments"
+  howOften="Monthly. Check it against your current calendar and commitments"
   when="When reviewing how you've spent the past month, when you feel like you're drifting"
   record="A yes/no, then a specific example that proves it">
   Are you living as if your time is limited?
@@ -214,7 +214,7 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <Question
   why="These two questions are different in a useful way. What will remain is about contribution; how knowing it ends changes how you live is about urgency. Together they push toward intentional living without tipping into anxiety."
-  howOften="Annually -- this is the year-in-review version of the mortality question"
+  howOften="Annually. This is the year-in-review version of the mortality question"
   when="At the end of a year, at a significant birthday, after losing someone"
   record="Write both answers. The gap between them is often where the real work lives.">
   What will remain when you're gone? How does knowing life ends change how you live today?
@@ -222,7 +222,7 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 ## Divine creation and becoming your best
 
-<SectionBanner why="These questions assume that you were made with intention -- that your capacity, your gifts, and your potential aren't accidents. Sitting with that assumption raises the stakes in a productive way." />
+<SectionBanner why="These questions assume that you were made with intention: that your capacity, your gifts, and your potential aren't accidents. Sitting with that assumption raises the stakes in a productive way." />
 
 <Question
   why="This question reframes your existence as purposeful at the source. Even if you're uncertain about faith, the question is useful: what would it mean to live as though you were made for something specific? The answer changes how you use your time."
@@ -233,16 +233,16 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 </Question>
 
 <Question
-  why="'Best version of yourself' is not a marketing phrase -- it's an honest benchmark. Most people know what it would look like for them to be operating at their best. The question is whether they're moving toward it or away from it."
-  howOften="Monthly -- this should be a regular check, not an annual abstraction"
+  why="'Best version of yourself' is not a marketing phrase; it's an honest benchmark. Most people know what it would look like for them to be operating at their best. The question is whether they're moving toward it or away from it."
+  howOften="Monthly. This should be a regular check, not an annual abstraction"
   when="When reviewing your habits, relationships, and outputs for the past month"
   record="Write a specific gap: here is what my best self looks like; here is where I actually am">
   Are you becoming the best version of yourself?
 </Question>
 
 <Question
-  why="Potential isn't the same as talent. Fulfilling your God-given potential is about full expression -- not just of what you're good at, but of what you were made to offer. This question asks whether you're leaving any of that on the table."
-  howOften="Quarterly -- potential is long-horizon, but the inputs are monthly"
+  why="Potential isn't the same as talent. Fulfilling your God-given potential is about full expression, not just of what you're good at, but of what you were made to offer. This question asks whether you're leaving any of that on the table."
+  howOften="Quarterly. Potential is long-horizon, but the inputs are monthly"
   when="When evaluating whether to take on something new, when you feel underused or overextended"
   record="Write what full expression would look like, then write what you're actually doing">
   What does it mean to fulfill your God-given potential?
@@ -257,8 +257,8 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 </Question>
 
 <Question
-  why="'Best version' needs to be specific to be useful. This question asks you to paint the picture clearly, and then to name the actual obstacle -- not a vague one, but the specific thing standing between you and that version."
-  howOften="Quarterly -- the obstacle changes; the vision should stay relatively stable"
+  why="'Best version' needs to be specific to be useful. This question asks you to paint the picture clearly, and then to name the actual obstacle: not a vague one, but the specific thing standing between you and that version."
+  howOften="Quarterly. The obstacle changes; the vision should stay relatively stable"
   when="When you feel stuck, when you're about to make a significant decision about your time"
   record="Write both: the vision AND the specific obstacle. The second one is where the work is.">
   What would the best version of you look like? What's stopping you from becoming who you were meant to be?
@@ -266,13 +266,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 ## Discovering your calling
 
-<SectionBanner why="Calling isn't usually announced -- it's discovered by noticing patterns. What you keep returning to, what you can't help caring about, what feels effortless to you and impossible to others -- these are the signals. These questions help you read them." />
+<SectionBanner why="Calling isn't usually announced; it's discovered by noticing patterns. What you keep returning to, what you can't help caring about, what feels effortless to you and impossible to others: these are the signals. These questions help you read them." />
 
 <Question
-  why="'Better than everyone else' sounds arrogant, but it's a useful thought experiment. Not literally -- but what is it that you bring that's yours? What have you cultivated that others haven't? That asymmetry often points to calling."
-  howOften="Annually -- your answer should deepen and sharpen over time"
+  why="'Better than everyone else' sounds arrogant, but it's a useful thought experiment. Not literally, but what is it that you bring that's yours? What have you cultivated that others haven't? That asymmetry often points to calling."
+  howOften="Annually. Your answer should deepen and sharpen over time"
   when="When considering what to invest in, what to offer, what to double down on"
-  record="Write a specific list -- not general traits, but specific capabilities">
+  record="Write a specific list. Not general traits, but specific capabilities">
   What makes you unique? What can you do better than everyone else?
 </Question>
 
@@ -285,31 +285,31 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 </Question>
 
 <Question
-  why="The problems you always want to solve are the ones you'll work on longest without burning out. Most people chase problems that are prestigious or profitable -- but calling tends to be the problems you'd work on even if no one was watching."
+  why="The problems you always want to solve are the ones you'll work on longest without burning out. Most people chase problems that are prestigious or profitable, but calling tends to be the problems you'd work on even if no one was watching."
   howOften="Annually"
   when="When evaluating whether to start something new, when you feel pulled toward a problem unprompted"
-  record="Write a specific list of problem types -- not industries, but actual problem patterns">
+  record="Write a specific list of problem types. Not industries, but actual problem patterns">
   What kinds of problems do you always want to solve?
 </Question>
 
 <Question
-  why="A question you want to dedicate your life to answering is a different level of commitment than a career. It's the level where calling lives. Most people never identify it -- but the ones who do tend to produce work that outlasts them."
+  why="A question you want to dedicate your life to answering is a different level of commitment than a career. It's the level where calling lives. Most people never identify it, but the ones who do tend to produce work that outlasts them."
   howOften="Once a year; this is a long-horizon question that should refine slowly"
   when="During extended reflection periods, when you're evaluating the next chapter of your life"
-  record="Write it as a single question -- if you can't compress it to one, you haven't found it yet">
+  record="Write it as a single question. If you can't compress it to one, you haven't found it yet">
   What question(s) do you want to dedicate your life to answering?
 </Question>
 
 <Question
   why="'Only you' and 'love answering' are two different filters. The first looks for your unique combination of experience and perspective. The second looks for genuine energy. Questions that pass both filters are your strongest signal of calling."
-  howOften="Annually -- this is a refining question, not a weekly check"
+  howOften="Annually. This is a refining question, not a weekly check"
   when="After periods of deep work, when you notice where your energy peaks"
   record="Write both answers separately, then look for the overlap">
   What question(s) can only you answer? What question do you love answering?
 </Question>
 
 <Question
-  why="Sweet spot is where your unique strength meets what the world actually needs and will pay for. Most people are somewhere off-center -- too internal (pure passion, no demand) or too external (pure demand, no energy). This question finds the center."
+  why="Sweet spot is where your unique strength meets what the world actually needs and will pay for. Most people are somewhere off-center: too internal (pure passion, no demand) or too external (pure demand, no energy). This question finds the center."
   howOften="Annually, and whenever you're considering a major pivot"
   when="During career reflection, when evaluating whether current work is sustainable long-term"
   record="Draw the three circles (what you love, what you're great at, what the world needs) and write where you actually are">
@@ -321,15 +321,15 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 <SectionBanner why="Purpose requires belief to become action. If you don't believe your life is for something, you won't do the hard work of finding out what. These questions check whether your beliefs are actually load-bearing." />
 
 <Question
-  why="Belief shapes action more than information does. What you believe is possible determines what you attempt. Luck favoring the believers isn't superstition -- it's the observation that people who believe in something take more shots and persist longer."
+  why="Belief shapes action more than information does. What you believe is possible determines what you attempt. Luck favoring the believers isn't superstition; it's the observation that people who believe in something take more shots and persist longer."
   howOften="Quarterly"
   when="Before starting something difficult, when doubt shows up, when you're evaluating whether to commit to something"
-  record="Write your core beliefs as statements, not aspirations -- things you actually act on">
+  record="Write your core beliefs as statements, not aspirations. Things you actually act on">
   Luck favors the believers: what do you believe in?
 </Question>
 
 <Question
-  why="Capability beliefs are often more limiting than actual capability. Most people underestimate what they can do because they've never been pushed far enough to find out. This question asks you to honestly assess -- and then challenge -- that ceiling."
+  why="Capability beliefs are often more limiting than actual capability. Most people underestimate what they can do because they've never been pushed far enough to find out. This question asks you to honestly assess, and then challenge, that ceiling."
   howOften="Quarterly"
   when="When facing something that feels too hard, when evaluating your own potential in a new domain"
   record="Write what you believe you're capable of, then write what evidence you'd need to believe more">
@@ -337,7 +337,7 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 </Question>
 
 <Question
-  why="Believing in something bigger than yourself is what makes sustained effort possible. Self-interest alone doesn't sustain people through difficulty -- but belief in a cause, a person, or a God can. This question checks whether you've found that."
+  why="Believing in something bigger than yourself is what makes sustained effort possible. Self-interest alone doesn't sustain people through difficulty, but belief in a cause, a person, or a God can. This question checks whether you've found that."
   howOften="Annually"
   when="During spiritual reflection, during periods of sustained effort or sacrifice"
   record="Write what it is. If you can't name it, that's the signal to keep searching.">
@@ -346,18 +346,18 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <Question
   why="Willingness to fail is the real test of belief. Most people believe in their purpose in theory but aren't willing to fail for it in practice. The number of times you're willing to get up tells you how real the belief actually is."
-  howOften="Ask this before starting something where failure is possible -- which is everything worth doing"
+  howOften="Ask this before starting something where failure is possible, which is everything worth doing"
   when="When evaluating whether to take a risk, when you're recovering from a failure"
-  record="Write a specific number or range -- and then note whether your behavior matches it">
+  record="Write a specific number or range, and then note whether your behavior matches it">
   How many times are you ready to fail?
 </Question>
 
 ## Championing a cause
 
-<SectionBanner why="A cause is bigger than a goal. It's what you're for in the world -- what you'd put your name on, what you'd sacrifice for. These questions ask whether you've found yours." />
+<SectionBanner why="A cause is bigger than a goal. It's what you're for in the world: what you'd put your name on, what you'd sacrifice for. These questions ask whether you've found yours." />
 
 <Question
-  why="A cause you champion is different from a cause you agree with. Championing means actively advancing it -- with time, voice, and resources. Most people have opinions about causes; fewer have commitments. This question checks which category you're in."
+  why="A cause you champion is different from a cause you agree with. Championing means actively advancing it, with time, voice, and resources. Most people have opinions about causes; fewer have commitments. This question checks which category you're in."
   howOften="Annually"
   when="When evaluating where to volunteer, donate, or invest your advocacy energy"
   record="Name the cause specifically, then write one concrete thing you're actively doing for it">
@@ -368,7 +368,7 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   why="Advancing humanity sounds grandiose until you break it down: what specific problem will you help solve? What specific status quo will you push against? The scale of the question is meant to lift your eyes beyond personal benefit."
   howOften="Annually"
   when="During long-horizon reflection, when deciding where to put your most serious effort"
-  record="Write the specific answer -- not 'I want to make the world better' but 'I will advance X by doing Y'">
+  record="Write the specific answer. Not 'I want to make the world better' but 'I will advance X by doing Y'">
   How will you advance humanity? How will you challenge the status quo?
 </Question>
 
@@ -382,26 +382,26 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 ## Knowing you're getting closer
 
-<SectionBanner why="Purpose isn't just about finding it -- it's about tracking it. These questions build a feedback loop so you can tell when you're aligned and when you've drifted, rather than waiting for the feeling to hit you." />
+<SectionBanner why="Purpose isn't just about finding it; it's about tracking it. These questions build a feedback loop so you can tell when you're aligned and when you've drifted, rather than waiting for the feeling to hit you." />
 
 <Question
   why="Without signals, you're navigating blind. This question asks you to define what alignment feels like so you can notice it when it's happening and notice its absence when it's not."
-  howOften="Monthly -- build it into your review practice"
+  howOften="Monthly. Build it into your review practice"
   when="During monthly reflection, when assessing whether current work feels right"
-  record="Write the signals you notice, not the theory -- specific feelings, moments, or patterns">
+  record="Write the signals you notice, not the theory. Specific feelings, moments, or patterns">
   How do you know you're getting closer to your purpose?
 </Question>
 
 <Question
   why="Milestones make the abstract tangible. If you can name the specific markers that would tell you you're on the path, you have a way to evaluate your choices. Without them, every path looks equally valid or invalid."
-  howOften="Quarterly -- review your milestones and update them as you learn more"
+  howOften="Quarterly. Review your milestones and update them as you learn more"
   when="When setting goals for a new quarter or year, when evaluating progress"
-  record="Write 3-5 specific milestones. Not outcomes -- leading indicators that you're moving in the right direction.">
+  record="Write 3-5 specific milestones. Not outcomes, but leading indicators that you're moving in the right direction.">
   What milestones will inch you closer?
 </Question>
 
 <Question
-  why="Passions can mislead. You can be passionate about something that isn't your calling -- it might just be enjoyable, ego-boosting, or familiar. Testing your passions against your purpose is how you distinguish between the two."
+  why="Passions can mislead. You can be passionate about something that isn't your calling. It might just be enjoyable, ego-boosting, or familiar. Testing your passions against your purpose is how you distinguish between the two."
   howOften="When you're evaluating whether a new passion deserves significant time investment"
   when="Before committing significant resources to a new interest or direction"
   record="Write the test you'd run and what the pass/fail criteria are">
@@ -410,8 +410,8 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <Question
   why="'True calling' signals are often quieter than the dramatic revelation people expect. This question asks you to define the signals in advance so you don't miss them or mistake lesser things for them."
-  howOften="Annually -- refine your criteria as you have more experience to draw from"
-  when="When something feels like it might be the thing -- use this question to check rigorously"
+  howOften="Annually. Refine your criteria as you have more experience to draw from"
+  when="When something feels like it might be the thing, use this question to check rigorously"
   record="Write the criteria, not just the feeling">
   How do you know you've found your true calling?
 </Question>
@@ -420,17 +420,17 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   why="There's a version of 'seeking purpose' that becomes avoidance. At some point, you have to commit to a direction based on the best information you have and stop waiting for certainty. This question asks when that moment is."
   howOften="Ask this when you've been in seeking mode for a while without committing"
   when="When you've been exploring for more than a year without landing, or when you're using 'searching' as a reason to avoid commitment"
-  record="Write your honest answer -- and if you've been seeking too long, write what you'd commit to today if you had to">
+  record="Write your honest answer, and if you've been seeking too long, write what you'd commit to today if you had to">
   When should you stop seeking purpose?
 </Question>
 
 ## Avoiding regret
 
-<SectionBanner why="Regret is information about what actually mattered to you. These questions use the threat of regret as a forward-looking tool -- not to generate anxiety, but to clarify what deserves your effort now." />
+<SectionBanner why="Regret is information about what actually mattered to you. These questions use the threat of regret as a forward-looking tool, not to generate anxiety, but to clarify what deserves your effort now." />
 
 <Question
   why="Skills that live only in you and die with you are gifts withheld from the world. This question is a sharp form of accountability: what have you developed that no one else will ever benefit from if you don't act?"
-  howOften="Annually -- this is a legacy question"
+  howOften="Annually. This is a legacy question"
   when="During year-end reflection, when you're deciding what to write, teach, or share"
   record="Write the specific list. Then write what you'd do with each if you committed to sharing it.">
   What skills will die with you?
@@ -438,23 +438,23 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <Question
   why="Regret about inaction is consistently worse than regret about action, according to most research and most people's experience. This question takes that finding seriously and applies it to your current hesitations."
-  howOften="Quarterly -- things you're not acting on tend to accumulate without notice"
+  howOften="Quarterly. Things you're not acting on tend to accumulate without notice"
   when="When you're hesitating on something significant, when you've been putting something off for more than a few months"
-  record="Write the honest answer. If you're not ready to act, write why -- and whether that reason will still feel valid in five years.">
+  record="Write the honest answer. If you're not ready to act, write why, and whether that reason will still feel valid in five years.">
   If you don't act now, what will you end up regretting?
 </Question>
 
 <Question
-  why="Knowing what you don't want to be is sometimes clearer than knowing what you do want to be -- and it's just as useful. Negative clarity points you toward the positive almost as reliably as positive clarity does."
+  why="Knowing what you don't want to be is sometimes clearer than knowing what you do want to be, and it's just as useful. Negative clarity points you toward the positive almost as reliably as positive clarity does."
   howOften="Annually"
   when="When you're evaluating a direction and unsure whether it's right, when you feel like you're becoming someone you don't respect"
-  record="Write a specific list -- not abstract vices, but specific patterns or tendencies you refuse to cultivate">
+  record="Write a specific list. Not abstract vices, but specific patterns or tendencies you refuse to cultivate">
   What do you not want to be?
 </Question>
 
 ## Listening to your inner voice
 
-<SectionBanner why="Your inner life is constantly giving you information about whether you're aligned with your purpose. The problem isn't that the signal is absent -- it's that most people have never learned to read it." />
+<SectionBanner why="Your inner life is constantly giving you information about whether you're aligned with your purpose. The problem isn't that the signal is absent; it's that most people have never learned to read it." />
 
 You possess an inner force trying to guide you to your full potential. It makes you
 feel unhappy when you stray from your purpose, and successful when you don't.
@@ -463,12 +463,12 @@ it, is most of the work.
 
 ## Understanding your uniqueness
 
-<SectionBanner why="Your uniqueness isn't about being special -- it's about being irreplaceable in a specific way. These questions help you identify the signature you leave on everything you touch, which is the practical definition of your calling." />
+<SectionBanner why="Your uniqueness isn't about being special; it's about being irreplaceable in a specific way. These questions help you identify the signature you leave on everything you touch, which is the practical definition of your calling." />
 
 <Question
   why="Transcribing a message means you're a conduit for something specific, not just a content producer. What others feel in your presence is a signal about what you're actually communicating beneath the words. Both questions point to your signature."
   howOften="Annually, and after significant pieces of work or interactions"
-  when="After giving a talk, publishing something, or ending a meaningful conversation -- what did people take away?"
+  when="After giving a talk, publishing something, or ending a meaningful conversation. What did people take away?"
   record="Collect actual feedback; the patterns across many instances are more reliable than your own perception">
   What message are you transcribing? What do you make people feel?
 </Question>
@@ -482,7 +482,7 @@ it, is most of the work.
 </Question>
 
 <Question
-  why="'What makes you you' is worth knowing precisely because it's the thing you can't outsource or replicate. And the question of why someone would want to know you -- that's the relational version of uniqueness, which is where it actually matters."
+  why="'What makes you you' is worth knowing precisely because it's the thing you can't outsource or replicate. And the question of why someone would want to know you is the relational version of uniqueness, which is where it actually matters."
   howOften="Annually"
   when="When introducing yourself to a new audience, when evaluating whether you're showing your real self or a curated version"
   record="Write both answers. The gap between them is usually where your best work is hiding.">
@@ -490,10 +490,10 @@ it, is most of the work.
 </Question>
 
 <Question
-  why="This is the most direct version of the uniqueness question. What can you say is genuinely, irreversibly yours? Not just your fingerprints -- but your combination of experience, perspective, and craft. That's where calling and identity converge."
+  why="This is the most direct version of the uniqueness question. What can you say is genuinely, irreversibly yours? Not just your fingerprints, but your combination of experience, perspective, and craft. That's where calling and identity converge."
   howOften="Annually"
   when="During deep reflection, when you feel like what you're doing could be done by anyone"
-  record="Write a specific answer. If you can't, that's the signal that you haven't developed your uniqueness enough yet -- and that's useful information too.">
+  record="Write a specific answer. If you can't, that's the signal that you haven't developed your uniqueness enough yet, and that's useful information too.">
   In what can you truly say "there will never be anyone else like me"?
 </Question>
 
@@ -501,20 +501,20 @@ The people who are closest to their nature will lead the world.
 
 ## Purifying intentions
 
-<SectionBanner why="Motivation matters even when the action is good. These questions check whether you're doing what you do for the right reasons -- because the reason determines what the work costs you and what it actually produces." />
+<SectionBanner why="Motivation matters even when the action is good. These questions check whether you're doing what you do for the right reasons, because the reason determines what the work costs you and what it actually produces." />
 
 <Question
-  why="Service for reciprocity is transactional -- and will eventually disappoint. Service for legacy is ego-driven -- and leads to burnout or resentment when the recognition doesn't come. Purifying intention means finding the reason to serve that doesn't depend on a return."
+  why="Service for reciprocity is transactional, and will eventually disappoint. Service for legacy is ego-driven, and leads to burnout or resentment when the recognition doesn't come. Purifying intention means finding the reason to serve that doesn't depend on a return."
   howOften="Annually, and any time you feel resentful or unappreciated"
   when="When you notice bitterness, entitlement, or ego in your motivations"
-  record="Write your honest answer. Most people's motivations are mixed -- that's fine. The goal is to know which ones are driving.">
+  record="Write your honest answer. Most people's motivations are mixed, and that's fine. The goal is to know which ones are driving.">
   Do you want to serve humanity for humanity to serve you back? To be remembered?
 </Question>
 
 <Question
-  why="Digging into purpose tends to surface things you weren't expecting -- including motivations you'd rather not acknowledge. This question invites that excavation without judgment. The deeper you go, the more honest your actions become."
+  why="Digging into purpose tends to surface things you weren't expecting, including motivations you'd rather not acknowledge. This question invites that excavation without judgment. The deeper you go, the more honest your actions become."
   howOften="Annually, and as a closing question after a season of purposeful work"
   when="During deep reflection sessions, at the end of a significant chapter"
-  record="Write the layers -- the surface reason and what you find when you keep digging. The deepest honest answer is the one worth acting from.">
+  record="Write the layers: the surface reason and what you find when you keep digging. The deepest honest answer is the one worth acting from.">
   Why do I do what I do? As I dig deeper into my purpose, I become more aware of the things I do, and why.
 </Question>

--- a/packages/blog-ui/package.json
+++ b/packages/blog-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omars-lab/blog-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, Gif animated-media figure, DiagramWithFootnotes, Assumption highlight, and the question-set set (SectionBanner, Question card+modal with power badges, PowerLegend).",
   "license": "MIT",
   "repository": {

--- a/packages/blog-ui/src/components/Question/index.tsx
+++ b/packages/blog-ui/src/components/Question/index.tsx
@@ -1,7 +1,8 @@
 import React, {CSSProperties, ReactNode, useCallback, useEffect, useState} from 'react';
 import clsx from 'clsx';
-import {GiLightningArc, GiFlame, GiChisel, GiAnvil} from 'react-icons/gi';
+import {GiLightningArc, GiFlame, GiChisel, GiAnvil, GiCycle} from 'react-icons/gi';
 import type {IconType} from 'react-icons';
+import Tooltip from '../Tooltip';
 import styles from './styles.module.css';
 
 /**
@@ -39,6 +40,12 @@ import styles from './styles.module.css';
 export type QuestionPower = 'spark' | 'fire' | 'chisel' | 'anvil';
 export type QuestionPriority = 'core' | 'high' | 'medium' | 'low';
 export type QuestionDepth = 'quick' | 'moderate' | 'deep';
+/**
+ * Cron cadence — how often a RECURRING question comes around. Think of it as the question's
+ * schedule (a "cron job" for self-reflection). `adhoc` marks a question with no fixed cadence
+ * (ask it when its situation arises). Rendered as a pill with a recurring-cycle icon.
+ */
+export type QuestionCron = 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'yearly' | 'adhoc';
 
 /** A single power may be passed as a bare string; multiple as an array. */
 export type QuestionPowerProp = QuestionPower | QuestionPower[];
@@ -53,7 +60,13 @@ export interface QuestionProps {
   power?: QuestionPowerProp;
   /** Importance tier. Renders as a colored pill. */
   priority?: QuestionPriority;
-  /** Short cadence label for the badge (e.g. "Yearly", "Daily"). The full sentence goes in howOften. */
+  /** Recurring cadence (daily/weekly/monthly/quarterly/yearly/adhoc). Pill + cycle icon. */
+  cron?: QuestionCron;
+  /**
+   * @deprecated Use `cron` instead. Free-text cadence label kept for back-compat: if `cron`
+   * is unset and `frequency` is a recognized cadence word it maps to `cron`; otherwise it
+   * renders as a plain text pill (no icon).
+   */
   frequency?: string;
   /** How much reflection it demands. */
   depth?: QuestionDepth;
@@ -70,7 +83,9 @@ export interface QuestionDetail {
   /** Normalized to an array before dispatch so the modal renders consistently. */
   power?: QuestionPower[];
   priority?: QuestionPriority;
-  frequency?: string;
+  cron?: QuestionCron;
+  /** Free-text fallback when `frequency` wasn't a recognized cadence word (no icon). */
+  frequencyText?: string;
   depth?: QuestionDepth;
 }
 
@@ -91,24 +106,69 @@ const POWER_META: Record<QuestionPower, {Icon: IconType; name: string; label: st
 /** Stable render order regardless of the order props are passed in. */
 const POWER_ORDER: QuestionPower[] = ['spark', 'fire', 'chisel', 'anvil'];
 
-const PRIORITY_META: Record<QuestionPriority, string> = {
-  core: 'Core',
-  high: 'High',
-  medium: 'Medium',
-  low: 'Low',
+const PRIORITY_META: Record<QuestionPriority, {label: string; gloss: string}> = {
+  core: {label: 'Core', gloss: 'A foundational question; everything else builds on it'},
+  high: {label: 'High', gloss: 'Important; worth returning to often'},
+  medium: {label: 'Medium', gloss: 'Useful, but not foundational'},
+  low: {label: 'Low', gloss: 'A lighter question; ask it when it fits'},
 };
 
-const DEPTH_META: Record<QuestionDepth, string> = {
-  quick: 'Quick',
-  moderate: 'Moderate',
-  deep: 'Deep',
+const DEPTH_META: Record<QuestionDepth, {label: string; gloss: string}> = {
+  quick: {label: 'Quick', gloss: 'A fast gut-check; answer in a moment'},
+  moderate: {label: 'Moderate', gloss: 'Some real reflection required'},
+  deep: {label: 'Deep', gloss: 'Sit with it; this one takes time'},
 };
+
+/** Cron cadence → {label, gloss}. The cycle icon (GiCycle) is shared across all cadences. */
+const CRON_META: Record<QuestionCron, {label: string; gloss: string}> = {
+  daily: {label: 'Daily', gloss: 'Ask every day'},
+  weekly: {label: 'Weekly', gloss: 'Ask every week'},
+  monthly: {label: 'Monthly', gloss: 'Ask every month'},
+  quarterly: {label: 'Quarterly', gloss: 'Ask every quarter'},
+  yearly: {label: 'Yearly', gloss: 'Ask every year'},
+  adhoc: {label: 'As needed', gloss: 'No fixed cadence; ask when it applies'},
+};
+
+const CRON_ORDER: QuestionCron[] = ['daily', 'weekly', 'monthly', 'quarterly', 'yearly', 'adhoc'];
+
+/** Map a free-text `frequency` value to a `cron` cadence when it's a recognized word. */
+function frequencyToCron(freq: string | undefined): QuestionCron | undefined {
+  if (!freq) return undefined;
+  const f = freq.trim().toLowerCase();
+  const direct = (CRON_ORDER as string[]).includes(f) ? (f as QuestionCron) : undefined;
+  if (direct) return direct;
+  const synonyms: Record<string, QuestionCron> = {
+    annually: 'yearly',
+    annual: 'yearly',
+    'every year': 'yearly',
+    'every day': 'daily',
+    'every week': 'weekly',
+    'every month': 'monthly',
+    'every quarter': 'quarterly',
+    'as needed': 'adhoc',
+    'ad hoc': 'adhoc',
+    'ad-hoc': 'adhoc',
+  };
+  return synonyms[f];
+}
 
 function normalizePower(power: QuestionPowerProp | undefined): QuestionPower[] {
   if (!power) return [];
   const arr = Array.isArray(power) ? power : [power];
   // de-dupe + apply a stable order so cards read consistently
   return POWER_ORDER.filter((p) => arr.includes(p));
+}
+
+/** Resolve the cron cadence + any leftover free-text frequency for rendering. */
+function resolveCadence(
+  cron: QuestionCron | undefined,
+  frequency: string | undefined,
+): {cron?: QuestionCron; frequencyText?: string} {
+  if (cron) return {cron};
+  const mapped = frequencyToCron(frequency);
+  if (mapped) return {cron: mapped};
+  if (frequency) return {frequencyText: frequency};
+  return {};
 }
 
 export const QUESTION_MODAL_EVENT = 'bop:question-modal';
@@ -134,47 +194,97 @@ function nodeToText(node: ReactNode): string {
 interface BadgesProps {
   power: QuestionPower[];
   priority?: QuestionPriority;
-  frequency?: string;
+  cron?: QuestionCron;
+  frequencyText?: string;
   depth?: QuestionDepth;
   /** 'card' is compact (icons only, terse pills); 'modal' shows labels. */
   variant: 'card' | 'modal';
 }
 
-function QuestionBadges({power, priority, frequency, depth, variant}: BadgesProps): React.JSX.Element | null {
-  const hasAny = power.length > 0 || priority || frequency || depth;
+function QuestionBadges({
+  power,
+  priority,
+  cron,
+  frequencyText,
+  depth,
+  variant,
+}: BadgesProps): React.JSX.Element | null {
+  const hasAny = power.length > 0 || priority || cron || frequencyText || depth;
   if (!hasAny) return null;
 
   return (
     <span className={clsx(styles.badges, variant === 'modal' && styles.badgesModal)}>
       {power.map((p) => {
-        const {Icon, label} = POWER_META[p];
+        const {Icon, name, label} = POWER_META[p];
         return (
-          <span
+          <Tooltip
             key={p}
-            className={clsx(styles.powerBadge, styles[`power_${p}`])}
-            title={label}
-            aria-label={label}>
-            <Icon className={styles.powerIcon} aria-hidden="true" />
-            {variant === 'modal' && <span className={styles.powerLabel}>{label}</span>}
-          </span>
+            content={
+              <>
+                <b>Power: {name}</b>
+                <br />
+                {label}
+              </>
+            }>
+            <span className={clsx(styles.powerBadge, styles[`power_${p}`])} aria-label={`Power: ${name}. ${label}`}>
+              <Icon className={styles.powerIcon} aria-hidden="true" />
+              {variant === 'modal' && <span className={styles.powerLabel}>{label}</span>}
+            </span>
+          </Tooltip>
         );
       })}
       {priority && (
-        <span
-          className={clsx(styles.pill, styles[`priority_${priority}`])}
-          title={`Priority: ${PRIORITY_META[priority]}`}>
-          {PRIORITY_META[priority]}
-        </span>
+        <Tooltip
+          content={
+            <>
+              <b>Priority: {PRIORITY_META[priority].label}</b>
+              <br />
+              {PRIORITY_META[priority].gloss}
+            </>
+          }>
+          <span className={clsx(styles.pill, styles[`priority_${priority}`])}>
+            {PRIORITY_META[priority].label}
+          </span>
+        </Tooltip>
       )}
-      {frequency && (
-        <span className={clsx(styles.pill, styles.pillFrequency)} title={`How often: ${frequency}`}>
-          {frequency}
-        </span>
+      {cron && (
+        <Tooltip
+          content={
+            <>
+              <b>Cadence: {CRON_META[cron].label}</b>
+              <br />
+              {CRON_META[cron].gloss}
+            </>
+          }>
+          <span className={clsx(styles.pill, styles.pillCron)}>
+            <GiCycle className={styles.cronIcon} aria-hidden="true" />
+            {CRON_META[cron].label}
+          </span>
+        </Tooltip>
+      )}
+      {!cron && frequencyText && (
+        <Tooltip
+          content={
+            <>
+              <b>How often</b>
+              <br />
+              {frequencyText}
+            </>
+          }>
+          <span className={clsx(styles.pill, styles.pillFrequency)}>{frequencyText}</span>
+        </Tooltip>
       )}
       {depth && (
-        <span className={clsx(styles.pill, styles.pillDepth)} title={`Depth: ${DEPTH_META[depth]}`}>
-          {DEPTH_META[depth]}
-        </span>
+        <Tooltip
+          content={
+            <>
+              <b>Depth: {DEPTH_META[depth].label}</b>
+              <br />
+              {DEPTH_META[depth].gloss}
+            </>
+          }>
+          <span className={clsx(styles.pill, styles.pillDepth)}>{DEPTH_META[depth].label}</span>
+        </Tooltip>
       )}
     </span>
   );
@@ -188,13 +298,16 @@ const Question: React.FC<QuestionProps> = ({
   record,
   power,
   priority,
+  cron,
   frequency,
   depth,
   className,
   style,
 }) => {
   const powers = normalizePower(power);
-  const hasBadges = powers.length > 0 || !!priority || !!frequency || !!depth;
+  const cadence = resolveCadence(cron, frequency);
+  const hasBadges =
+    powers.length > 0 || !!priority || !!cadence.cron || !!cadence.frequencyText || !!depth;
   const hasDetail = !!(why || howOften || when || record) || hasBadges;
 
   const handleClick = useCallback(() => {
@@ -207,10 +320,23 @@ const Question: React.FC<QuestionProps> = ({
       record,
       power: powers,
       priority,
-      frequency,
+      cron: cadence.cron,
+      frequencyText: cadence.frequencyText,
       depth,
     });
-  }, [children, why, howOften, when, record, priority, frequency, depth, powers, hasDetail]);
+  }, [
+    children,
+    why,
+    howOften,
+    when,
+    record,
+    priority,
+    cadence.cron,
+    cadence.frequencyText,
+    depth,
+    powers,
+    hasDetail,
+  ]);
 
   const handleKey = useCallback(
     (e: React.KeyboardEvent) => {
@@ -235,7 +361,8 @@ const Question: React.FC<QuestionProps> = ({
         <QuestionBadges
           power={powers}
           priority={priority}
-          frequency={frequency}
+          cron={cadence.cron}
+          frequencyText={cadence.frequencyText}
           depth={depth}
           variant="card"
         />
@@ -349,7 +476,8 @@ function QuestionModalImpl(): React.JSX.Element | null {
         <QuestionBadges
           power={detail.power ?? []}
           priority={detail.priority}
-          frequency={detail.frequency}
+          cron={detail.cron}
+          frequencyText={detail.frequencyText}
           depth={detail.depth}
           variant="modal"
         />

--- a/packages/blog-ui/src/components/Question/styles.module.css
+++ b/packages/blog-ui/src/components/Question/styles.module.css
@@ -158,6 +158,21 @@
   font-weight: 500;
 }
 
+/* Cron cadence pill — a recurring-cycle icon + the cadence label. */
+.pillCron {
+  gap: 0.3rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary-darker, var(--ifm-color-primary));
+  background: color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 28%, transparent);
+}
+.cronIcon {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
 /* ── PowerLegend ─────────────────────────────────────────────────────── */
 
 .legend {

--- a/packages/blog-ui/src/components/Tooltip/index.tsx
+++ b/packages/blog-ui/src/components/Tooltip/index.tsx
@@ -1,0 +1,68 @@
+import React, {CSSProperties, ReactNode, useCallback, useId, useRef, useState} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * Tooltip — a small, theme-aware hover/focus/tap popover for explaining UI affordances.
+ *
+ * Built for the Question badges (where "Medium" / "Moderate" mean nothing without context),
+ * but generic. Wrap any inline element; `content` is shown on hover, keyboard focus, and tap
+ * (touch toggles it). Accessible: the trigger gets aria-describedby pointing at the bubble.
+ *
+ *   <Tooltip content={<><b>Priority: Medium</b><br/>Moderately foundational.</>}>
+ *     <span className="badge">Medium</span>
+ *   </Tooltip>
+ *
+ * Keep `content` short (a label + one sentence). For a full legend, link to the keystone post.
+ */
+export interface TooltipProps {
+  /** What to show in the bubble. A short node: a bolded label + a sentence works best. */
+  content: ReactNode;
+  children: ReactNode;
+  /** Preferred side. Defaults to 'top'; flips are not computed (keep triggers away from edges). */
+  placement?: 'top' | 'bottom';
+  className?: string;
+  style?: CSSProperties;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({content, children, placement = 'top', className, style}) => {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = useCallback(() => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    setOpen(true);
+  }, []);
+  const hide = useCallback(() => {
+    setOpen(false);
+  }, []);
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  return (
+    <span
+      className={clsx(styles.wrap, className)}
+      style={style}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      onClick={toggle}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') hide();
+      }}
+      tabIndex={0}
+      aria-describedby={open ? id : undefined}>
+      {children}
+      <span
+        id={id}
+        role="tooltip"
+        className={clsx(styles.bubble, styles[placement], open && styles.open)}
+        aria-hidden={!open}>
+        {content}
+      </span>
+    </span>
+  );
+};
+
+export default Tooltip;

--- a/packages/blog-ui/src/components/Tooltip/styles.module.css
+++ b/packages/blog-ui/src/components/Tooltip/styles.module.css
@@ -1,0 +1,81 @@
+/* Tooltip — theme-aware hover/focus/tap popover. */
+
+.wrap {
+  position: relative;
+  display: inline-flex;
+  cursor: help;
+  outline: none;
+}
+.wrap:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.bubble {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  z-index: 50;
+  width: max-content;
+  max-width: 16rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 8px;
+  background: var(--ifm-color-emphasis-900);
+  color: var(--ifm-color-emphasis-0, #fff);
+  font-size: 0.8rem;
+  line-height: 1.35;
+  font-style: normal;
+  font-weight: 400;
+  text-align: left;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.28);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+.bubble b {
+  font-weight: 700;
+}
+
+/* placement */
+.top {
+  bottom: calc(100% + 8px);
+}
+.bottom {
+  top: calc(100% + 8px);
+}
+
+.open {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* little arrow */
+.bubble::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+}
+.top::after {
+  top: 100%;
+  border-top-color: var(--ifm-color-emphasis-900);
+}
+.bottom::after {
+  bottom: 100%;
+  border-bottom-color: var(--ifm-color-emphasis-900);
+}
+
+/* In light mode the emphasis-900 is near-black (good contrast). In dark mode it's near-white,
+   so flip the text color to keep the bubble readable. */
+[data-theme='dark'] .bubble {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-900);
+}
+[data-theme='dark'] .top::after {
+  border-top-color: var(--ifm-color-emphasis-200);
+}
+[data-theme='dark'] .bottom::after {
+  border-bottom-color: var(--ifm-color-emphasis-200);
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -24,6 +24,9 @@ export type {AssumptionProps} from './components/Assumption';
 export {default as SectionBanner} from './components/SectionBanner';
 export type {SectionBannerProps} from './components/SectionBanner';
 
+export {default as Tooltip} from './components/Tooltip';
+export type {TooltipProps} from './components/Tooltip';
+
 export {
   default as Question,
   QuestionModalHost,
@@ -37,5 +40,6 @@ export type {
   QuestionPowerProp,
   QuestionPriority,
   QuestionDepth,
+  QuestionCron,
   PowerLegendProps,
 } from './components/Question';


### PR DESCRIPTION
## What

Two additions to the `Question` badge system, both verified in dev.

### `cron` cadence badge
A recurring-cadence badge (`daily` / `weekly` / `monthly` / `quarterly` / `yearly` / `adhoc`) rendered as a pill with a `GiCycle` recurring icon. Think of it as the question's schedule, a "cron job" for self-reflection.

- **Replaces** the free-text `frequency` prop, kept for back-compat: a recognized cadence word (`"Yearly"`, `"Annually"`, …) maps to `cron`; anything else renders as a plain text pill.

### `Tooltip` (new reusable component)
A theme-aware hover / focus / tap popover. **Every badge is now wrapped in one**, so a reader hovering an ambiguous label sees what it means:

- `Medium` → **"Priority: Medium — Useful, but not foundational"**
- `Moderate` → **"Depth: Moderate — Some real reflection required"**
- the fire icon → **"Power: Fire — A burn that confronts you"**

This directly fixes the "what does Medium/Moderate mean?" confusion. Replaces the native `title=` tooltips. `PRIORITY_META` / `DEPTH_META` gained gloss text to feed it; exported as `Tooltip` from the package.

## Verification

- `yarn build` clean; cron + Tooltip present in dist.
- Dev (`:3000`): cron pill renders with the cycle icon + cadence; hovering any badge shows the styled explanation (screenshots captured during dev). Light/dark hold.

Migrates the PoC post (`questions-for-finding-your-purpose`) from `frequency=` to `cron=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)