### PR TITLE
feat(blog): kind-driven sidebar emoji + short sidebar labels (+ validation)

### DIFF
--- a/.claude/hooks/validate-post-outline-hook.sh
+++ b/.claude/hooks/validate-post-outline-hook.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
-# PostToolUse hook for Edit|Write: WARN (never block) when a post that declares a
-# `kind:` is missing the structural elements that kind of post should have.
+# PostToolUse hook for Edit|Write: WARN (never block) on blog/doc post-shape issues.
+# Surfaces every advisory from scripts/validate-post-outline.js for the edited file:
 #
-# Convention (see the import-co-design + upgrade-post skills): a post's `kind:` frontmatter
-# (e.g. `kind: system-design`) implies a required OUTLINE — a system-design post should
-# paint the whole picture, so it must carry a UX mockup, a Decisions section, and a
-# description. This advises when one is missing; it's a judgment call (a stub mid-draft is
-# fine), so it exits 0 and never blocks. Pairs with scripts/validate-post-outline.js.
+#   - missing-kind        a BLOG post has no `kind:` (kind drives the sidebar emoji)
+#   - unknown-kind        `kind:` isn't one of the blog kinds in scripts/lib/blog-kind-emoji.json
+#   - long-sidebar-label  the sidebar entry (sidebar_label || title) is long; add a short
+#                         `sidebar_label:` (the full title stays on the page H1)
+#   - outline-<x>         a post of a given `kind:` is missing that kind's required elements
+#                         (e.g. system-design needs a mockup + Decisions; question-set needs
+#                         H2 sections + <Question> cards + a <SectionBanner>)
+#
+# All are judgment calls (a stub mid-draft is fine), so the validator exits 0 and this hook
+# never blocks. For DOCS it only runs when a `kind:` is present; for BLOG/designs it always
+# runs (so a missing kind is caught). Pairs with scripts/validate-post-outline.js + the
+# author-blog-post / upgrade-post skills.
 
 input=$(cat)
 file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
@@ -27,14 +34,22 @@ case "$(basename "$file_path")" in
   _*) exit 0 ;;
 esac
 
-# Fast pre-check: only run the validator if the file declares a `kind:` in frontmatter
-# (otherwise no outline rule applies — avoid spawning node needlessly).
-has_kind=$(awk '
-  /^---[[:space:]]*$/ { c++; next }
-  c==1 && /^kind:/    { print "yes"; exit }
-  c>=2                { exit }
-' "$file_path")
-[ "$has_kind" = "yes" ] || exit 0
+# Fast pre-check: for DOCS, only run the validator if the file declares a `kind:`
+# (docs have no missing-kind rule — avoid spawning node needlessly). For BLOG/designs
+# posts we run REGARDLESS, because a MISSING `kind:` is itself a finding there (kind
+# drives the sidebar emoji), and the validator emits a missing-kind nudge.
+case "$file_path" in
+  */bytesofpurpose-blog/blog/*|*/bytesofpurpose-blog/designs/*)
+    : ;; # always run for blog/designs
+  *)
+    has_kind=$(awk '
+      /^---[[:space:]]*$/ { c++; next }
+      c==1 && /^kind:/    { print "yes"; exit }
+      c>=2                { exit }
+    ' "$file_path")
+    [ "$has_kind" = "yes" ] || exit 0
+    ;;
+esac
 
 proj="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 script="$proj/bytesofpurpose-blog/scripts/validate-post-outline.js"

--- a/bytesofpurpose-blog/blog/2026-06-05-what-does-gtm-mean.md
+++ b/bytesofpurpose-blog/blog/2026-06-05-what-does-gtm-mean.md
@@ -1,6 +1,8 @@
 ---
 slug: what-does-gtm-mean
 title: "What Does GTM Mean? (And Is It the Same as an Experiment Dial-Up Plan?)"
+kind: reference
+sidebar_label: "What Is GTM?"
 description: "GTM (go-to-market) strategy is the plan for how a product reaches and wins customers. Here's what it actually covers, and why a dial-up plan isn't the same thing."
 authors: [oeid]
 tags: [product-management, go-to-market, strategy, experimentation, launch]

--- a/bytesofpurpose-blog/plugins/draft-docs/index.js
+++ b/bytesofpurpose-blog/plugins/draft-docs/index.js
@@ -2,6 +2,17 @@ const fs = require('fs');
 const path = require('path');
 const matter = require('gray-matter');
 
+// Blog post-kind -> sidebar emoji (single source of truth). The sidebar label for a
+// blog post is prefixed with its kind's emoji so the Posts list is scannable BY TYPE.
+let BLOG_KIND_EMOJI = {};
+try {
+  BLOG_KIND_EMOJI = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', '..', 'scripts', 'lib', 'blog-kind-emoji.json'), 'utf8'),
+  ).kinds || {};
+} catch {
+  BLOG_KIND_EMOJI = {};
+}
+
 /**
  * Local Docusaurus plugin: collects the permalink of every DRAFT doc
  * (`draft: true` frontmatter) and of every PREMIUM doc (`premium: true`), and
@@ -17,6 +28,7 @@ const matter = require('gray-matter');
  * Consumed via:
  *   useGlobalData()['draft-docs-plugin'].default.draftPermalinks    // string[] — draft doc pages
  *   useGlobalData()['draft-docs-plugin'].default.premiumPermalinks  // string[] — premium doc pages
+ *   useGlobalData()['draft-docs-plugin'].default.blogSidebarLabels  // {permalink: shortLabel} — blog posts with sidebar_label
  *
  * Only individual docs with `draft: true` are tracked — the swizzled sidebar
  * badges the LEAF link. (Category/folder badging was dropped: a fully-draft folder
@@ -50,6 +62,10 @@ module.exports = function draftDocsPlugin(context) {
       const draftPermalinks = new Set();
       const premiumPermalinks = new Set();
       const blogDraftPermalinks = new Set();
+      // permalink -> short sidebar label, for blog posts that set `sidebar_label:`.
+      // The blog sidebar item carries only {title, permalink}, so the swizzle looks
+      // the label up here (same indirection the draft set uses).
+      const blogSidebarLabels = {};
 
       const walk = (dir) => {
         for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
@@ -92,8 +108,28 @@ module.exports = function draftDocsPlugin(context) {
           } catch {
             continue;
           }
+          const permalink = toBlogPermalink(entry.name, data, base);
           if (data.draft === true) {
-            blogDraftPermalinks.add(toBlogPermalink(entry.name, data, base));
+            blogDraftPermalinks.add(permalink);
+          }
+          // Compute the rendered sidebar label = <kind emoji> + <short label or title>.
+          //   - the short text is `sidebar_label:` if set (trimmed), else the full title;
+          //   - the emoji is auto-derived from `kind:` (authors never type it). If the
+          //     short text already starts with the kind emoji (or any emoji), we don't
+          //     double-prefix.
+          // We only publish an override when it DIFFERS from the plain title (so posts
+          // with neither a sidebar_label nor a kind fall through to the default title).
+          const shortText =
+            typeof data.sidebar_label === 'string' && data.sidebar_label.trim()
+              ? data.sidebar_label.trim()
+              : typeof data.title === 'string'
+                ? data.title.trim()
+                : '';
+          const emoji = (data.kind && BLOG_KIND_EMOJI[data.kind]) || '';
+          const rendered =
+            emoji && !startsWithEmoji(shortText) ? `${emoji} ${shortText}` : shortText;
+          if (rendered && rendered !== (data.title || '').trim()) {
+            blogSidebarLabels[permalink] = rendered;
           }
         }
       }
@@ -102,6 +138,7 @@ module.exports = function draftDocsPlugin(context) {
         draftPermalinks: [...draftPermalinks],
         premiumPermalinks: [...premiumPermalinks],
         blogDraftPermalinks: [...blogDraftPermalinks],
+        blogSidebarLabels,
       };
     },
 
@@ -124,6 +161,14 @@ function toBlogPermalink(filename, data, base) {
     .replace(/\.mdx?$/, '')
     .replace(/^\d{4}-\d{2}-\d{2}-/, '');
   return `${base}/${stem}`;
+}
+
+// True when a string already begins with an emoji (so we don't double-prefix a label
+// that a human already emoji'd). Covers the common pictographic + symbol ranges and a
+// leading variation selector / ZWJ sequence.
+function startsWithEmoji(s) {
+  if (!s) return false;
+  return /^(\p{Extended_Pictographic}|\p{Emoji_Presentation})/u.test(s.trim());
 }
 
 // Strip a leading `NN-` (e.g. "4-development" -> "development") that Docusaurus

--- a/bytesofpurpose-blog/scripts/lib/blog-kind-emoji.json
+++ b/bytesofpurpose-blog/scripts/lib/blog-kind-emoji.json
@@ -1,0 +1,23 @@
+{
+  "__doc__": "Single source of truth for the BLOG post-kind -> sidebar emoji convention. A blog post's emoji reflects its DOCUMENT KIND (what type of thing it is), NOT its topic, so the Posts sidebar is scannable by type. Set `kind:` in a post's frontmatter; the emoji is auto-derived from this map and prepended to the sidebar label by the draft-docs plugin (authors never type the emoji). Read by validate-blog-kind.js + the validate-blog-kind-hook.sh nudge + the draft-docs plugin. Mirrors the docs emoji system (scripts/lib/emoji-map.json). The reader-facing prose mirror is the blog-kinds terminology doc. Keep them in lockstep: when you add a kind, add it here, in the plugin is automatic (it reads this file), and note it in the terminology doc + the author-blog-post skill.",
+  "kinds": {
+    "question-set": "❓",
+    "framework": "🧩",
+    "reflection": "💭",
+    "system-design": "🏗️",
+    "tutorial": "🧪",
+    "reference": "📖",
+    "event-recap": "🎙️",
+    "legend": "🧭"
+  },
+  "descriptions": {
+    "question-set": "A set of introspective questions to ask yourself (the 'What I Ask Myself' / 'Questions for' series).",
+    "framework": "A reusable model or framework for thinking about something ('A Framework for', 'The Anatomy of').",
+    "reflection": "A personal essay or set of takeaways ('Notes From', 'What X Taught Me', affirmations).",
+    "system-design": "An architecture or build write-up (system designs, shipping a thing, repo evolution).",
+    "tutorial": "A hands-on, learn-by-doing walkthrough ('A Hands-On Way to', 'Teaching X', 'Running X Locally').",
+    "reference": "A concept explainer or taxonomy ('A Taxonomy of', 'What Does X Mean').",
+    "event-recap": "A recap of a conference or event.",
+    "legend": "A series index or keystone that explains a set of posts and the conventions they share."
+  }
+}

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -14,8 +14,26 @@
  *     - a UX mockup           (<Mockup …> in the body OR a `mockups:` frontmatter link)
  *     - a Decisions section   (a heading matching Decisions / Key Decisions / Trade-offs / Trade offs)
  *     - a description         (non-empty `description:` frontmatter)
+ *   kind: question-set   must have →
+ *     - H2 sections           (themed clusters; the questions are grouped, not a flat list)
+ *     - <Question> cards      (each question is a card, not a bare bullet)
+ *     - a <SectionBanner>     (the per-section "why these matter" callout)
+ *     - a description
+ *   kind: framework      must have →
+ *     - the framework laid out (numbered steps, an H2-per-stage, or a diagram/<DiagramWithFootnotes>)
+ *     - a description
+ *   kind: tutorial       must have →
+ *     - steps or a runnable artifact (numbered steps, a code fence, a <Walkthrough>, or a <Gif>)
+ *     - a description
+ *   kind: reference / reflection / event-recap → a description (light contract; mostly prose)
+ *   kind: legend         must have →
+ *     - a legend/explainer of the conventions it indexes (a table, a <PowerLegend>, or links out)
+ *     - a description
  *
- * Posts with no `kind:` are skipped (no rule applies). Add new kinds to OUTLINES below.
+ * The `kind:` value must be one of the blog kinds in scripts/lib/blog-kind-emoji.json
+ * (that file drives the sidebar emoji). An UNKNOWN kind is itself a finding here.
+ * Posts with no `kind:` are skipped by THIS file's outline checks; the missing-kind
+ * nudge lives in validate-blog-kind.js. Add new kinds to OUTLINES below AND to the map.
  *
  * Usage:
  *   node scripts/validate-post-outline.js [paths…]   # scan (default: blog + designs + docs)
@@ -32,7 +50,38 @@ const matter = require('gray-matter');
 const ROOT = path.join(__dirname, '..');
 const DEFAULT_DIRS = ['blog', 'designs', 'docs'];
 
+// The canonical blog kinds (drives the sidebar emoji). A `kind:` not in this set is
+// flagged as unknown by checkFile().
+let KNOWN_KINDS = [];
+try {
+  KNOWN_KINDS = Object.keys(
+    JSON.parse(fs.readFileSync(path.join(__dirname, 'lib', 'blog-kind-emoji.json'), 'utf8')).kinds,
+  );
+} catch {
+  KNOWN_KINDS = [];
+}
+
+// Sidebar-label length budget. The kind emoji is added automatically, so these bound the
+// TEXT only. ~3 words / ~32 chars keeps a Posts-sidebar entry to a single tidy line.
+const MAX_LABEL_WORDS = 3;
+const MAX_LABEL_CHARS = 32;
+
+// Drop a leading emoji (+ trailing space) so the length check measures the words a human
+// reads, not the auto-prepended kind glyph.
+function stripLeadingEmoji(s) {
+  return s.replace(/^(?:\p{Extended_Pictographic}|\p{Emoji_Presentation})[️‍]*\s*/u, '');
+}
+
+// Reusable checks.
+const hasDescription = {
+  id: 'description',
+  label: 'a non-empty `description:` frontmatter (powers the social card + share text)',
+  test: (fm) => typeof fm.description === 'string' && fm.description.trim().length > 0,
+};
+const hasH2 = (body) => /^##\s+\S/m.test(body);
+
 // Per-kind required elements. Each check: {id, label, test(fm, body) -> boolean present}.
+// Kinds must match scripts/lib/blog-kind-emoji.json (which drives the sidebar emoji).
 const OUTLINES = {
   'system-design': [
     {
@@ -46,12 +95,64 @@ const OUTLINES = {
       test: (fm, body) =>
         /^#{1,4}\s+.*\b(key decisions?|decisions?|trade[-\s]?offs?)\b/im.test(body),
     },
-    {
-      id: 'description',
-      label: 'a non-empty `description:` frontmatter (powers the social card + share text)',
-      test: (fm) => typeof fm.description === 'string' && fm.description.trim().length > 0,
-    },
+    hasDescription,
   ],
+  'question-set': [
+    {
+      id: 'sections',
+      label: 'themed H2 sections (questions grouped by theme, not a flat list)',
+      test: (fm, body) => hasH2(body),
+    },
+    {
+      id: 'question-cards',
+      label: 'one or more <Question> cards (each question is a card, not a bare bullet)',
+      test: (fm, body) => /<Question[\s>]/.test(body),
+    },
+    {
+      id: 'section-banner',
+      label: 'a <SectionBanner> (the per-section "why these questions matter" callout)',
+      test: (fm, body) => /<SectionBanner[\s>]/.test(body),
+    },
+    hasDescription,
+  ],
+  framework: [
+    {
+      id: 'framework-laid-out',
+      label:
+        'the framework laid out (numbered steps, an H2-per-stage, or a <DiagramWithFootnotes>/mermaid)',
+      test: (fm, body) =>
+        /^\s*\d+\.\s+\S/m.test(body) ||
+        hasH2(body) ||
+        /<DiagramWithFootnotes[\s>]/.test(body) ||
+        /```mermaid/.test(body),
+    },
+    hasDescription,
+  ],
+  tutorial: [
+    {
+      id: 'steps-or-artifact',
+      label:
+        'steps or a runnable artifact (numbered steps, a code fence, a <Walkthrough>, or a <Gif>)',
+      test: (fm, body) =>
+        /^\s*\d+\.\s+\S/m.test(body) ||
+        /```/.test(body) ||
+        /<(Walkthrough|Gif)[\s>]/.test(body),
+    },
+    hasDescription,
+  ],
+  legend: [
+    {
+      id: 'legend-explainer',
+      label:
+        'an explainer of the conventions it indexes (a table, a <PowerLegend>, or a list of links out)',
+      test: (fm, body) =>
+        /<PowerLegend[\s/>]/.test(body) || /^\|.*\|/m.test(body) || /^\s*[-*]\s+\[/m.test(body),
+    },
+    hasDescription,
+  ],
+  reference: [hasDescription],
+  reflection: [hasDescription],
+  'event-recap': [hasDescription],
 };
 
 const isContent = (n) => /\.mdx?$/.test(n) && !path.basename(n).startsWith('_');
@@ -76,8 +177,58 @@ function checkFile(file) {
     return []; // unparseable frontmatter — other validators handle that
   }
   const kind = parsed.data && parsed.data.kind;
-  if (!kind || !OUTLINES[kind]) return []; // no rule for this kind
   const findings = [];
+  // Only enforce the kind vocabulary for BLOG posts (docs use their own kind words).
+  const isBlogPost = /\/(blog|designs)\//.test(file);
+
+  // A blog post with NO `kind:` can't get a type-based sidebar emoji. Nudge to add one.
+  if (!kind) {
+    if (isBlogPost && KNOWN_KINDS.length) {
+      findings.push({
+        file: path.relative(ROOT, file),
+        kind: '(none)',
+        id: 'missing-kind',
+        detail: `blog post has no \`kind:\`. Add one of: ${KNOWN_KINDS.join(', ')} (drives the sidebar emoji; see scripts/lib/blog-kind-emoji.json)`,
+      });
+    }
+    return findings;
+  }
+
+  // An unknown kind (not in the emoji map) can't get an emoji and has no outline contract.
+  if (isBlogPost && KNOWN_KINDS.length && !KNOWN_KINDS.includes(kind)) {
+    findings.push({
+      file: path.relative(ROOT, file),
+      kind,
+      id: 'unknown-kind',
+      detail: `kind: "${kind}" is not a known blog kind. Use one of: ${KNOWN_KINDS.join(', ')} (see scripts/lib/blog-kind-emoji.json)`,
+    });
+  }
+
+  // Sidebar label length: the entry shown in the Posts list should be SHORT (a long title
+  // wraps to a messy multi-line block). The effective label is `sidebar_label:` if set,
+  // else the title. Strip a leading emoji (the kind emoji is prepended automatically) and
+  // warn when the remaining text is long. The FULL title stays on the page H1, so this
+  // only asks for a short `sidebar_label:`, not for shortening the title itself.
+  if (isBlogPost) {
+    const fm = parsed.data;
+    const usingLabel = typeof fm.sidebar_label === 'string' && fm.sidebar_label.trim();
+    const labelText = stripLeadingEmoji(
+      (usingLabel ? fm.sidebar_label : fm.title || '').toString().trim(),
+    );
+    const words = labelText.split(/\s+/).filter(Boolean).length;
+    if (labelText && (words > MAX_LABEL_WORDS || labelText.length > MAX_LABEL_CHARS)) {
+      findings.push({
+        file: path.relative(ROOT, file),
+        kind,
+        id: 'long-sidebar-label',
+        detail: usingLabel
+          ? `sidebar_label "${labelText}" is long (${words} words / ${labelText.length} chars). Aim for <= ${MAX_LABEL_WORDS} words.`
+          : `no \`sidebar_label:\` and the title is long (${words} words / ${labelText.length} chars) for the sidebar. Add a short \`sidebar_label:\` (<= ${MAX_LABEL_WORDS} words); the full title stays on the page.`,
+      });
+    }
+  }
+
+  if (!OUTLINES[kind]) return findings; // no outline contract for this kind
   for (const check of OUTLINES[kind]) {
     if (!check.test(parsed.data, parsed.content)) {
       findings.push({
@@ -96,8 +247,18 @@ function main() {
   const json = args.includes('--json');
   const targets = args.filter((a) => !a.startsWith('--'));
 
+  // Resolve each target: a directory is walked for content files; a file is used as-is.
+  // (Allows `validate-post-outline.js blog` as well as explicit file paths.)
+  const resolveTarget = (t) => {
+    const abs = path.resolve(t);
+    try {
+      return fs.statSync(abs).isDirectory() ? walk(abs) : [abs];
+    } catch {
+      return [];
+    }
+  };
   const files = targets.length
-    ? targets.map((t) => path.resolve(t))
+    ? targets.flatMap(resolveTarget)
     : DEFAULT_DIRS.flatMap((d) => walk(path.join(ROOT, d)));
 
   const findings = files.flatMap(checkFile);

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
@@ -5,6 +5,7 @@ import {translate} from '@docusaurus/Translate';
 import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
+import {useBlogSidebarLabel} from '@site/src/theme/BlogSidebar/blogSidebarLabel';
 import styles from './styles.module.css';
 
 // Swizzled @theme/BlogSidebar/Desktop: identical to upstream, except the post
@@ -24,13 +25,15 @@ function SidebarItemLink({
   linkActiveClassName?: string;
 }) {
   const isDraft = useIsBlogDraft(item.permalink);
+  const label = useBlogSidebarLabel(item.permalink, item.title);
   return (
     <Link
       isNavLink
       to={item.permalink}
       className={linkClassName}
-      activeClassName={linkActiveClassName}>
-      {item.title}
+      activeClassName={linkActiveClassName}
+      title={item.title}>
+      {label}
       {isDraft && <DraftBadge />}
     </Link>
   );

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
@@ -4,21 +4,25 @@ import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client
 import {NavbarSecondaryMenuFiller} from '@docusaurus/theme-common';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
+import {useBlogSidebarLabel} from '@site/src/theme/BlogSidebar/blogSidebarLabel';
 import styles from './styles.module.css';
 
 // Swizzled @theme/BlogSidebar/Mobile: mirrors upstream, adding the same dev-only
-// "D" draft badge as the Desktop sidebar (see ../Desktop). Gated to localhost +
-// non-prod; no-op in production.
+// "D" draft badge as the Desktop sidebar (see ../Desktop) and the same short
+// sidebar_label override. Draft badge is gated to localhost + non-prod; the short
+// label ships to prod too.
 
 function SidebarItemLink({item}: {item: {title: string; permalink: string}}) {
   const isDraft = useIsBlogDraft(item.permalink);
+  const label = useBlogSidebarLabel(item.permalink, item.title);
   return (
     <Link
       isNavLink
       to={item.permalink}
       className="menu__link"
-      activeClassName="menu__link--active">
-      {item.title}
+      activeClassName="menu__link--active"
+      title={item.title}>
+      {label}
       {isDraft && <DraftBadge />}
     </Link>
   );

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/blogSidebarLabel.ts
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/blogSidebarLabel.ts
@@ -1,0 +1,40 @@
+import React from 'react';
+import {useAllPluginInstancesData} from '@docusaurus/useGlobalData';
+
+// Resolves the SHORT sidebar label for a blog post. The Docusaurus blog sidebar item
+// carries only {title, permalink} (it does not read the post's `sidebar_label:`
+// frontmatter the way the docs sidebar does). The draft-docs plugin walks every blog
+// post and publishes a {permalink -> sidebar_label} map; the swizzled BlogSidebar looks
+// the label up here and falls back to the full title when none is set.
+//
+// Unlike the draft badge, this is NOT dev-gated: short sidebar labels are a real
+// reader-facing improvement that should ship to production too.
+
+function normalize(href: string): string {
+  if (!href) return href;
+  return href.length > 1 ? href.replace(/\/$/, '') : href;
+}
+
+function useBlogSidebarLabels(): Record<string, string> {
+  const data = useAllPluginInstancesData('draft-docs-plugin') as
+    | {default?: {blogSidebarLabels?: Record<string, string>}}
+    | undefined;
+  const raw = data?.default?.blogSidebarLabels ?? {};
+  return React.useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const [permalink, label] of Object.entries(raw)) {
+      out[normalize(permalink)] = label;
+    }
+    return out;
+  }, [raw]);
+}
+
+/**
+ * The label to show for a blog post in the Posts sidebar: its `sidebar_label:` if set,
+ * otherwise the full `title`. Pass the sidebar item's title + permalink.
+ */
+export function useBlogSidebarLabel(permalink: string | undefined, title: string): string {
+  const labels = useBlogSidebarLabels();
+  if (!permalink) return title;
+  return labels[normalize(permalink)] ?? title;
+}


### PR DESCRIPTION
## What

Makes the **Posts sidebar scannable by document TYPE** and tidy in length. The emoji reflects a post's **kind** (not its topic), auto-derived so authors never type it.

### kind → emoji (single source of truth)
`scripts/lib/blog-kind-emoji.json` maps each blog `kind:` to an emoji, mirroring the docs emoji-map:

| kind | emoji | | kind | emoji |
|---|---|---|---|---|
| question-set | ❓ | | tutorial | 🧪 |
| framework | 🧩 | | reference | 📖 |
| reflection | 💭 | | event-recap | 🎙️ |
| system-design | 🏗️ | | legend | 🧭 |

### Short sidebar labels
- New `sidebar_label:` blog frontmatter = a **short** sidebar entry, distinct from the long page title (which stays the H1 / SEO title / browser tab).
- The Docusaurus blog plugin doesn't read `sidebar_label` natively, so the **draft-docs plugin** publishes a `{permalink → rendered label}` map where `rendered = <kind emoji> + (sidebar_label || title)`, and the swizzled **BlogSidebar** (Desktop + Mobile) uses it. Full title shows on hover via `title=`.

### Validation (warn-tier, via the existing `validate-post-outline` hook)
The hook now also runs for blog/designs posts with **no** `kind:`. Findings:
- **missing-kind** — a blog post with no `kind:`
- **unknown-kind** — a `kind:` not in the emoji map
- **long-sidebar-label** — sidebar entry > ~3 words / ~32 chars → add a short `sidebar_label`
- **per-kind outline** — e.g. `question-set` needs H2 + `<Question>` + `<SectionBanner>`; `framework` needs the framework laid out; `tutorial` needs steps/artifact; `legend` needs an explainer; `system-design` keeps its mockup + Decisions contract
- Also fixed `validate-post-outline.js` to accept a directory arg (it crashed on `… blog`).

## Proof
The GTM post (`kind: reference` + `sidebar_label: "What Is GTM?"`) renders **"📖 What Is GTM?"** in the sidebar, full title on the page. (Screenshot captured in dev.)

## Follow-ups (separate PRs)
- Backfill all 46 posts with `kind:` + short `sidebar_label`.
- The blog-wide **legend/index** post (kind-emoji legend + series map).

## Verification
- Plugin loads; full prod `yarn build` clean (`[SUCCESS] Generated static files`).
- Validator: GTM clean; missing/unknown/long-label cases all flag correctly; all 46 current posts correctly report missing-kind (will clear on backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)