### PR TITLE
feat(blog-ui): badge icons + priority-sorted QuestionSection (v0.6.0)

### DIFF
--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -231,7 +231,7 @@ available. NOT for questions in general docs — only introspective/journaling p
 <Question
   power={['fire', 'anvil']}
   priority="core"
-  frequency="Yearly"
+  cron="yearly"
   depth="deep"
   why="Without a clear answer, every decision defaults to what feels comfortable, not what's deepest."
   howOften="Once per year, and any time you feel like you're going through the motions"
@@ -242,6 +242,10 @@ available. NOT for questions in general docs — only introspective/journaling p
 ```
 
 - `children` = the question text (plain string in the card + modal heading).
+- **Every badge dimension now has its own ICON** (so the card scans fast), and every badge
+  is wrapped in a `<Tooltip>` that explains it on hover/focus/tap (e.g. "Priority: Medium —
+  Useful, but not foundational"; "Depth: Deep — Sit with it; this one takes time"). The
+  glosses live in the `*_META` objects in `Question/index.tsx` (single source of truth).
 - **Badge props (all optional):**
   - `power` — the "power of a question" charge(s). One value or an array. The taxonomy
     (a forge metaphor, rendered with `react-icons/gi` SVG glyphs, theme-aware):
@@ -250,10 +254,16 @@ available. NOT for questions in general docs — only introspective/journaling p
     `'chisel'` (GiChisel — carves away what isn't you),
     `'anvil'` (GiAnvil — reshapes who you become). Omit `power` for a calm/no-icon
     question. A question may carry MULTIPLE (e.g. `power={['fire','anvil']}`).
-  - `priority` — `'core' | 'high' | 'medium' | 'low'` (colored pill; core/high stand out).
-  - `frequency` — short cadence label for the badge (e.g. `"Yearly"`, `"Monthly"`,
-    `"In hard stretches"`). The full sentence still goes in `howOften`.
-  - `depth` — `'quick' | 'moderate' | 'deep'` (how much reflection it demands).
+  - `priority` — `'core' | 'high' | 'medium' | 'low'`. Pill + a `LuFlag` (Lucide) flag
+    icon COLORED by tier (red core, orange high, amber medium, grey low).
+  - `cron` — RECURRING cadence: `'daily' | 'weekly' | 'monthly' | 'quarterly' | 'yearly' |
+    'adhoc'`. Pill + a `GiCycle` recurring icon. Think of it as the question's schedule (a
+    "cron job" for self-reflection); `adhoc` = ask when it applies. **`cron` replaces the
+    old free-text `frequency` prop** — `frequency` still works for back-compat (a recognized
+    cadence word maps to `cron`; anything else renders as a plain text pill), but new posts
+    should use `cron`.
+  - `depth` — `'quick' | 'moderate' | 'deep'`. Pill + a `LuBrain` (Lucide) brain icon whose
+    OPACITY scales with depth (faint quick → solid deep).
 - All detail props (`why`, `howOften`, `when`, `record`) are optional; the modal renders
   only the rows with values. A card opens the modal if it has ANY badge or detail.
 - Modal is pub/sub via `CustomEvent('bop:question-modal')`. The `QuestionModalHost` is
@@ -263,6 +273,34 @@ available. NOT for questions in general docs — only introspective/journaling p
   text (no nested JSX) and it will extract cleanly.
 - Registered in `MDXComponents.tsx` — no import needed in `.mdx` blog posts.
 - The file must be `.mdx` (not `.md`).
+
+### QuestionSection (sort a section's questions by priority)
+
+WHAT: a wrapper around the `<Question>` cards under one H2 that renders them sorted by
+`priority` (core > high > medium > low), preserving the authored order WITHIN each tier
+(stable sort). Questions with no `priority` sort last. WHEN: every section in a
+`question-set` post that has 2+ questions — so the reader meets the most-foundational
+questions first. HOW: wrap the section's questions (after the `<SectionBanner>`):
+
+```mdx
+## Core purpose
+
+<SectionBanner why="…" />
+
+<QuestionSection>
+
+<Question priority="high" …>…</Question>
+<Question priority="core" …>…</Question>   {/* renders FIRST despite being authored second */}
+
+</QuestionSection>
+```
+
+- One `<QuestionSection>` per H2 section; never nest, never wrap across an H2 boundary.
+- Put blank lines around the open/close tags so MDX parses the children as blocks.
+- Trailing prose AFTER the last question stays OUTSIDE the wrapper (close right after the
+  last `<Question>`). A pure-prose section (no questions) gets no wrapper.
+- Authors keep writing questions in any order; the component sorts at render time, so you
+  never hand-reorder cards. Registered in `MDXComponents.tsx`.
 
 ### PowerLegend (the canonical power-taxonomy legend)
 
@@ -338,6 +376,18 @@ invalid"). If you add an icon from a new react-icons subpath, it's already cover
 
 ## Learnings log (newest first)
 
+- 2026-06-24 (latest) — **Every badge dimension got an icon + a custom Tooltip, `cron`
+  replaced `frequency`, and `QuestionSection` sorts by priority.** Priority → a `LuFlag`
+  (Lucide) flag colored by tier (red/orange/amber/grey); depth → a `LuBrain` (Lucide) brain
+  whose opacity scales with depth; cron (new, replaces the free-text `frequency`) → a
+  `GiCycle` recurring icon with enum cadences (daily…yearly/adhoc). A reusable `<Tooltip>`
+  component wraps every badge so hovering an ambiguous label ("Medium"/"Moderate") explains
+  it. `<QuestionSection>` wraps a section's cards and stable-sorts them by priority at render
+  time (authors never hand-reorder). Lucide icons import from `react-icons/lu` and bundle the
+  same way as `gi` (the `noExternal` glob already covers all of react-icons). Applied across
+  all 23 question-set posts (badge icons are automatic; QuestionSection wrapping was a
+  per-section edit done by parallel agents). Gotcha: a `{/* JSX comment */}` inside a `/** */`
+  JSDoc block breaks the tsup build — keep example JSX comments out of doc-comments.
 - 2026-06-24 (later) — Added the **badge system** to `Question` (`power`/`priority`/
   `frequency`/`depth`) + the `PowerLegend` component. The "power of a question" taxonomy is a
   forge metaphor rendered with `react-icons/gi` SVG glyphs (spark=GiLightningArc,

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-aligning-actions-with-ambitions.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-aligning-actions-with-ambitions.mdx
@@ -20,6 +20,8 @@ uncomfortable.
 
 <SectionBanner why="My calendar tells the truth my intentions don't. These questions hold my daily actions up against my stated ambitions and name the gap, which is the whole reason the rest of the work exists." />
 
+<QuestionSection>
+
 <Question
   power={['fire', 'anvil']}
   priority="core"
@@ -55,9 +57,13 @@ uncomfortable.
   What are you going to do to be successful?
 </Question>
 
+</QuestionSection>
+
 ## What to stop doing
 
 <SectionBanner why="Progress is often subtraction, not addition. The quiet 'why do I have to do this?' that surfaces when I'm resisting something is a useful signal that it may need to stop, so these questions hunt for what to cut." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -83,9 +89,13 @@ uncomfortable.
   What are you doing that doesn't serve your ambitions? What should you stop doing?
 </Question>
 
+</QuestionSection>
+
 ## What to start doing
 
 <SectionBanner why="The most useful starting questions begin with 'why,' because they surface the thing I keep avoiding. These questions name what I've been putting off and turn it into something I'll actually begin." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'chisel']}
@@ -110,9 +120,13 @@ uncomfortable.
   What should you start doing to align with your ambitions?
 </Question>
 
+</QuestionSection>
+
 ## What to increase doing
 
 <SectionBanner why="Alignment isn't only about stopping and starting; it's also about feeding what's already working. These questions find the things I should simply do more of, especially the gift-developing ones that need more time than they get." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -148,9 +162,13 @@ uncomfortable.
   How will you fully utilize your talents? Are you developing your gifts?
 </Question>
 
+</QuestionSection>
+
 ## Challenging yourself
 
 <SectionBanner why="Alignment without stretch turns into a comfortable rut. These questions check whether I'm actually at the edge of my comfort zone, and whether the pressure I'm putting on myself is the kind that forms a diamond or just wears me down." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -176,9 +194,13 @@ uncomfortable.
   Where and why do you fall short of your expectations? How do you pressure yourself to become a diamond?
 </Question>
 
+</QuestionSection>
+
 ## Progress and purpose alignment
 
 <SectionBanner why="It's possible to be busy, even challenged, and still drifting away from my purpose. These questions zoom out to ask whether all the motion is actually forward, and whether it's pointed at what I'm here to do." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -216,9 +238,13 @@ uncomfortable.
   Are you moving forward, or moving back? Are you making progress, or are you stagnated?
 </Question>
 
+</QuestionSection>
+
 ## Effort and values
 
 <SectionBanner why="Alignment has two tests: am I giving it everything I've got, and does what I'm doing actually reflect what I believe? These questions check both my effort and my integrity at once." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -244,9 +270,13 @@ uncomfortable.
   Do your actions resonate with your values?
 </Question>
 
+</QuestionSection>
+
 ## Intentions
 
 <SectionBanner why="Before action comes intention, and a muddy intention produces scattered action. Naming clearly what I intend to do is what gives everything downstream a direction to point at." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -260,9 +290,13 @@ uncomfortable.
   What are your intentions? What do you intend to do?
 </Question>
 
+</QuestionSection>
+
 ## Taking action
 
 <SectionBanner why="All the reflection only matters if it ends in a move. These questions close the loop: naming the concrete thing I'll do toward my goals and the plan that carries it into tomorrow." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -287,3 +321,5 @@ uncomfortable.
   record="Write tomorrow's specific plan and the one habit or choice the change actually requires">
   What does it take to change, to set a plan for tomorrow?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-challenging-your-own-assumptions.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-challenging-your-own-assumptions.mdx
@@ -21,6 +21,8 @@ make you a little uncomfortable.
 
 <SectionBanner why="Before you can challenge a belief you have to catch it in the act. These questions help me notice where my certainty is sitting so I know where to aim." />
 
+<QuestionSection>
+
 <Question
   priority="medium"
   cron="weekly"
@@ -44,9 +46,13 @@ make you a little uncomfortable.
   What are you assuming right now? What arguments or positions are you currently holding?
 </Question>
 
+</QuestionSection>
+
 ## Challenging your thinking
 
 <SectionBanner why="It is easy to collect evidence that flatters what I already believe. This cluster forces me to go looking for the parts that hurt." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -95,9 +101,13 @@ make you a little uncomfortable.
   Why are you so adhered to your argument?
 </Question>
 
+</QuestionSection>
+
 ## Considering opposing views
 
 <SectionBanner why="The fastest way to test a belief is to genuinely understand its opposite. These questions make me argue the other side as if I meant it." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -145,9 +155,13 @@ make you a little uncomfortable.
   What are the odds of your mind changing through a simple conversation?
 </Question>
 
+</QuestionSection>
+
 ## Examining your reasoning
 
 <SectionBanner why="These overlap on purpose: assumptions, evidence, and error are the three places reasoning quietly fails. Returning to them is a deliberate audit of the foundation." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -182,6 +196,8 @@ make you a little uncomfortable.
   record="Write the most plausible way you're wrong, and what you'd do if you were">
   How might you be wrong about this?
 </Question>
+
+</QuestionSection>
 
 ## Categories worth questioning
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-discovering-your-interests.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-discovering-your-interests.mdx
@@ -20,6 +20,8 @@ problems I keep circling back to.
 
 <SectionBanner why="I can't recite my interests on demand, but my behavior leaks them constantly. These questions read the evidence I'm already producing instead of waiting for a list to appear." />
 
+<QuestionSection>
+
 <Question
   power="spark"
   priority="core"
@@ -54,9 +56,13 @@ problems I keep circling back to.
   How do you make sure you're not overlooking an interest when you take stock?
 </Question>
 
+</QuestionSection>
+
 ## Topics and interests
 
 <SectionBanner why="The obvious layer is still worth naming: what topics actually draw me, and which ones have quietly stopped. Tracking the change tells me where I'm heading." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -92,9 +98,13 @@ problems I keep circling back to.
   What are you interested in tinkering with, learning more about, or checking out?
 </Question>
 
+</QuestionSection>
+
 ## Problems and questions
 
 <SectionBanner why="My deepest interests tend to show up as problems I can't stop poking at. These questions look for the puzzles I'm drawn to solve, which is often the most durable signal." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -131,9 +141,13 @@ problems I keep circling back to.
   What problems spike your curiosity? What kinds of problems do you naturally solve?
 </Question>
 
+</QuestionSection>
+
 ## Resources and tools
 
 <SectionBanner why="What I want to read and which tools I reach for are quiet votes for my interests. These questions surface the resources my curiosity is already pointing at." />
+
+<QuestionSection>
 
 <Question
   priority="low"
@@ -168,9 +182,13 @@ problems I keep circling back to.
   What tools or software components are you interested in using?
 </Question>
 
+</QuestionSection>
+
 ## Projects and research
 
 <SectionBanner why="Projects are where interests get tested against reality. These questions help me pick the ones that pull several threads together and actually move me toward my goals." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -206,9 +224,13 @@ problems I keep circling back to.
   What should you research? What books would help with your projects?
 </Question>
 
+</QuestionSection>
+
 ## Identifying your passions
 
 <SectionBanner why="Passions are interests that have hardened into something I'll return to without prompting. These questions help me tell a real passion apart from a passing enthusiasm." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -257,9 +279,13 @@ problems I keep circling back to.
   projects you've completed?
 </Question>
 
+</QuestionSection>
+
 ## Identifying your hatreds
 
 <SectionBanner why="My aversions point at my interests from the other side. I hate wasting time on redundant work, which is probably exactly why I'm drawn to automation, so what I can't stand is worth reading just as carefully as what I love." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -273,9 +299,13 @@ problems I keep circling back to.
   What do you hate, and what interest does each aversion point at?
 </Question>
 
+</QuestionSection>
+
 ## Activities and themes that recur
 
 <SectionBanner why="When I look across what I keep doing, the themes repeat. I want to build, to identify and solve problems and puzzles. I'm passionate about composing meaning, which may be why I'm pulled toward both engineering and arts and crafts. I like designing things I think are valuable and seeing if they work. Part of my passion is pioneering, mixing and matching ideas, being creative. The recurring theme is structuring and organizing a thinking process so it can help others structure their own thoughts." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -289,9 +319,13 @@ problems I keep circling back to.
   What theme keeps recurring across everything you choose to do?
 </Question>
 
+</QuestionSection>
+
 ## Problems worth dedicating yourself to
 
 <SectionBanner why="Some problems are big enough to organize a life around. These questions stress-test a problem against whether it's truly mine and whether enough people share it to matter." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -339,9 +373,13 @@ problems I keep circling back to.
   How do you evaluate your problems? How many people share them?
 </Question>
 
+</QuestionSection>
+
 ## Narrowing down
 
 <SectionBanner why="Eventually a wide field of interests has to collapse into a direction. These questions help me find the roles, works, and domains where my interests concentrate." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -377,3 +415,5 @@ problems I keep circling back to.
   record="Map your passions to the domains where they fit best">
   What domains most align with your passions?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-facing-your-fears.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-facing-your-fears.mdx
@@ -16,6 +16,8 @@ Fear rarely announces itself honestly. It hides behind hesitation, busyness, and
 
 <SectionBanner why="Most fear runs in the background, unnamed. These questions force me to say out loud what I'm actually afraid of, because a fear I can name is one I can finally examine." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="core"
@@ -64,9 +66,13 @@ Fear rarely announces itself honestly. It hides behind hesitation, busyness, and
   What are you running from?
 </Question>
 
+</QuestionSection>
+
 ## What threatens you
 
 <SectionBanner why="Once I know my fears, I look at what's actually behind them. These questions separate real threats from imagined ones so I can spend my courage where it counts." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -104,9 +110,13 @@ Fear rarely announces itself honestly. It hides behind hesitation, busyness, and
   What threatens your goals and dreams?
 </Question>
 
+</QuestionSection>
+
 ## Overcoming fear
 
 <SectionBanner why="Naming fear is only half the work. This cluster is about the move from fear to action: what dissolves the fear, what I'd do without it, and how I pressure myself to grow through it." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -156,9 +166,13 @@ Fear rarely announces itself honestly. It hides behind hesitation, busyness, and
   How do you move from fear to action?
 </Question>
 
+</QuestionSection>
+
 ## Courage and faith
 
 <SectionBanner why="Courage isn't the absence of fear, it's having something stronger to draw on. These questions find the source of my strength so I can reach for it when sight runs out." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -205,9 +219,13 @@ Fear rarely announces itself honestly. It hides behind hesitation, busyness, and
   What helps you trust the process?
 </Question>
 
+</QuestionSection>
+
 ## Facing opposition
 
 <SectionBanner why="Opposition, rejection, and setbacks are where fear becomes real and unavoidable. These questions prepare me to meet them on purpose instead of being caught off guard." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -243,3 +261,5 @@ Fear rarely announces itself honestly. It hides behind hesitation, busyness, and
   record="Write how you recover from a no, so the fear of one loses its grip">
   How do you handle rejection and setbacks?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-finding-your-purpose.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-finding-your-purpose.mdx
@@ -20,6 +20,8 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
 
 <SectionBanner why="These are the hardest questions to answer and the most important to keep asking. Most people live their whole lives without a clear answer, and that gap shows up as restlessness, drift, and doing things for the wrong reasons." />
 
+<QuestionSection>
+
 <Question
   power={['fire', 'anvil']}
   priority="core"
@@ -56,9 +58,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What's the meaning of your life?
 </Question>
 
+</QuestionSection>
+
 ## What gives you meaning
 
 <SectionBanner why="Knowing what drives you is a navigational tool. When you can name your motivators specifically, you can design your life to include more of them, and notice faster when they're missing." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -84,9 +90,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What gives you the strength to keep going forward?
 </Question>
 
+</QuestionSection>
+
 ## Why you do what you do
 
 <SectionBanner why="Most people act on autopilot: their reasons are inherited, unconscious, or borrowed from someone else. These questions surface the actual drivers so you can decide whether to keep them." />
+
+<QuestionSection>
 
 <Question
   why="Reasons matter because they determine sustainability. You can do anything for a while out of fear, pressure, or habit, but only the things you can articulate real reasons for will survive the hard stretches."
@@ -112,9 +122,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What are your goals, values, convictions, decisions, and plans worth?
 </Question>
 
+</QuestionSection>
+
 ## Legacy and remembrance
 
 <SectionBanner why="Legacy questions are useful not because you should live for posterity, but because they clarify what actually matters to you when you zoom out far enough to escape the noise of the immediate." />
+
+<QuestionSection>
 
 <Question
   why="The refusal to be forgotten is often the most honest signal of what you think your life was for. But it's worth interrogating: do you want to be remembered for who you were, or for what you did? The answer shapes everything."
@@ -140,9 +154,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What difference will you make with the blessings you've been given?
 </Question>
 
+</QuestionSection>
+
 ## Vision and story
 
 <SectionBanner why="You are writing a story whether you intend to or not. These questions ask you to become the author rather than just a character: to choose the arc, not just react to the events." />
+
+<QuestionSection>
 
 <Question
   why="A vision without a story is just a wish. Your story gives your vision context: where it came from, what it cost, who it's for. Most people have neither; the ones who lead something tend to have both."
@@ -176,9 +194,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   Do you believe your story? Is it as valuable as you think it is?
 </Question>
 
+</QuestionSection>
+
 ## Mortality and finite time
 
 <SectionBanner why="Mortality is the sharpest clarifier we have. Not to be morbid, but because the finite nature of time is what makes choices matter at all. These questions use that pressure productively." />
+
+<QuestionSection>
 
 <Question
   why="Most people act as though they have unlimited time. They don't, and deep down they know it. This question confronts the gap between knowing time is limited and actually living that way."
@@ -220,9 +242,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What will remain when you're gone? How does knowing life ends change how you live today?
 </Question>
 
+</QuestionSection>
+
 ## Divine creation and becoming your best
 
 <SectionBanner why="These questions assume that you were made with intention: that your capacity, your gifts, and your potential aren't accidents. Sitting with that assumption raises the stakes in a productive way." />
+
+<QuestionSection>
 
 <Question
   why="This question reframes your existence as purposeful at the source. Even if you're uncertain about faith, the question is useful: what would it mean to live as though you were made for something specific? The answer changes how you use your time."
@@ -264,9 +290,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What would the best version of you look like? What's stopping you from becoming who you were meant to be?
 </Question>
 
+</QuestionSection>
+
 ## Discovering your calling
 
 <SectionBanner why="Calling isn't usually announced; it's discovered by noticing patterns. What you keep returning to, what you can't help caring about, what feels effortless to you and impossible to others: these are the signals. These questions help you read them." />
+
+<QuestionSection>
 
 <Question
   why="'Better than everyone else' sounds arrogant, but it's a useful thought experiment. Not literally, but what is it that you bring that's yours? What have you cultivated that others haven't? That asymmetry often points to calling."
@@ -316,9 +346,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What is your sweet spot? What does the world demand?
 </Question>
 
+</QuestionSection>
+
 ## Believing in purpose
 
 <SectionBanner why="Purpose requires belief to become action. If you don't believe your life is for something, you won't do the hard work of finding out what. These questions check whether your beliefs are actually load-bearing." />
+
+<QuestionSection>
 
 <Question
   why="Belief shapes action more than information does. What you believe is possible determines what you attempt. Luck favoring the believers isn't superstition; it's the observation that people who believe in something take more shots and persist longer."
@@ -352,9 +386,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   How many times are you ready to fail?
 </Question>
 
+</QuestionSection>
+
 ## Championing a cause
 
 <SectionBanner why="A cause is bigger than a goal. It's what you're for in the world: what you'd put your name on, what you'd sacrifice for. These questions ask whether you've found yours." />
+
+<QuestionSection>
 
 <Question
   why="A cause you champion is different from a cause you agree with. Championing means actively advancing it, with time, voice, and resources. Most people have opinions about causes; fewer have commitments. This question checks which category you're in."
@@ -380,9 +418,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What will excite the human spirit of those around you?
 </Question>
 
+</QuestionSection>
+
 ## Knowing you're getting closer
 
 <SectionBanner why="Purpose isn't just about finding it; it's about tracking it. These questions build a feedback loop so you can tell when you're aligned and when you've drifted, rather than waiting for the feeling to hit you." />
+
+<QuestionSection>
 
 <Question
   why="Without signals, you're navigating blind. This question asks you to define what alignment feels like so you can notice it when it's happening and notice its absence when it's not."
@@ -424,9 +466,13 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   When should you stop seeking purpose?
 </Question>
 
+</QuestionSection>
+
 ## Avoiding regret
 
 <SectionBanner why="Regret is information about what actually mattered to you. These questions use the threat of regret as a forward-looking tool, not to generate anxiety, but to clarify what deserves your effort now." />
+
+<QuestionSection>
 
 <Question
   why="Skills that live only in you and die with you are gifts withheld from the world. This question is a sharp form of accountability: what have you developed that no one else will ever benefit from if you don't act?"
@@ -452,6 +498,8 @@ meaning, and how you want to be remembered. Pick the ones that sting a little.
   What do you not want to be?
 </Question>
 
+</QuestionSection>
+
 ## Listening to your inner voice
 
 <SectionBanner why="Your inner life is constantly giving you information about whether you're aligned with your purpose. The problem isn't that the signal is absent; it's that most people have never learned to read it." />
@@ -464,6 +512,8 @@ it, is most of the work.
 ## Understanding your uniqueness
 
 <SectionBanner why="Your uniqueness isn't about being special; it's about being irreplaceable in a specific way. These questions help you identify the signature you leave on everything you touch, which is the practical definition of your calling." />
+
+<QuestionSection>
 
 <Question
   why="Transcribing a message means you're a conduit for something specific, not just a content producer. What others feel in your presence is a signal about what you're actually communicating beneath the words. Both questions point to your signature."
@@ -497,11 +547,15 @@ it, is most of the work.
   In what can you truly say "there will never be anyone else like me"?
 </Question>
 
+</QuestionSection>
+
 The people who are closest to their nature will lead the world.
 
 ## Purifying intentions
 
 <SectionBanner why="Motivation matters even when the action is good. These questions check whether you're doing what you do for the right reasons, because the reason determines what the work costs you and what it actually produces." />
+
+<QuestionSection>
 
 <Question
   why="Service for reciprocity is transactional, and will eventually disappoint. Service for legacy is ego-driven, and leads to burnout or resentment when the recognition doesn't come. Purifying intention means finding the reason to serve that doesn't depend on a return."
@@ -518,3 +572,5 @@ The people who are closest to their nature will lead the world.
   record="Write the layers: the surface reason and what you find when you keep digging. The deepest honest answer is the one worth acting from.">
   Why do I do what I do? As I dig deeper into my purpose, I become more aware of the things I do, and why.
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-growing-yourself.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-growing-yourself.mdx
@@ -16,6 +16,8 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
 
 <SectionBanner why="Growth starts as a posture before it shows up as progress. These questions check whether I actually want to get better, or just want to feel like I am." />
 
+<QuestionSection>
+
 <Question
   power="spark"
   priority="core"
@@ -63,9 +65,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   When it's all over, will you walk away with more than what you had?
 </Question>
 
+</QuestionSection>
+
 ## Reaching your potential
 
 <SectionBanner why="There's a gap between what I'm capable of and what I'm actually doing. These questions press on that gap, because unused potential is the quietest kind of regret." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -114,9 +120,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   What good are you if the problems you live to solve today will be solved tomorrow?
 </Question>
 
+</QuestionSection>
+
 ## Investing in yourself
 
 <SectionBanner why="Growth requires deliberate inputs, not just effort. These questions audit what I'm actually putting into myself: knowledge, techniques, and the results I'm aiming at." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -162,9 +172,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   What results are you looking for?
 </Question>
 
+</QuestionSection>
+
 ## Self-knowledge for growth
 
 <SectionBanner why="I can't grow well in a direction I don't understand about myself. These questions map how I'm wired so I can build on my real strengths and values." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -212,9 +226,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   What is your velocity?
 </Question>
 
+</QuestionSection>
+
 ## Learning from masters
 
 <SectionBanner why="I don't have to invent the path. These questions point me at the people who already walked it, so I can borrow their methods instead of rediscovering them slowly." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -238,9 +256,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   Who has mastered what you're trying to learn?
 </Question>
 
+</QuestionSection>
+
 ## Measuring growth
 
 <SectionBanner why="Growth I can't measure is growth I can't trust. These questions look for hard evidence that I'm improving rather than just the comfortable feeling of it." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -276,9 +298,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   Have you automated your personal experimentation process?
 </Question>
 
+</QuestionSection>
+
 ## The growth journey
 
 <SectionBanner why="Two things keep me steady over the long haul: learning compounds like interest, so small consistent gains become large, and the visible competitions are the easy part while the real work happens behind the scenes. These questions keep me focused on that quiet, compounding work." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -303,9 +329,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   How do you grow? How do things grow?
 </Question>
 
+</QuestionSection>
+
 ## Acknowledging limits
 
 <SectionBanner why="Honest growth starts with an honest map of what I don't know. These questions keep me humble about the edges of my knowledge so I don't build on ground that isn't there." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -342,9 +372,13 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   Are you acknowledging the limits of your actions?
 </Question>
 
+</QuestionSection>
+
 ## Key growth questions
 
 <SectionBanner why="These are the questions I keep coming back to, the ones that most reliably move me forward. They turn the whole reflection into a concrete focus for what to learn next." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -391,3 +425,5 @@ Growth is easy to assume and hard to verify. It's possible to stay busy for year
   record="Write honestly whether you're maxing out what you actually have">
   Are you doing everything you can with what you have?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-improving-how-you-operate.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-improving-how-you-operate.mdx
@@ -19,6 +19,8 @@ them, reuse what works, and retire what doesn't. Pick a section and sit with it.
 
 <SectionBanner why="The methods you run on are usually invisible until you name them. Putting language to how you actually operate is the first step to improving any of it." />
 
+<QuestionSection>
+
 <Question
   priority="high"
   cron="quarterly"
@@ -75,9 +77,13 @@ them, reuse what works, and retire what doesn't. Pick a section and sit with it.
   How do you understand questions?
 </Question>
 
+</QuestionSection>
+
 ## Reusing and learning from the past
 
 <SectionBanner why="Solutions you already found are wasted if you can't find them again. This section is about building a memory you can actually draw on." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -112,9 +118,13 @@ them, reuse what works, and retire what doesn't. Pick a section and sit with it.
   How often will you re-evaluate your previous solutions?
 </Question>
 
+</QuestionSection>
+
 ## Process evaluation
 
 <SectionBanner why="A process is only worth keeping if it earns its place. These questions audit what you run on so you can add what's missing and drop what's dead weight." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -172,9 +182,13 @@ them, reuse what works, and retire what doesn't. Pick a section and sit with it.
   What is your plan of action, your process for coming into action?
 </Question>
 
+</QuestionSection>
+
 ## Artifacts and constraints
 
 <SectionBanner why="A good process leaves something behind and runs inside limits. Naming the outputs and the boundaries keeps your methods grounded in something real." />
+
+<QuestionSection>
 
 <Question
   priority="low"
@@ -198,9 +212,13 @@ them, reuse what works, and retire what doesn't. Pick a section and sit with it.
   What constraints will you impose on your process?
 </Question>
 
+</QuestionSection>
+
 ## Automation
 
 <SectionBanner why="Anything you do over and over by hand is a candidate for handing off to a system. This is where you reclaim time you didn't know you were spending." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -213,3 +231,5 @@ them, reuse what works, and retire what doesn't. Pick a section and sit with it.
   record="List the repeating actions and which one is worth automating first">
   What actions repeat in your life that you can automate?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-what-you-want.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-what-you-want.mdx
@@ -19,6 +19,8 @@ getting at. I sit with the ones that make me uncomfortable.
 
 <SectionBanner why="Before I can chase anything well, I have to know what I actually want, and just as importantly what I don't. Naming both ends keeps me from spending a life pursuing things I never chose." />
 
+<QuestionSection>
+
 <Question
   power={['fire', 'chisel']}
   priority="core"
@@ -54,9 +56,13 @@ getting at. I sit with the ones that make me uncomfortable.
   What would you rather have?
 </Question>
 
+</QuestionSection>
+
 ## What you're chasing
 
 <SectionBanner why="There's a difference between what I claim to want and what I'm actually running toward all day. These questions catch what's really pulling me, including the infatuations and turn-offs I don't usually admit." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -93,9 +99,13 @@ getting at. I sit with the ones that make me uncomfortable.
   What's got you turned on? What's got you turned off?
 </Question>
 
+</QuestionSection>
+
 ## Regrets and wishes
 
 <SectionBanner why="Future regret is information about what actually matters to me, arriving early enough to do something about it. These questions borrow my deathbed perspective and bring it back to today." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -133,9 +143,13 @@ getting at. I sit with the ones that make me uncomfortable.
   What would you regret not pursuing?
 </Question>
 
+</QuestionSection>
+
 ## Dreams and aspirations
 
 <SectionBanner why="Dreams point further than goals, and they carry a feeling I want others to share. These questions ask not just where I want to end up but whether I'm actually living toward it or just longing for it." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -173,9 +187,13 @@ getting at. I sit with the ones that make me uncomfortable.
   Are you crying for a dream? Are you living your ideal life?
 </Question>
 
+</QuestionSection>
+
 ## Emotions and triggers
 
 <SectionBanner why="My strongest emotional reactions are arrows pointing at what I care about. What moves me to tears or sends a chill through me reveals desires my rational answers tend to hide." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -201,9 +219,13 @@ getting at. I sit with the ones that make me uncomfortable.
   What gives you the chills? What sends shivers down your spine?
 </Question>
 
+</QuestionSection>
+
 ## Mastery and likes
 
 <SectionBanner why="Wanting to be good at something and being willing to pay for it are two different things. These questions separate what I'd like to master from what I'm actually ready to sacrifice for, and remind me to notice the small likes too." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -240,9 +262,13 @@ getting at. I sit with the ones that make me uncomfortable.
   What are the things you like?
 </Question>
 
+</QuestionSection>
+
 ## Infatuation and bliss
 
 <SectionBanner why="The clearest sign I'm pointed at the right thing is the feeling of being lost in it. These questions check whether what I do actually absorbs me, or whether I just think it should." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -278,3 +304,5 @@ getting at. I sit with the ones that make me uncomfortable.
   record="List what actually made me happy recently, not what I think should have">
   What makes you happy?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-who-you-are.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-knowing-who-you-are.mdx
@@ -19,6 +19,8 @@ emotions quietly steering me, and the story I keep feeding myself.
 
 <SectionBanner why="If I can't name who I am in plain terms, every other answer rests on sand. Getting a working definition of myself is the foundation everything else builds on." />
 
+<QuestionSection>
+
 <Question
   power={['fire', 'anvil']}
   priority="core"
@@ -43,9 +45,13 @@ emotions quietly steering me, and the story I keep feeding myself.
   How do you define yourself? What is the gist of you? What is your reality?
 </Question>
 
+</QuestionSection>
+
 ## Examining your character
 
 <SectionBanner why="Character is what's left when the performance stops, and the story I tell myself about myself quietly becomes that character. Watching the inner dialog is how I stay the author of it instead of the product of it." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -71,11 +77,15 @@ emotions quietly steering me, and the story I keep feeding myself.
   What story do you feed yourself?
 </Question>
 
+</QuestionSection>
+
 Pay attention to your inner dialog. It's writing you whether you watch it or not.
 
 ## Values and beliefs
 
 <SectionBanner why="My values and beliefs are the code my decisions quietly run on. Making them explicit lets me update them on purpose instead of being governed by ones I inherited by accident." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -111,9 +121,13 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   Will your thoughts and beliefs matter in 100 years?
 </Question>
 
+</QuestionSection>
+
 ## What controls and shapes you
 
 <SectionBanner why="I'm being steered by needs, fears, and constraints I didn't consciously choose, and some of them I've gotten too comfortable inside. Naming what controls me is the first step to deciding what I'll actually allow." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -162,9 +176,13 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   Why have you gotten comfortable in the darkness?
 </Question>
 
+</QuestionSection>
+
 ## Becoming self-aware
 
 <SectionBanner why="Self-awareness is the one study I keep postponing on the subject I know least. These questions push me to start the work and to define what 'aware' would even look like, so it's a destination and not a vague intention." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -201,9 +219,13 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   How do you become self-aware? What must you do to declare yourself self-aware? What is your process for reaching a full state of self-awareness, and what are its different states?
 </Question>
 
+</QuestionSection>
+
 ## Capturing the essentials
 
 <SectionBanner why="Sometimes I need a fast inventory of myself instead of a deep dive: what I think about, what I'm good at, what stops me, and how I get past it. This compact battery takes that snapshot quickly." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -239,9 +261,13 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   What are your obstacles? What motivates you? What thoughts push you past your obstacles? You can overcome thought X by remembering thought Y. How can you manage your emotions?
 </Question>
 
+</QuestionSection>
+
 ## Learning about yourself through what's around you
 
 <SectionBanner why="I'm not the only mirror I have. Watching society, nature, and the divine reflects parts of me back that I can't see from the inside, and that outside view often teaches me more about myself than introspection alone." />
+
+<QuestionSection>
 
 <Question
   priority="low"
@@ -266,9 +292,13 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   How can you learn more about yourself from God? How does that push you to become more self-aware? Do you minimally reflect any of the 99 names of God?
 </Question>
 
+</QuestionSection>
+
 ## "I am" statements
 
 <SectionBanner why="The way I finish 'I am' and 'I will' quietly declares my identity, and I can be guessed by it. Checking whether those statements line up with what I claim to be passionate about is how I tell who I really am from who I say I am." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -294,9 +324,13 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   Can you guess who you are based on your "I am's" and your "I will's"? Do your "I am" statements align with what you believe your passion is?
 </Question>
 
+</QuestionSection>
+
 ## Manifesting your beliefs
 
 <SectionBanner why="Beliefs that stay inside my head don't shape anything. These questions push me to encode what I believe into something tangible, because the act of making values real is where identity stops being a feeling and starts being a contribution." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -321,3 +355,5 @@ Pay attention to your inner dialog. It's writing you whether you watch it or not
   record="For each core belief, name one tangible thing it has produced or will produce">
   We have an opportunity to encode our beliefs, to make our values tangible. How will you do that?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-making-better-decisions.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-making-better-decisions.mdx
@@ -20,6 +20,8 @@ you pause.
 
 <SectionBanner why="The decisions already behind you are the cheapest data you have. Looking back deliberately is what turns a finished choice into a lesson." />
 
+<QuestionSection>
+
 <Question
   priority="medium"
   cron="monthly"
@@ -54,9 +56,13 @@ you pause.
   Which decisions had the biggest impact on your life?
 </Question>
 
+</QuestionSection>
+
 ## Understanding outcomes
 
 <SectionBanner why="A decision and its outcome are two different things. Studying how a call actually played out is how you keep your expectations honest." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -92,9 +98,13 @@ you pause.
   Was the outcome due to good decision-making or luck?
 </Question>
 
+</QuestionSection>
+
 ## Learning from decisions
 
 <SectionBanner why="A decision you don't learn from is one you'll likely repeat. These questions extract the lesson while the experience is still warm." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -130,9 +140,13 @@ you pause.
   Was your reasoning sound even if the outcome wasn't?
 </Question>
 
+</QuestionSection>
+
 ## Decision patterns
 
 <SectionBanner why="Your worst decisions tend to rhyme. Spotting the recurring shape of how you decide is how you stop repeating the same mistake in new clothes." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -180,9 +194,13 @@ you pause.
   When do you make your best decisions? Your worst?
 </Question>
 
+</QuestionSection>
+
 ## Processing regrets
 
 <SectionBanner why="Regret is information about what mattered to you, but it can also become a weight you carry past its usefulness. These questions mine the lesson and then let the rest go." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -231,9 +249,13 @@ you pause.
   Are you holding onto regret that's no longer serving you?
 </Question>
 
+</QuestionSection>
+
 ## Decision quality over time
 
 <SectionBanner why="The real measure isn't any single decision; it's whether you're getting better at deciding. These questions track the trend line." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -257,9 +279,13 @@ you pause.
   What types of decisions are you good at? Which do you struggle with?
 </Question>
 
+</QuestionSection>
+
 ## Reversals and course corrections
 
 <SectionBanner why="Changing your mind is a skill, not a failure. These questions examine whether your reversals were wise and whether your timing on them was right." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -295,9 +321,13 @@ you pause.
   How do you know when to stay the course versus change direction?
 </Question>
 
+</QuestionSection>
+
 ## Decisions avoided
 
 <SectionBanner why="The decisions you keep dodging cost you quietly, every day they stay open. These questions drag the avoided ones into the light." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -334,9 +364,13 @@ you pause.
   What would help you move forward?
 </Question>
 
+</QuestionSection>
+
 ## Involving others, in retrospect
 
 <SectionBanner why="Who you brought in, and whether you actually listened, shapes outcomes as much as the call itself. These questions audit how you used the people around you." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -371,3 +405,5 @@ you pause.
   record="Note how each person's input moved the outcome, for better or worse">
   How did others' input affect the outcome?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-managing-your-emotions.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-managing-your-emotions.mdx
@@ -16,6 +16,8 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
 
 <SectionBanner why="Before I can manage a feeling I have to know what it is and where it came from. These questions name the emotion and find its trigger, which is the start of any real regulation." />
 
+<QuestionSection>
+
 <Question
   priority="core"
   cron="adhoc"
@@ -72,9 +74,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   What role do emotions play in my prayers?
 </Question>
 
+</QuestionSection>
+
 ## Directing your emotions (fuel vs. overcome)
 
 <SectionBanner why="Not every feeling should be suppressed and not every feeling should be obeyed. These questions sort my emotions into fuel to lean into and weight to overcome." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -124,9 +130,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   What feelings do I REFUSE to endure once more?
 </Question>
 
+</QuestionSection>
+
 ## Controlling your emotions
 
 <SectionBanner why="Regulation is a skill, not a mood. These questions are about the actual mechanics of influencing my own emotional state, including the hard ones like sorrow." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -151,9 +161,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   How do I overcome my sorrow?
 </Question>
 
+</QuestionSection>
+
 ## When you feel frustrated
 
 <SectionBanner why="Frustration is a signal pointing at something specific. These questions name what's actually frustrating me so I can address the cause instead of stewing in the feeling." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -201,9 +215,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   How do I overcome these feelings?
 </Question>
 
+</QuestionSection>
+
 ## When you feel like giving up
 
 <SectionBanner why="At the edge of quitting, the right question can tip me back. These questions test whether the hope and the conviction are really gone, or just buried under fatigue." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -241,9 +259,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   What would make me want to continue?
 </Question>
 
+</QuestionSection>
+
 ## When you feel like speaking out
 
 <SectionBanner why="Strong feelings often demand to be voiced, but not every expression helps. These questions check whether speaking out serves a purpose before I let the feeling do the talking." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -279,9 +301,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   Will speaking out serve a positive purpose?
 </Question>
 
+</QuestionSection>
+
 ## Conducting others' emotions
 
 <SectionBanner why="My emotions don't stay inside me; they shape the people around me. These questions ask me to be intentional about the emotional journey I lead others through." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -328,9 +354,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   How do you mold the emotions of others?
 </Question>
 
+</QuestionSection>
+
 ## Overcoming fear
 
 <SectionBanner why="Fear masquerades as caution and shrinks my life one avoidance at a time. These questions confront whether fear is quietly running my days and stopping me from starting." />
+
+<QuestionSection>
 
 > You are given an opportunity. You can deny it because you're afraid, afraid that you're too young, afraid of the unknown. Or you can take it. This is your choice.
 
@@ -358,9 +388,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   What are you afraid to do? Are you afraid to get started?
 </Question>
 
+</QuestionSection>
+
 ## Overcoming negative emotions
 
 <SectionBanner why="Negative emotions accumulate fastest when I don't track them. These questions and their specific subtypes build a strategy for facing each one head on instead of absorbing them silently." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -498,9 +532,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   Do I lose track of where I am, unsure how many rakas I've prayed?
 </Question>
 
+</QuestionSection>
+
 ## Tracking your emotions
 
 <SectionBanner why="What gets tracked gets managed. These questions pick the few emotions most worth measuring so I don't try to track everything and end up tracking nothing." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -525,9 +563,13 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   What are the THREE things I should track, ranked by importance, with regard to the negative feelings I want to minimize in my life?
 </Question>
 
+</QuestionSection>
+
 ## Staying optimistic
 
 <SectionBanner why="Optimism is partly a discipline of what I let into my mind and what I deliberately amplify. These questions guard the gate against negative thoughts and turn up the positive ones on purpose." />
+
+<QuestionSection>
 
 ### Purging negative thoughts
 
@@ -580,6 +622,8 @@ Your emotions are signals, and they are also fuel. The skill is learning which f
   record="Collect the empowering words and phrases that actually shift your state">
   How do I leverage empowering words?
 </Question>
+
+</QuestionSection>
 
 ## Further reading
 

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-measuring-your-progress.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-measuring-your-progress.mdx
@@ -16,6 +16,8 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
 
 <SectionBanner why="Potential is the gap between who you are and who you could be. These questions check whether you're actually moving across that gap or just standing at its edge." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="high"
@@ -64,9 +66,13 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   Do you know where you are going?
 </Question>
 
+</QuestionSection>
+
 ## Accomplishments
 
 <SectionBanner why="What you've actually done is the hard evidence of progress. These questions take stock of the ground you've covered and how much remains." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -114,9 +120,13 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   What obstacles have you overcome?
 </Question>
 
+</QuestionSection>
+
 ## Winning and losing
 
 <SectionBanner why="You can't tell whether you're winning if you've never defined the game or kept score. These questions force the scoreboard into view." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -166,9 +176,13 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   How do you celebrate?
 </Question>
 
+</QuestionSection>
+
 ## Readiness and will
 
 <SectionBanner why="Skill gets you to the starting line, but will is what carries you through the grind. These questions test whether you have the stomach for what progress actually demands." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -218,9 +232,13 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   Are you letting something out of your control control you?
 </Question>
 
+</QuestionSection>
+
 ## Readiness to change
 
 <SectionBanner why="Real change starts with deciding you're ready for it. These questions ask whether you've actually committed to the shift or are still circling it." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -258,9 +276,13 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   Are you ready to change your life?
 </Question>
 
+</QuestionSection>
+
 ## Waking up excited
 
 <SectionBanner why="How you feel when you wake up is a daily readout on whether your work and your life are aligned. These questions check that signal." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -298,9 +320,13 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   Do you wake up itching to work every day?
 </Question>
 
+</QuestionSection>
+
 ## Goal achievement and tracking
 
 <SectionBanner why="Progress you don't track is progress you can't trust. These questions build the measurement loop that turns effort into evidence." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -346,3 +372,5 @@ Progress is easy to assume and hard to measure. It's worth stopping every so oft
   record="Note the failures you've already turned into forward steps">
   Have you begun failing your way to success?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-what-youre-learning.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-what-youre-learning.mdx
@@ -16,6 +16,8 @@ It's easy to keep learning and never stop to ask whether you're learning the rig
 
 <SectionBanner why="It's easy to keep learning and never ask whether you're learning the right things. These questions point your studying at who you actually want to become." />
 
+<QuestionSection>
+
 <Question
   priority="medium"
   cron="weekly"
@@ -74,9 +76,13 @@ It's easy to keep learning and never stop to ask whether you're learning the rig
   How do you ensure you are learning things that fulfill what you want to become?
 </Question>
 
+</QuestionSection>
+
 ## Education focus
 
 <SectionBanner why="Attention is finite, so what you choose to study is itself a decision worth making well. These questions help you aim your education instead of scattering it." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -112,9 +118,13 @@ It's easy to keep learning and never stop to ask whether you're learning the rig
   What subjects do you enjoy learning about?
 </Question>
 
+</QuestionSection>
+
 ## Growth areas and shortcomings
 
 <SectionBanner why="The gaps you avoid looking at are the ones that hold you back the most. These questions name what you'd rather not, so you can actually work on it." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -162,9 +172,13 @@ It's easy to keep learning and never stop to ask whether you're learning the rig
   What are your gaps? What are your shortcomings?
 </Question>
 
+</QuestionSection>
+
 ## Learning style
 
 <SectionBanner why="How you learn best shapes how fast and how deeply you learn at all. Knowing your style lets you stop fighting your own wiring." />
+
+<QuestionSection>
 
 <Question
   priority="low"
@@ -177,9 +191,13 @@ It's easy to keep learning and never stop to ask whether you're learning the rig
   What is your learning style?
 </Question>
 
+</QuestionSection>
+
 ## Capturing realizations
 
 <SectionBanner why="Insights are easy to have and easy to lose. These questions are about catching your realizations before they slip away unrecorded." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -214,3 +232,5 @@ It's easy to keep learning and never stop to ask whether you're learning the rig
   record="Write the insight each experience produced, not just what happened">
   What insights have emerged from your experiences?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-priorities.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-priorities.mdx
@@ -16,6 +16,8 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
 
 <SectionBanner why="Naming what matters right now is the anchor for everything else. If I can't say my top priorities out loud, my calendar will fill itself with whatever shouts loudest." />
 
+<QuestionSection>
+
 <Question
   priority="high"
   cron="weekly"
@@ -49,9 +51,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   What areas of growth have you prioritized?
 </Question>
 
+</QuestionSection>
+
 ## Time allocation
 
 <SectionBanner why="A priority you don't fund with time is just a preference. This section checks whether my hours line up with what I claim matters, and forces the today-versus-eventually split." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -87,9 +93,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   What needs to be done today to enable tomorrow?
 </Question>
 
+</QuestionSection>
+
 ## Priority shifts
 
 <SectionBanner why="Priorities change, and pretending they don't is how stale goals keep eating my time. This section makes the changes explicit so I can act on them instead of drifting." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -136,9 +146,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   What goals are you ignoring?
 </Question>
 
+</QuestionSection>
+
 ## Task prioritization
 
 <SectionBanner why="Not all tasks are equal, and the ones that pay off aren't always the ones I want to do. This section sorts the high-value work from the merely appealing." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -173,9 +187,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   Are you ignoring any tasks? Are you keeping up with them?
 </Question>
 
+</QuestionSection>
+
 ## Learning priorities
 
 <SectionBanner why="Learning is a priority that's easy to defer because nothing breaks when I skip it. Naming what I should be learning keeps growth from being the thing that always gets cut." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -210,9 +228,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   What do you need to learn to expand your mind?
 </Question>
 
+</QuestionSection>
+
 ## Goals and plans
 
 <SectionBanner why="A goal without a plan stays a hope. This section pushes each goal toward the concrete: the projects, the timing, and the reasons behind them." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -258,9 +280,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   Why and when are you going to do something?
 </Question>
 
+</QuestionSection>
+
 ## Weekly planning
 
 <SectionBanner why="The weekly ritual is the heartbeat of staying on track. Without a repeatable rhythm, planning happens only in crisis, which is too late to matter." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -284,9 +310,13 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   What are this week's goals?
 </Question>
 
+</QuestionSection>
+
 ## Quests and dreams
 
 <SectionBanner why="Beneath the weekly tasks are the bigger things I'm actually chasing. To achieve my goals and my dreams, I set out on quests, and these questions keep those quests in view." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -323,3 +353,5 @@ Priorities drift quietly. What mattered last month keeps occupying my calendar l
   record="Write what you want to become and what you want to master; revisit it across years">
   What do you want to become? What do you want to master?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-worth.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-reflecting-on-your-worth.mdx
@@ -19,6 +19,8 @@ rather than a flattering one. I pick the ones that make me pause before I answer
 
 <SectionBanner why="Before I can grow my worth, I have to be able to assess it honestly, without inflating or deflating it. These questions ask for a clear-eyed read on what actually makes me valuable." />
 
+<QuestionSection>
+
 <Question
   power={['fire', 'chisel']}
   priority="core"
@@ -54,9 +56,13 @@ rather than a flattering one. I pick the ones that make me pause before I answer
   What are your most impressive skills?
 </Question>
 
+</QuestionSection>
+
 ## How you add value
 
 <SectionBanner why="Worth isn't a static number; it's something I produce by adding value to specific people and places. These questions push me from 'what am I worth' to 'how, where, and to whom do I actually create value.'" />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -92,9 +98,13 @@ rather than a flattering one. I pick the ones that make me pause before I answer
   How are you valuable to yourself? To society?
 </Question>
 
+</QuestionSection>
+
 ## Your impact on others
 
 <SectionBanner why="A real measure of my worth is the change I leave in other people's heads and hearts. These questions ask me to be deliberate about the thoughts and feelings I want to invoke, instead of leaving my effect on people to chance." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -131,9 +141,13 @@ rather than a flattering one. I pick the ones that make me pause before I answer
   How do you want others to see you? How can you affect how others think, feel, and perceive you?
 </Question>
 
+</QuestionSection>
+
 ## Skills and talents
 
 <SectionBanner why="My skills are the raw material of my worth, but only if I know them honestly and develop the right ones. These questions take a real inventory of what I can do and decide where to deepen it." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -182,9 +196,13 @@ rather than a flattering one. I pick the ones that make me pause before I answer
   What qualifies you to teach what you know?
 </Question>
 
+</QuestionSection>
+
 ## Your contribution
 
 <SectionBanner why="Worth measured at different scales looks different: what I give myself, my family, society, and the planet. These questions widen the lens so my contribution isn't only counted in one narrow place." />
+
+<QuestionSection>
 
 <Question
   power={['anvil', 'fire']}
@@ -220,9 +238,13 @@ rather than a flattering one. I pick the ones that make me pause before I answer
   What resources of the world are you utilizing?
 </Question>
 
+</QuestionSection>
+
 ## Taking inventory
 
 <SectionBanner why="Most of my self-assessment is either too flattering or too harsh. These questions ask for a plain, honest inventory: what I actually do well, what I actually know, and what genuinely deserves more of my attention." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -258,3 +280,5 @@ rather than a flattering one. I pick the ones that make me pause before I answer
   record="Pick the one or two areas that most deserve deeper investment, and why">
   What deserves more of your attention to develop further?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-11-questions-for-understanding-your-inaction.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-11-questions-for-understanding-your-inaction.mdx
@@ -19,6 +19,8 @@ just isn't getting done. I read them slowly and answer the ones that make me fli
 
 <SectionBanner why="I can't fix a problem I haven't named. Before any of the why or how, I have to admit plainly what I'm not doing and stop letting it stay vague enough to ignore." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="core"
@@ -55,9 +57,13 @@ just isn't getting done. I read them slowly and answer the ones that make me fli
   When will you start?
 </Question>
 
+</QuestionSection>
+
 ## Barriers preventing action
 
 <SectionBanner why="Some of what stops me is real and removable; some of it is imaginary. These questions sort the genuine barriers from the excuses and ask what would actually have to change for me to move." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -104,9 +110,13 @@ just isn't getting done. I read them slowly and answer the ones that make me fli
   Which of these barriers can actually be removed?
 </Question>
 
+</QuestionSection>
+
 ## Patterns that keep you stuck
 
 <SectionBanner why="My inaction usually isn't a one-off; it's a pattern I repeat. These questions look for the loop itself, including the trap of choosing the safe, logical thing over the meaningful one, and the comfort I've found in staying stuck." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -156,9 +166,13 @@ just isn't getting done. I read them slowly and answer the ones that make me fli
   Why NOT do things?
 </Question>
 
+</QuestionSection>
+
 ## Constraints, self-imposed and external
 
 <SectionBanner why="Some of my limits I built myself and some came from others, and they call for different responses. These questions separate the two and surface the needs and emotions quietly running the whole pattern of inaction." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -194,3 +208,5 @@ just isn't getting done. I read them slowly and answer the ones that make me fli
   record="Write the honest needs, beliefs, and emotions driving the stall, including the ones I'd rather not admit">
   What are the needs, beliefs, and emotions that are controlling you?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-capturing-what-you-could-do.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-capturing-what-you-could-do.mdx
@@ -16,6 +16,8 @@ Before I can decide what to work on now, I have to see the whole field of what I
 
 <SectionBanner why="The first job of capture is to empty my head onto the page. Anything that stays unnamed can't be chosen later, so this section casts the widest possible net before any sorting begins. I record goals in the context of my roles." />
 
+<QuestionSection>
+
 <Question
   priority="medium"
   cron="weekly"
@@ -94,9 +96,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What must be done in order to realize my goals? How many tasks do I have in each objective?
 </Question>
 
+</QuestionSection>
+
 ## Goals by category
 
 <SectionBanner why="Capturing goals one domain at a time keeps any area of life from being silently skipped. Walking the categories deliberately, from career to spiritual, makes the blind spots obvious." />
+
+<QuestionSection>
 
 ### Career
 
@@ -203,9 +209,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What are my spiritual goals? How do I want to grow spiritually?
 </Question>
 
+</QuestionSection>
+
 ## Commitments
 
 <SectionBanner why="Commitments are the goals I've already bound my time to, which makes them the truest signal of my real priorities. This section audits whether what I've committed to still matches what I care about." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -275,9 +285,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What are my annual commitments? What commitments have I made to my family? What commitments have I made to myself? What commitments have I made spiritually?
 </Question>
 
+</QuestionSection>
+
 ## Challenges
 
 <SectionBanner why="I need to consistently create new challenges to keep myself engaged. This section captures the hard things I'm choosing on purpose, because comfortable goals rarely grow me." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -313,9 +327,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What challenges am I facing? What milestones seem hard to reach?
 </Question>
 
+</QuestionSection>
+
 ## Things to build (artifactual outcomes)
 
 <SectionBanner why="Some goals produce a thing I can point at: an app, a site, a document. Capturing those artifacts separately keeps the tangible outputs from getting lost among abstract aims." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -328,9 +346,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What do I want to build/create? What artifacts do I want to produce? What apps, sites, diagrams, or documents do I want to make?
 </Question>
 
+</QuestionSection>
+
 ## Themes
 
 <SectionBanner why="Across all my initiatives, a few recurring themes tend to repeat. Spotting them tells me where my real interests cluster and where my ideas keep coming from." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -344,9 +366,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What themes scale across my initiatives? On what basis do I have ideas? Where do my ideas come from?
 </Question>
 
+</QuestionSection>
+
 ## Why nots
 
 <SectionBanner why="The fastest way to find missed options is to ask why I'm not already doing something. This section deliberately hunts for the things I've overlooked rather than the ones already on the list." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -360,9 +386,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   Why don't I...? What am I NOT doing that I should consider?
 </Question>
 
+</QuestionSection>
+
 ## Reflecting on your initiatives
 
 <SectionBanner why="Once initiatives are captured, they deserve a second look: what goals hide inside them, why I want them, and how they're shifting over time. Capture without reflection just produces a longer list." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -376,9 +406,13 @@ Before I can decide what to work on now, I have to see the whole field of what I
   What goals are hidden in my initiatives? Why do I want to do each of these things? As time has progressed, how are the things I want to work on changing?
 </Question>
 
+</QuestionSection>
+
 ## Identifying projects
 
 <SectionBanner why="A project is a bundle of work with a definite outcome, and it's the unit I actually execute on. This section turns loose ideas and learning objectives into projects worth committing to. Innovating, for me, is taking an idea and merging it with what I'm passionate about until it becomes a project bundle I can work on." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -412,3 +446,5 @@ Before I can decide what to work on now, I have to see the whole field of what I
   record="For each completed project, note which objectives it advanced">
   What objectives were advanced by the projects I have already completed? What objectives have I advanced through my projects?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-deciding-what-to-learn.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-deciding-what-to-learn.mdx
@@ -16,6 +16,8 @@ There is always more to learn than time to learn it. The hard part is not findin
 
 <SectionBanner why="The first step is surfacing everything I might want to learn before judging any of it. Casting a wide net here keeps me from defaulting to whatever's trendy or in front of me." />
 
+<QuestionSection>
+
 <Question
   priority="medium"
   cron="monthly"
@@ -62,9 +64,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   What bundles of knowledge do I want to learn more about? What do I want to study on the side? Should I make a learning catalogue of everything I want to learn?
 </Question>
 
+</QuestionSection>
+
 ## Learning priorities
 
 <SectionBanner why="With the field surfaced, the next job is ordering it. Difficulty estimates and value tell me what to learn first, so I'm not spending my best energy on the least useful thing." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -77,9 +83,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   What are my learning priorities? Which topics have I done before, so I can estimate their level of difficulty? What is most valuable for me to learn first?
 </Question>
 
+</QuestionSection>
+
 ## Your learning plan and curriculum
 
 <SectionBanner why="A plan turns intentions into a path: what I'll learn, by when, and in what order. This section builds the curriculum and the backlog so learning has structure instead of being a pile of bookmarks." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -115,9 +125,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   What is my learning backlog of things I could possibly learn? Which items from my backlog have I actually committed myself to learning?
 </Question>
 
+</QuestionSection>
+
 ## Making time for learning
 
 <SectionBanner why="A plan is worthless without protected time, and learning time is the first thing the day eats. This section is about carving out and reclaiming hours, including the idle ones." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -141,9 +155,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   Could I learn during idle time, the way some people listen to audiobooks while exercising, vacuuming, doing the dishes, or grilling? Can I learn from any material while exercising, or is there a specific kind that sticks better?
 </Question>
 
+</QuestionSection>
+
 ## Learning commitments
 
 <SectionBanner why="A commitment is what turns a plan into something I'm accountable to. This section pins down exactly what I've signed up to learn, how much time per week, and whether I'm keeping up." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -168,9 +186,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   Should I be working on any certifications? Why are certifications important? Are certifications the only milestone that can reflect my level of learning?
 </Question>
 
+</QuestionSection>
+
 ## Overlapping learning with work
 
 <SectionBanner why="The cheapest learning is the kind that overlaps with what I'm already building. This section looks for where work and study can reinforce each other instead of competing for hours." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -184,9 +206,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   How might my learning plan shift based on the opportunities I have to work on different technologies at work? Where can I deliberately overlap what I am learning with what I am building?
 </Question>
 
+</QuestionSection>
+
 ## Consolidating your learning material
 
 <SectionBanner why="Learning material scattered across bookmarks, links, photos, and screenshots is material I'll never actually use. This section is about gathering it all into one place I can return to." />
+
+<QuestionSection>
 
 <Question
   priority="low"
@@ -199,9 +225,13 @@ There is always more to learn than time to learn it. The hard part is not findin
   Where do I capture notes on all the different things I want to learn from? How do I index all of my learning material in one place? Could I categorize my browser bookmarks, consolidate saved links from LinkedIn, gather the photos of books on my phone, and collect screenshots of useful websites?
 </Question>
 
+</QuestionSection>
+
 ## Feeding your curiosity
 
 <SectionBanner why="Underneath all the planning is curiosity, the engine that makes learning sustainable. This section tunes into what I'm actually drawn to right now, because forced learning rarely lasts." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -214,3 +244,5 @@ There is always more to learn than time to learn it. The hard part is not findin
   record="Note what you're curious about now and where it pulls you">
   What am I curious about right now, and what does that push me to learn more about? What are the different kinds of things I want to learn?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-finding-where-to-improve.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-finding-where-to-improve.mdx
@@ -20,6 +20,8 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
 
 <SectionBanner why="I can't fix what I won't name. This section is the honest inventory of where I'm weak, including a concrete checklist of specific areas to rate myself against so the gaps can't hide behind vagueness." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="high"
@@ -55,9 +57,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   Run down a checklist of specific areas and ask honestly where you are weak: Scaling? Performance? Security (SSL/TLS, vulnerability scanning, OAuth)? Agile? Business models? Product offerings? Web dev beyond the basics (CSS)? Experience with databases? Can't show my work (no repos, no docs)? Design, color, palette? Cloud development? Functional programming?
 </Question>
 
+</QuestionSection>
+
 ## Growth opportunities
 
 <SectionBanner why="Gaps tell me where I'm behind; opportunities tell me where I could stretch. This section looks forward, toward the new and uncomfortable, because growth lives where I'm willing to be a beginner." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -83,9 +89,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   How do I ensure I always grow? How do I establish a mindset that pushes me to always grow?
 </Question>
 
+</QuestionSection>
+
 ## Desiring change
 
 <SectionBanner why="Improvement starts with actually wanting it. This short section checks whether I have a real desire to change, because effort without genuine want rarely sticks." />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -99,9 +109,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   What change do I desire? What about myself do I want to change?
 </Question>
 
+</QuestionSection>
+
 ## Learning from others
 
 <SectionBanner why="Other people are a mirror for my own gaps. Spotting skills in them that I lack is one of the fastest ways to see what I should work on, and who I should learn it from." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -114,9 +128,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   What skills have I spotted in others that I lack myself? Who can I learn from?
 </Question>
 
+</QuestionSection>
+
 ## Your improvement approach
 
 <SectionBanner why="Knowing where to improve is useless without a plan to do it. This section turns the gaps into a concrete approach: the actions, the habits, and how it all ties back to my goals and learning." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -141,9 +159,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   How will I improve this year? Next year? What things will I learn? What habits will I start or stop? What habits am I willing to commit to?
 </Question>
 
+</QuestionSection>
+
 ## Technical gaps
 
 <SectionBanner why="Beyond general growth, there are specific technical things I want to understand better. This section names the concrete frameworks, tools, and processes on my list, like rasa, spaCy, Google Analytics, Spark, the Critical Path Method, and a Gantt-style view for ordering work." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -168,9 +190,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   Which skills of mine need work?
 </Question>
 
+</QuestionSection>
+
 ## Expanding your roles
 
 <SectionBanner why="Growth isn't only about getting better at what I already do; it's about taking on new activities and roles. This section looks at widening the kinds of things I do, not just deepening them." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -184,9 +210,13 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   What new activities should I take on? What new roles should I play?
 </Question>
 
+</QuestionSection>
+
 ## Enhancing your skills
 
 <SectionBanner why="Some of the most valuable skills are the soft and structural ones I tend to neglect: persuasion, negotiation, showing my value, and modeling cleanly. This section targets those underinvested capabilities." />
+
+<QuestionSection>
 
 <Question
   priority="medium"
@@ -210,3 +240,5 @@ Growth starts with an honest map of where I stand. Before I can pick what to wor
   record="Note where you can lean more on ADTs and focus on capabilities over processes">
   Can I model in ADTs as much as possible? Can I focus less on processes and more on capabilities?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-how-you-learn.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-how-you-learn.mdx
@@ -16,6 +16,8 @@ Most of us were taught *what* to learn, but rarely *how* we ourselves learn best
 
 <SectionBanner why="I learn differently than the next person, and naming how I actually take things in lets me lean into it instead of fighting it." />
 
+<QuestionSection>
+
 <Question
   priority="high"
   cron="adhoc"
@@ -68,9 +70,13 @@ Most of us were taught *what* to learn, but rarely *how* we ourselves learn best
   What are the common questions I ask when attempting to learn a new field?
 </Question>
 
+</QuestionSection>
+
 ## Your learning process
 
 <SectionBanner why="A learning style is how I take things in; a process is the repeatable sequence I run so I'm always learning something on purpose. The bullets below are a starting shape for mine." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -83,6 +89,8 @@ Most of us were taught *what* to learn, but rarely *how* we ourselves learn best
   What do I need to continually do to ensure that I am always in a state of learning? What does my personal learning process look like?
 </Question>
 
+</QuestionSection>
+
 A starting shape for that process:
 
 - Capture a whole bunch of questions that intrigue me around a topic
@@ -94,6 +102,8 @@ A starting shape for that process:
 ## Seeking knowledge effectively
 
 <SectionBanner why="A guiding principle for this section: employ the scientific method as much as possible. Treat curiosity as a hypothesis to test, not just a feeling to follow." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -126,6 +136,8 @@ A starting shape for that process:
   While observing, how do I capture what I'm taking in? (Take notes and document ideas, structure them into graphs, and learn the setup even if I don't like it.)
 </Question>
 
+</QuestionSection>
+
 ## Expanding your knowledge
 
 <SectionBanner why="Seeking knowledge gets me started; expanding it is the deliberate work of mapping, classifying, and connecting what I take in so it compounds. The list below is the sequence I run." />
@@ -145,6 +157,8 @@ A sequence for expanding what I know:
 
 <SectionBanner why="There's more than one way to learn, and knowing the named methods lets me pick the right tool instead of always defaulting to 'read more.'" />
 
+<QuestionSection>
+
 <Question
   cron="adhoc"
   depth="quick"
@@ -154,6 +168,8 @@ A sequence for expanding what I know:
   record="Keep a list of learning methods and which kinds of material each suits">
   What are different ways in which I can learn?
 </Question>
+
+</QuestionSection>
 
 Topics worth learning more about:
 
@@ -165,6 +181,8 @@ Topics worth learning more about:
 ## Maintaining a learning mindset
 
 <SectionBanner why="The hardest part isn't starting to learn, it's not stopping. These questions check whether I'm still a sponge or have quietly gone stale." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -189,9 +207,13 @@ Topics worth learning more about:
   When do I get bored, and when do I stop learning?
 </Question>
 
+</QuestionSection>
+
 ## Self-teaching vs needing a teacher
 
 <SectionBanner why="Some things I can figure out alone; others need a guide. Knowing which is which keeps me from either struggling needlessly or outsourcing what I should own." />
+
+<QuestionSection>
 
 <Question
   cron="adhoc"
@@ -203,9 +225,13 @@ Topics worth learning more about:
   What do I need a teacher to learn versus what can I learn on my own? Why do I need a teacher?
 </Question>
 
+</QuestionSection>
+
 ## Understanding knowledge
 
 <SectionBanner why="Fields aren't islands. Seeing where the sciences intersect and where they share tools makes everything I learn reinforce everything else." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -218,9 +244,13 @@ Topics worth learning more about:
   Where do the different sciences intersect? What is the ultimate goal of each? How can some benefit from others, and what tools can be used across them?
 </Question>
 
+</QuestionSection>
+
 ## Capturing your learnings
 
 <SectionBanner why="Knowledge I don't capture leaks away. These questions are about building the storehouse so what I learn stays findable and reusable." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -262,3 +292,5 @@ Topics worth learning more about:
   record="A place to log lessons per tool and per software component">
   Where do I capture the things I learned about the different tools I have used, and about different software components?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-managing-your-tasks.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-managing-your-tasks.mdx
@@ -16,6 +16,8 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
 
 <SectionBanner why="A task system is only as good as what makes it in. If capture is hard or unclear, half my work never reaches the list and lives in my head instead." />
 
+<QuestionSection>
+
 <Question
   priority="high"
   cron="adhoc"
@@ -47,9 +49,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   Do I only capture tasks as "a planner"? Is planning the main reason tasks get captured?
 </Question>
 
+</QuestionSection>
+
 ## Tracking tasks
 
 <SectionBanner why="Capture gets tasks in; tracking is how I know where each one stands and what to touch next. Without it, the list rots into a pile I avoid." />
+
+<QuestionSection>
 
 <Question
   cron="weekly"
@@ -142,9 +148,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   Did I ever stop wanting to do something? Why?
 </Question>
 
+</QuestionSection>
+
 ## Capturing triggers
 
 <SectionBanner why="Some tasks shouldn't live on a fixed date but should fire when something happens in the world. These questions are about catching those event-driven needs." />
+
+<QuestionSection>
 
 <Question
   cron="adhoc"
@@ -156,9 +166,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   What triggers or events lead to me needing to do something? Could I have trigger-based reminders, such as when a store has a sale, when I get my paycheck, when I arrive somewhere, when I check my phone, or when I go too long without doing something?
 </Question>
 
+</QuestionSection>
+
 ## Recurring tasks
 
 <SectionBanner why="A surprising share of my work repeats. Naming the recurring tasks (and dreaming up ways to regenerate them) keeps me from re-entering the same things forever." />
+
+<QuestionSection>
 
 <Question
   cron="weekly"
@@ -170,9 +184,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   What recurring tasks do I have? Could a script recreate tasks based on hashtags like a recurring "weekly" marker?
 </Question>
 
+</QuestionSection>
+
 ## Predicting potential tasks
 
 <SectionBanner why="Beyond what already recurs, there's work I can see coming. These questions explore predicting tasks before they're due so they appear at the right moment on their own." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -205,9 +223,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   Could I specify a date range for a goal (a start and end date) so the goal applies for the whole period and shows up on every day in that span?
 </Question>
 
+</QuestionSection>
+
 ## Task dependencies
 
 <SectionBanner why="Tasks rarely stand alone. Many can't start until something else finishes or some event occurs, and modeling that is what keeps me from working things in the wrong order." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -250,9 +272,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   Could I extract a list of events from these kinds of todos, and template-ize event annotations (like "beforeEarningX")? Could I auto-add a due date as soon as the `@when` condition is met?
 </Question>
 
+</QuestionSection>
+
 ## Automating tasks
 
 <SectionBanner why="The least valuable work is the bookkeeping of tasks themselves. These questions hunt for what a script could create, recreate, or remind me of without my touch." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -275,9 +301,13 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   Should I create todos for the number of stashed commits I have (implying a backlog, since it hasn't been committed)? Should I create a todo for things I want to buy when I take a picture of a product, or when I add an item to my Amazon cart?
 </Question>
 
+</QuestionSection>
+
 ## Breaking down work
 
 <SectionBanner why="Some work is bigger than a task and deserves to be a story with a reason behind it. These questions are about decomposing effort and knowing why it's worth doing." />
+
+<QuestionSection>
 
 <Question
   cron="adhoc"
@@ -288,6 +318,8 @@ Tasks are the atoms of my work: the individual things that make up my plans and 
   record="Note the why, the ordered steps, and the resources each task needs">
   What is the advantage of using stories over tasks? Reduced number of tickets? Why (as a company) are we working on this feature? What needs to be done to accomplish this feature, and in what order? Which resources should I allocate to perform a specific task?
 </Question>
+
+</QuestionSection>
 
 ## Structuring your tasks
 

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-planning-across-horizons.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-planning-across-horizons.mdx
@@ -16,6 +16,8 @@ Priorities only become real when they meet a calendar. Planning is how I transla
 
 <SectionBanner why="Before I plan a single day, I need to understand what planning even is and how I actually spend my time, not how I imagine I do." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="high"
@@ -49,6 +51,8 @@ Priorities only become real when they meet a calendar. Planning is how I transla
   Is prioritizing a part of planning? Or do I figure out my priorities first, and then figure out how to collectively realize them? As a do-er, I grow a list of things I want to do; as a planner, I figure out what I should do first. What is planning? What does it mean to plan?
 </Question>
 
+</QuestionSection>
+
 A few framing ideas worth holding onto:
 
 - Planning is part of time management; it is preparing for a future.
@@ -62,6 +66,8 @@ A few framing ideas worth holding onto:
 
 <SectionBanner why="A plan without a reason behind each item is just a schedule. I want to always be able to justify what I'm doing and what I'm choosing not to do." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="high"
@@ -74,11 +80,15 @@ A few framing ideas worth holding onto:
   Why am I doing what I am doing, and can I justify why I am not doing something else? At a given point in time, what am I working on? As a programmer, what features am I working on? As a learner, what am I learning? As a doer, what projects am I working on?
 </Question>
 
+</QuestionSection>
+
 I don't know when I'll be asked for a status update, but I need to be confident and clear, because I should always know what I am doing and why I am doing it.
 
 ## Recurring activities
 
 <SectionBanner why="Across all my horizons, the same handful of activities keep showing up. Naming them tells me what my time really goes toward, week after week." />
+
+<QuestionSection>
 
 <Question
   cron="weekly"
@@ -90,9 +100,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   What are the things I constantly find myself doing? Which of these am I doing: learning something new, doing something interesting, organizing myself, fixing a gap or weakness, or marketing myself?
 </Question>
 
+</QuestionSection>
+
 ## Daily planning
 
 <SectionBanner why="The shortest horizon. A day is where intention either turns into action or quietly evaporates, so I name what today is actually for." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -105,9 +119,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   What should I accomplish today? What is my plan for today?
 </Question>
 
+</QuestionSection>
+
 ## Weekly planning
 
 <SectionBanner why="A week is the unit where I can both refine the last stretch and set up the next. It's the rhythm where most of my real adjustments happen." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -120,9 +138,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   What should we refine from last week? What should we introduce this week? What are we planning on doing next week? How should we align what we do this week to make next week easier to work with?
 </Question>
 
+</QuestionSection>
+
 ## Quarterly planning
 
 <SectionBanner why="A quarter is long enough to make real progress and short enough to course-correct. It's where weekly motion connects to yearly ambition." />
+
+<QuestionSection>
 
 <Question
   cron="quarterly"
@@ -134,9 +156,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   What should I accomplish this quarter? What are my quarterly objectives? How does this quarter contribute to my yearly goals? Have I snapshotted my learning plans so I know what I've committed myself to learn over time?
 </Question>
 
+</QuestionSection>
+
 ## Yearly planning
 
 <SectionBanner why="A year is long enough to change who I am, not just what I finish. This horizon is where I name what I want to be different by next year." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -150,9 +176,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   What must I accomplish this year? What will I do differently this year? What books will I read, scripts will I write, and topics will I learn this year? This year, it will be valuable if I…
 </Question>
 
+</QuestionSection>
+
 ## Lifetime timeline
 
 <SectionBanner why="The widest horizon. Zooming out to decades reveals the trajectory my daily choices are quietly drawing, and whether it points where I want to go." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -166,9 +196,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   Where do I see myself in 30 years, 20 years, 10 years, 5 years, 1 year? What is the trajectory of my life? What major milestones do I want to hit?
 </Question>
 
+</QuestionSection>
+
 ## Planning techniques
 
 <SectionBanner why="Knowing the horizons isn't enough; I need techniques for replanning and for sizing a learning plan. These are the mechanics that make the horizons usable." />
+
+<QuestionSection>
 
 <Question
   cron="weekly"
@@ -190,9 +224,13 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   How much time should be considered in each chunk of the plan? A learning plan should be in 10-week chunks: what can I learn in 10 weeks? How much time will I spend each day?
 </Question>
 
+</QuestionSection>
+
 ## Reflecting on and assessing plans
 
 <SectionBanner why="A plan I never check against reality is a wish. These questions close the loop: am I on track, and when do I adjust, re-prioritize, or change course entirely?" />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -216,3 +254,5 @@ I don't know when I'll be asked for a status update, but I need to be confident 
   record="Write the case for staying versus switching, judged against everything else I could do">
   When do I decide whether to continue down this path, or switch to something more beneficial for the time? Are the things I am pursuing the best things to learn right now, considering all the things I could be doing? What functionality is valuable, what is my function to society, and what am I passionate about producing versus consuming?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/blog/2017-02-13-questions-for-prioritizing-your-work.mdx
+++ b/bytesofpurpose-blog/blog/2017-02-13-questions-for-prioritizing-your-work.mdx
@@ -16,6 +16,8 @@ Capturing every idea is the easy part. The hard part is deciding what to do *now
 
 <SectionBanner why="Everything starts with 'now.' Before any framework, I name the single thing I most need to be working on at this moment." />
 
+<QuestionSection>
+
 <Question
   power="fire"
   priority="high"
@@ -28,9 +30,13 @@ Capturing every idea is the easy part. The hard part is deciding what to do *now
   What question(s) am I focused on answering now? What initiatives have I decided to work on now? What projects should I work on, and what things should I learn now? What's the most valuable thing I can do now? What do I **need** to be working on right now?
 </Question>
 
+</QuestionSection>
+
 ## How I prioritize
 
 <SectionBanner why="Naming the now is easy; defending it is the work. This is the method underneath the choice: how I actually decide what's important and what wins." />
+
+<QuestionSection>
 
 <Question
   power="anvil"
@@ -65,9 +71,13 @@ Capturing every idea is the easy part. The hard part is deciding what to do *now
   What do my candidates depend on, and what are the ultimate goal(s) I'm prioritizing against? How will I sort my learning objectives/initiatives? Which do I NEED to learn vs WANT to learn? Which ones have I recently started?
 </Question>
 
+</QuestionSection>
+
 ## Prioritization factors
 
 <SectionBanner why="A good priority decision rests on factors I can name and weigh. These questions make those factors explicit so the call isn't pure gut feel." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -90,6 +100,8 @@ Capturing every idea is the easy part. The hard part is deciding what to do *now
   Which one is easier to do? Which one needs to be done now? Which ones am I most interested in doing? How often should I address each of these concerns? What's the difference between a factor and a concern?
 </Question>
 
+</QuestionSection>
+
 Principles:
 
 - A task is higher in priority if it overlaps with many of my goals.
@@ -98,6 +110,8 @@ Principles:
 ## By life category
 
 <SectionBanner why="Priorities aren't only about work. Sweeping across career, growth, organization, learning, and family makes sure no whole area of life gets silently dropped." />
+
+<QuestionSection>
 
 <Question
   priority="high"
@@ -110,9 +124,13 @@ Principles:
   What do I need to be doing now to advance my career, become more organized, learn, grow, advance our family, and better market myself? What projects do I need to work on now?
 </Question>
 
+</QuestionSection>
+
 ## Balancing priorities
 
 <SectionBanner why="Two things constantly compete for my time: doing and learning. This question is about holding that balance instead of letting one starve the other." />
+
+<QuestionSection>
 
 <Question
   cron="weekly"
@@ -124,9 +142,13 @@ Principles:
   How do I balance learnings and projects? What can I do now vs what do I need to learn to do new things?
 </Question>
 
+</QuestionSection>
+
 ## What gets prioritized
 
 <SectionBanner why="Before prioritizing, it helps to know what's even in the running and where it lives. This question is about taking inventory across roles and tools." />
+
+<QuestionSection>
 
 <Question
   cron="monthly"
@@ -138,9 +160,13 @@ Principles:
   What goes on the roadmap, and what goes straight to my task manager? What do I prioritize, and what don't I prioritize? What are the things I am prioritizing, and where are they found? Are these in Jira? Are they scattered across roles? What initiatives am I prioritizing?
 </Question>
 
+</QuestionSection>
+
 ## Prioritizing projects
 
 <SectionBanner why="Projects are the big bets, so they deserve their own filter. These questions check a project against what I'll learn, enjoy, and can share before I commit." />
+
+<QuestionSection>
 
 <Question
   power="spark"
@@ -154,11 +180,15 @@ Principles:
   How do I figure out what project(s) I should work on? How many of these does it check off: will it help me learn what I want to learn, does it overlap with what I enjoy, do I want to work on it? How marketable is this project? How distributable is it? What else should I consider? What projects am I passionate about? Of all the things I want to do, what should I do first?
 </Question>
 
+</QuestionSection>
+
 I generally work on projects for one of two reasons: to learn something new, or to save myself time.
 
 ### Aligning projects to objectives
 
 <SectionBanner why="A project earns its place by advancing a real objective. These questions force each project to declare which goal it serves and what it'll teach me." />
+
+<QuestionSection>
 
 <Question
   cron="monthly"
@@ -170,9 +200,13 @@ I generally work on projects for one of two reasons: to learn something new, or 
   What projects help me advance specific objectives, and what objectives does each project help me meet? Why should I work on specific projects? What is the result of working on each, and what will each teach me? What projects can advance my self-marketing objective (are any in a repo I can share, will any help me learn what I want to learn)?
 </Question>
 
+</QuestionSection>
+
 ### Projects reflecting priorities
 
 <SectionBanner why="My projects should be a mirror of my priorities. When they aren't, that mismatch is the signal that I'm working on the wrong things." />
+
+<QuestionSection>
 
 <Question
   power="fire"
@@ -185,9 +219,13 @@ I generally work on projects for one of two reasons: to learn something new, or 
   How do my priorities affect the projects I actually work on? Do my projects reflect my priorities? Am I working on projects that push me to explore the things I want to do and learn? How do the things I work on align with what I want to learn? Can I commit to a personal project where I apply the things I learn?
 </Question>
 
+</QuestionSection>
+
 ### Evaluating projects
 
 <SectionBanner why="Once a project is in motion, it still needs a rubric. These questions are how I judge each project's benefit, alignment, and what it showcases about me." />
+
+<QuestionSection>
 
 <Question
   cron="monthly"
@@ -199,9 +237,13 @@ I generally work on projects for one of two reasons: to learn something new, or 
   How will I evaluate each project? Why do I want to work on each, and what are the benefits? Which do I want to work on the most? How much does each align with my interests, overlap with what I want to learn, and reflect how I market myself? What does each project showcase about my skills, technical capabilities, and product design capabilities?
 </Question>
 
+</QuestionSection>
+
 ## Deprioritizing
 
 <SectionBanner why="Prioritizing is also about subtraction. These questions are the hard ones: what do I stop, drop, or admit I no longer actually want?" />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -215,9 +257,13 @@ I generally work on projects for one of two reasons: to learn something new, or 
   What should I stop doing? What should I deprioritize? What am I spending time on that isn't important? What are the things I wanted to do at some point that I no longer want to do?
 </Question>
 
+</QuestionSection>
+
 ## Constructing a roadmap
 
 <SectionBanner why="Priorities laid on a timeline become a roadmap. These questions place my goals in time and short-vs-long-term order so I can see the whole arc at once." />
+
+<QuestionSection>
 
 <Question
   power={['fire', 'anvil']}
@@ -231,9 +277,13 @@ I generally work on projects for one of two reasons: to learn something new, or 
   Can I see my goals over time, on a timeline? Can I classify my goals into short-term and long-term, and see timelines for each type? What are my desired end-goals by end of year and next year? Where do I see myself in 30 years, 20 years, 10 years? What is my vision for myself, and where do I want my goals to take me? How and where do all of my goals and milestones intersect? What goals are more important to complete than others? Given dependencies between goals, which should be prioritized first to attain them all in a timely fashion? Which activities should I focus on to collectively attain my goals?
 </Question>
 
+</QuestionSection>
+
 ## Tracking dependencies
 
 <SectionBanner why="Goals lean on other goals. Knowing which depend on which, and what's in the way, keeps me from chasing a goal whose prerequisites aren't ready." />
+
+<QuestionSection>
 
 <Question
   cron="monthly"
@@ -245,9 +295,13 @@ I generally work on projects for one of two reasons: to learn something new, or 
   What goals depend on other goals/activities? What obstacles are hindering me from accomplishing my goals?
 </Question>
 
+</QuestionSection>
+
 ## Retrospecting
 
 <SectionBanner why="Prioritization is a skill, and skills improve by review. These questions close the loop: how well did my last set of choices actually serve me?" />
+
+<QuestionSection>
 
 <Question
   power="chisel"
@@ -260,3 +314,5 @@ I generally work on projects for one of two reasons: to learn something new, or 
   record="Write what worked, what I wrongly prioritized, what I missed, and how to get better">
   How well did my prioritization work? What did I prioritize that I shouldn't have? What did I miss? How can I get better at prioritizing? What shortcomings have I observed?
 </Question>
+
+</QuestionSection>

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -21,6 +21,7 @@ import {
   Gif,
   SectionBanner,
   Question,
+  QuestionSection,
   PowerLegend,
 } from '@omars-lab/blog-ui';
 import '@omars-lab/blog-ui/style.css';
@@ -60,6 +61,9 @@ export default {
   // Question: a clickable card for an introspective question; click opens a modal with
   // metadata (why/howOften/when/record). QuestionModalHost must be mounted in Root.tsx.
   Question,
+  // QuestionSection: wraps a section's <Question> cards and renders them sorted by
+  // priority (core>high>medium>low), keeping authored order within each tier.
+  QuestionSection,
   // PowerLegend: the canonical "power of a question" legend (spark/fire/chisel/anvil),
   // rendered from the same source as the card badges so it can't drift. Used in the
   // "What I Ask Myself" keystone post.

--- a/packages/blog-ui/package.json
+++ b/packages/blog-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omars-lab/blog-ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Reusable React components for design/blog posts: animated UX Walkthrough, Mockup frame, Gif animated-media figure, DiagramWithFootnotes, Assumption highlight, and the question-set set (SectionBanner, Question card+modal with power badges, PowerLegend).",
   "license": "MIT",
   "repository": {

--- a/packages/blog-ui/src/components/Question/index.tsx
+++ b/packages/blog-ui/src/components/Question/index.tsx
@@ -1,6 +1,7 @@
 import React, {CSSProperties, ReactNode, useCallback, useEffect, useState} from 'react';
 import clsx from 'clsx';
 import {GiLightningArc, GiFlame, GiChisel, GiAnvil, GiCycle} from 'react-icons/gi';
+import {LuFlag, LuBrain} from 'react-icons/lu';
 import type {IconType} from 'react-icons';
 import Tooltip from '../Tooltip';
 import styles from './styles.module.css';
@@ -243,6 +244,7 @@ function QuestionBadges({
             </>
           }>
           <span className={clsx(styles.pill, styles[`priority_${priority}`])}>
+            <LuFlag className={styles.priorityIcon} aria-hidden="true" />
             {PRIORITY_META[priority].label}
           </span>
         </Tooltip>
@@ -283,7 +285,10 @@ function QuestionBadges({
               {DEPTH_META[depth].gloss}
             </>
           }>
-          <span className={clsx(styles.pill, styles.pillDepth)}>{DEPTH_META[depth].label}</span>
+          <span className={clsx(styles.pill, styles.pillDepth, styles[`depth_${depth}`])}>
+            <LuBrain className={styles.depthIcon} aria-hidden="true" />
+            {DEPTH_META[depth].label}
+          </span>
         </Tooltip>
       )}
     </span>

--- a/packages/blog-ui/src/components/Question/styles.module.css
+++ b/packages/blog-ui/src/components/Question/styles.module.css
@@ -150,12 +150,58 @@
   opacity: 0.75;
 }
 
+/* Priority flag icon — colored by tier (heat ramp): red core, orange high, amber medium,
+   grey low. The flag color signals urgency at a glance, on top of the pill tint. */
+.priorityIcon {
+  width: 0.78rem;
+  height: 0.78rem;
+  flex-shrink: 0;
+}
+.priority_core .priorityIcon {
+  color: #d6322a; /* red */
+  fill: #d6322a;
+}
+.priority_high .priorityIcon {
+  color: #e2562a; /* orange */
+  fill: #e2562a;
+}
+.priority_medium .priorityIcon {
+  color: #c79100; /* amber */
+  fill: #c79100;
+}
+.priority_low .priorityIcon {
+  color: var(--ifm-color-emphasis-500); /* grey */
+}
+[data-theme='dark'] .priority_medium .priorityIcon {
+  color: #e8b339;
+  fill: #e8b339;
+}
+
 .pillFrequency {
   font-weight: 500;
 }
 .pillDepth {
   font-style: italic;
   font-weight: 500;
+  gap: 0.32rem;
+}
+
+/* Depth brain icon — opacity scales with how much thinking the question demands:
+   faint for a quick gut-check, solid for a deep sit-with-it question. */
+.depthIcon {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-700));
+}
+.depth_quick .depthIcon {
+  opacity: 0.4;
+}
+.depth_moderate .depthIcon {
+  opacity: 0.7;
+}
+.depth_deep .depthIcon {
+  opacity: 1;
 }
 
 /* Cron cadence pill — a recurring-cycle icon + the cadence label. */

--- a/packages/blog-ui/src/components/QuestionSection/index.tsx
+++ b/packages/blog-ui/src/components/QuestionSection/index.tsx
@@ -1,0 +1,60 @@
+import React, {Children, ReactNode, isValidElement} from 'react';
+import clsx from 'clsx';
+import type {QuestionPriority} from '../Question';
+import styles from './styles.module.css';
+
+/**
+ * QuestionSection — wraps the <Question> cards under one H2 and renders them sorted by
+ * priority (core > high > medium > low), preserving the authored order WITHIN each tier
+ * (a stable sort). Questions with no `priority` sort last, in authored order.
+ *
+ * Authors keep writing questions in whatever order reads naturally; the section presents
+ * them most-foundational-first so the reader meets the core questions before the lighter
+ * ones. Non-Question children (stray text, a note) are passed through in place after the
+ * sorted questions.
+ *
+ *   ## Core purpose
+ *   <SectionBanner why="…" />
+ *   <QuestionSection>
+ *     <Question priority="high" …>…</Question>
+ *     <Question priority="core" …>…</Question>   (this one renders FIRST)
+ *   </QuestionSection>
+ */
+export interface QuestionSectionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const PRIORITY_RANK: Record<QuestionPriority, number> = {
+  core: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+const NO_PRIORITY_RANK = 4;
+
+function rankOf(node: ReactNode): number {
+  if (isValidElement(node)) {
+    const p = (node.props as {priority?: QuestionPriority}).priority;
+    if (p && p in PRIORITY_RANK) return PRIORITY_RANK[p];
+  }
+  return NO_PRIORITY_RANK;
+}
+
+const QuestionSection: React.FC<QuestionSectionProps> = ({children, className}) => {
+  // Keep only real element children (MDX injects whitespace text nodes between blocks).
+  const items = Children.toArray(children).filter(
+    (c) => !(typeof c === 'string' && c.trim() === ''),
+  );
+
+  // Stable sort by priority rank. Array.prototype.sort is stable in modern engines, so
+  // equal-rank items keep their authored order; we also carry the original index to be safe.
+  const sorted = items
+    .map((node, i) => ({node, i, rank: rankOf(node)}))
+    .sort((a, b) => a.rank - b.rank || a.i - b.i)
+    .map(({node}) => node);
+
+  return <div className={clsx(styles.section, className)}>{sorted}</div>;
+};
+
+export default QuestionSection;

--- a/packages/blog-ui/src/components/QuestionSection/styles.module.css
+++ b/packages/blog-ui/src/components/QuestionSection/styles.module.css
@@ -1,0 +1,5 @@
+/* QuestionSection — a plain grouping wrapper. It exists to sort its <Question> children
+   by priority; visually it adds nothing beyond keeping the cards together. */
+.section {
+  display: block;
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -43,3 +43,6 @@ export type {
   QuestionCron,
   PowerLegendProps,
 } from './components/Question';
+
+export {default as QuestionSection} from './components/QuestionSection';
+export type {QuestionSectionProps} from './components/QuestionSection';


### PR DESCRIPTION
## What

Two improvements to the question-set badge system, applied across all 23 posts.

### Every badge dimension now has an icon (scans at a glance)
- **priority** → a `LuFlag` (Lucide) flag **colored by tier**: red Core, orange High, amber Medium, grey Low.
- **depth** → a `LuBrain` (Lucide) brain whose **opacity scales** with depth (faint Quick → solid Deep), so "how much thinking" reads without the label.
- power keeps its forge icons (⚡🔥/chisel/anvil), cron keeps its cycle icon.
- Every badge stays wrapped in the `<Tooltip>` from v0.5.0, so hovering still explains it.

This answers "what does Medium / Moderate mean?" twice over: the icon + the tooltip.

### `QuestionSection` — sort questions by priority within each section
A new wrapper that **stable-sorts** its `<Question>` children by priority (core > high > medium > low), preserving authored order within each tier. The reader meets the most-foundational questions first; authors never hand-reorder (the component sorts at render time).

```mdx
<QuestionSection>
  <Question priority="high" …>…</Question>
  <Question priority="core" …>…</Question>   {/* renders FIRST */}
</QuestionSection>
```

Applied to every section across the 23 posts (badge icons are automatic; the `<QuestionSection>` wrapping was an additive per-section edit by parallel agents, open/close balanced).

## Notes
- Lucide icons import from `react-icons/lu` and bundle via the existing `noExternal` glob (verified: nothing external in dist).
- blog-ui bumped to **v0.6.0**.

## Verification
- `yarn build` (package) + full prod `yarn build` (blog) both clean — `[SUCCESS] Generated static files`.
- `node scripts/validate-em-dash.js blog` → corpus clean.
- Rendered: flag colors + brain opacity per tier, priority sort reorders High after Core, tooltips on every badge. Light/dark hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)