### PR TITLE
feat(blog): sidebar "Guides" section + tag scoping with a cancelable facet

### DIFF
--- a/bytesofpurpose-blog/plugins/draft-docs/index.js
+++ b/bytesofpurpose-blog/plugins/draft-docs/index.js
@@ -71,6 +71,9 @@ module.exports = function draftDocsPlugin(context) {
       // Blog posts pinned ABOVE the year groups in the sidebar: `pinned: true`, or any
       // `kind: legend` (an index/keystone belongs at the top, not buried by its date).
       const blogPinnedPermalinks = new Set();
+      // permalink -> normalized tag slugs, so the swizzled BlogSidebar can SCOPE itself to
+      // the current tag on a /<route>/tags/<tag> page (its items carry no tag info).
+      const blogPostTags = {};
 
       const walk = (dir) => {
         for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
@@ -122,6 +125,13 @@ module.exports = function draftDocsPlugin(context) {
           if (data.pinned === true || data.kind === 'legend') {
             blogPinnedPermalinks.add(permalink);
           }
+          // Record this post's tags (normalized to slugs) so the sidebar can scope to a tag.
+          if (Array.isArray(data.tags) && data.tags.length) {
+            blogPostTags[permalink] = data.tags
+              .map((t) => (typeof t === 'string' ? t : t && (t.label || t.slug)))
+              .filter(Boolean)
+              .map(tagSlug);
+          }
           // Compute the rendered sidebar label = <kind emoji> + <short label or title>.
           //   - the short text is `sidebar_label:` if set (trimmed), else the full title;
           //   - the emoji is auto-derived from `kind:` (authors never type it). If the
@@ -150,6 +160,7 @@ module.exports = function draftDocsPlugin(context) {
         blogDraftPermalinks: [...blogDraftPermalinks],
         blogSidebarLabels,
         blogPinnedPermalinks: [...blogPinnedPermalinks],
+        blogPostTags,
       };
     },
 
@@ -172,6 +183,16 @@ function toBlogPermalink(filename, data, base) {
     .replace(/\.mdx?$/, '')
     .replace(/^\d{4}-\d{2}-\d{2}-/, '');
   return `${base}/${stem}`;
+}
+
+// Normalize a tag to the slug Docusaurus uses in /tags/<slug> URLs (lowercase, spaces and
+// non-alphanumerics to hyphens). Good enough for this repo's simple string tags.
+function tagSlug(tag) {
+  return String(tag)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 // True when a string already begins with an emoji (so we don't double-prefix a label

--- a/bytesofpurpose-blog/plugins/draft-docs/index.js
+++ b/bytesofpurpose-blog/plugins/draft-docs/index.js
@@ -68,6 +68,9 @@ module.exports = function draftDocsPlugin(context) {
       // The blog sidebar item carries only {title, permalink}, so the swizzle looks
       // the label up here (same indirection the draft set uses).
       const blogSidebarLabels = {};
+      // Blog posts pinned ABOVE the year groups in the sidebar: `pinned: true`, or any
+      // `kind: legend` (an index/keystone belongs at the top, not buried by its date).
+      const blogPinnedPermalinks = new Set();
 
       const walk = (dir) => {
         for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
@@ -114,6 +117,11 @@ module.exports = function draftDocsPlugin(context) {
           if (data.draft === true) {
             blogDraftPermalinks.add(permalink);
           }
+          // Pin to the top of the sidebar: explicit `pinned: true`, or any legend (an
+          // index/keystone should sit above the year groups regardless of its date).
+          if (data.pinned === true || data.kind === 'legend') {
+            blogPinnedPermalinks.add(permalink);
+          }
           // Compute the rendered sidebar label = <kind emoji> + <short label or title>.
           //   - the short text is `sidebar_label:` if set (trimmed), else the full title;
           //   - the emoji is auto-derived from `kind:` (authors never type it). If the
@@ -141,6 +149,7 @@ module.exports = function draftDocsPlugin(context) {
         premiumPermalinks: [...premiumPermalinks],
         blogDraftPermalinks: [...blogDraftPermalinks],
         blogSidebarLabels,
+        blogPinnedPermalinks: [...blogPinnedPermalinks],
       };
     },
 

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
@@ -5,7 +5,10 @@ import {translate} from '@docusaurus/Translate';
 import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
-import {useBlogSidebarLabel} from '@site/src/theme/BlogSidebar/blogSidebarLabel';
+import {
+  useBlogSidebarLabel,
+  usePartitionedBlogItems,
+} from '@site/src/theme/BlogSidebar/blogSidebarLabel';
 import styles from './styles.module.css';
 
 // Swizzled @theme/BlogSidebar/Desktop: identical to upstream, except the post
@@ -57,6 +60,9 @@ const ListComponent = ({items}: {items: Array<{title: string; permalink: string}
 
 function BlogSidebarDesktop({sidebar}: any): React.JSX.Element {
   const items = useVisibleBlogSidebarItems(sidebar.items);
+  // Pinned posts (`pinned: true` / `kind: legend`) render ABOVE the year groups so an
+  // index/keystone isn't buried by its date; the rest year-group as normal.
+  const [pinned, rest] = usePartitionedBlogItems(items);
   return (
     <aside className="col col--3">
       <nav
@@ -66,11 +72,21 @@ function BlogSidebarDesktop({sidebar}: any): React.JSX.Element {
           message: 'Blog recent posts navigation',
           description: 'The ARIA label for recent posts in the blog sidebar',
         })}>
-        <div className={clsx(styles.sidebarItemTitle, 'margin-bottom--md')}>
-          {sidebar.title}
-        </div>
+        {pinned.length > 0 ? (
+          <>
+            {/* Pinned legends/keystones get their own "Guides" section at the very top; the
+                dated posts below keep the "Posts" heading (sidebar.title). */}
+            <div className={clsx(styles.sidebarItemTitle, 'margin-bottom--md')}>Guides</div>
+            <ListComponent items={pinned} />
+            <div className={clsx(styles.sidebarItemTitle, styles.sidebarSectionTitle)}>
+              {sidebar.title}
+            </div>
+          </>
+        ) : (
+          <div className={clsx(styles.sidebarItemTitle, 'margin-bottom--md')}>{sidebar.title}</div>
+        )}
         <BlogSidebarContent
-          items={items}
+          items={rest}
           ListComponent={ListComponent}
           yearGroupHeadingClassName={styles.yearGroupHeading}
         />

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
@@ -4,10 +4,12 @@ import Link from '@docusaurus/Link';
 import {translate} from '@docusaurus/Translate';
 import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
+import {useLocation} from '@docusaurus/router';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
 import {
   useBlogSidebarLabel,
   usePartitionedBlogItems,
+  useTagScopedItems,
 } from '@site/src/theme/BlogSidebar/blogSidebarLabel';
 import styles from './styles.module.css';
 
@@ -59,10 +61,17 @@ const ListComponent = ({items}: {items: Array<{title: string; permalink: string}
 };
 
 function BlogSidebarDesktop({sidebar}: any): React.JSX.Element {
-  const items = useVisibleBlogSidebarItems(sidebar.items);
+  const allItems = useVisibleBlogSidebarItems(sidebar.items);
+  const {pathname} = useLocation();
+  // On a /tags/<tag> page, scope the sidebar to that tag so it matches the filtered main
+  // area (otherwise the heading says "1 post" while the sidebar shows everything).
+  const {items, tag} = useTagScopedItems(allItems, pathname);
   // Pinned posts (`pinned: true` / `kind: legend`) render ABOVE the year groups so an
-  // index/keystone isn't buried by its date; the rest year-group as normal.
-  const [pinned, rest] = usePartitionedBlogItems(items);
+  // index/keystone isn't buried by its date; the rest year-group as normal. (Skip pinning
+  // when scoped to a tag — the list is already short and on-topic.)
+  const [pinnedRaw, restRaw] = usePartitionedBlogItems(items);
+  const pinned = tag ? [] : pinnedRaw;
+  const rest = tag ? items : restRaw;
   return (
     <aside className="col col--3">
       <nav
@@ -72,7 +81,22 @@ function BlogSidebarDesktop({sidebar}: any): React.JSX.Element {
           message: 'Blog recent posts navigation',
           description: 'The ARIA label for recent posts in the blog sidebar',
         })}>
-        {pinned.length > 0 ? (
+        {tag ? (
+          // Scoped to a tag: show the active tag as a cancelable facet. The × clears back
+          // to all posts (the blog root), matching the tag-filtered main area.
+          <div className={clsx(styles.sidebarItemTitle, 'margin-bottom--md')}>
+            <span className={styles.tagFacet}>
+              <span className={styles.tagFacetLabel}>{tag}</span>
+              <Link
+                to="/thoughts"
+                className={styles.tagFacetClear}
+                aria-label={`Clear the "${tag}" tag filter`}
+                title="Show all posts">
+                &times;
+              </Link>
+            </span>
+          </div>
+        ) : pinned.length > 0 ? (
           <>
             {/* Pinned legends/keystones get their own "Guides" section at the very top; the
                 dated posts below keep the "Posts" heading (sidebar.title). */}

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/styles.module.css
@@ -52,3 +52,35 @@
   margin-top: 1.6rem;
   margin-bottom: 0.4rem;
 }
+
+/* Active-tag facet: a cancelable chip shown as the sidebar heading on a /tags/<tag> page. */
+.tagFacet {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.4rem 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  background: color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 35%, transparent);
+  color: var(--ifm-color-primary-darker, var(--ifm-color-primary));
+}
+.tagFacetLabel {
+  font-weight: 600;
+}
+.tagFacetClear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: inherit;
+  text-decoration: none;
+}
+.tagFacetClear:hover {
+  background: color-mix(in srgb, var(--ifm-color-primary) 22%, transparent);
+  text-decoration: none;
+}

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/styles.module.css
@@ -14,6 +14,13 @@
   font-weight: var(--ifm-font-weight-bold);
 }
 
+/* The "Posts" heading when it follows the pinned "Guides" section: add space above so the
+   two sections read as distinct. */
+.sidebarSectionTitle {
+  margin-top: 1.8rem;
+  margin-bottom: var(--ifm-spacing-vertical, 1rem);
+}
+
 .sidebarItemList {
   font-size: 0.9rem;
 }

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
@@ -4,10 +4,12 @@ import Link from '@docusaurus/Link';
 import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client';
 import {NavbarSecondaryMenuFiller} from '@docusaurus/theme-common';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
+import {useLocation} from '@docusaurus/router';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
 import {
   useBlogSidebarLabel,
   usePartitionedBlogItems,
+  useTagScopedItems,
 } from '@site/src/theme/BlogSidebar/blogSidebarLabel';
 import styles from './styles.module.css';
 
@@ -45,10 +47,22 @@ const ListComponent = ({items}: {items: Array<{title: string; permalink: string}
 };
 
 function BlogSidebarMobileSecondaryMenu({sidebar}: any) {
-  const items = useVisibleBlogSidebarItems(sidebar.items);
-  const [pinned, rest] = usePartitionedBlogItems(items);
+  const allItems = useVisibleBlogSidebarItems(sidebar.items);
+  const {pathname} = useLocation();
+  const {items, tag} = useTagScopedItems(allItems, pathname);
+  const [pinnedRaw, restRaw] = usePartitionedBlogItems(items);
+  const pinned = tag ? [] : pinnedRaw;
+  const rest = tag ? items : restRaw;
   return (
     <>
+      {tag && (
+        <div className={clsx('menu__list-item-collapsible', styles.mobileSectionTitle)}>
+          Tagged: {tag}{' '}
+          <Link to="/thoughts" aria-label={`Clear the "${tag}" tag filter`}>
+            &times;
+          </Link>
+        </div>
+      )}
       {pinned.length > 0 && (
         <>
           <div className={clsx('menu__list-item-collapsible', styles.mobileSectionTitle)}>Guides</div>

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
@@ -1,10 +1,14 @@
 import React, {memo} from 'react';
+import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client';
 import {NavbarSecondaryMenuFiller} from '@docusaurus/theme-common';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
-import {useBlogSidebarLabel} from '@site/src/theme/BlogSidebar/blogSidebarLabel';
+import {
+  useBlogSidebarLabel,
+  usePartitionedBlogItems,
+} from '@site/src/theme/BlogSidebar/blogSidebarLabel';
 import styles from './styles.module.css';
 
 // Swizzled @theme/BlogSidebar/Mobile: mirrors upstream, adding the same dev-only
@@ -42,12 +46,24 @@ const ListComponent = ({items}: {items: Array<{title: string; permalink: string}
 
 function BlogSidebarMobileSecondaryMenu({sidebar}: any) {
   const items = useVisibleBlogSidebarItems(sidebar.items);
+  const [pinned, rest] = usePartitionedBlogItems(items);
   return (
-    <BlogSidebarContent
-      items={items}
-      ListComponent={ListComponent}
-      yearGroupHeadingClassName={styles.yearGroupHeading}
-    />
+    <>
+      {pinned.length > 0 && (
+        <>
+          <div className={clsx('menu__list-item-collapsible', styles.mobileSectionTitle)}>Guides</div>
+          <ListComponent items={pinned} />
+          <div className={clsx('menu__list-item-collapsible', styles.mobileSectionTitle)}>
+            {sidebar.title}
+          </div>
+        </>
+      )}
+      <BlogSidebarContent
+        items={rest}
+        ListComponent={ListComponent}
+        yearGroupHeadingClassName={styles.yearGroupHeading}
+      />
+    </>
   );
 }
 

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/styles.module.css
@@ -5,3 +5,9 @@
 .yearGroupHeading {
   margin: 1rem 0.75rem 0.5rem;
 }
+
+/* "Guides" / "Posts" section headings above the pinned + dated lists (mobile). */
+.mobileSectionTitle {
+  font-weight: var(--ifm-font-weight-bold);
+  cursor: default;
+}

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/blogSidebarLabel.ts
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/blogSidebarLabel.ts
@@ -38,3 +38,32 @@ export function useBlogSidebarLabel(permalink: string | undefined, title: string
   if (!permalink) return title;
   return labels[normalize(permalink)] ?? title;
 }
+
+// Posts pinned ABOVE the year groups (`pinned: true` or `kind: legend`). The plugin
+// publishes their permalinks; the swizzled BlogSidebar pulls these out of the year-grouped
+// list and renders them at the very top, so an index/keystone isn't buried by its date.
+function useBlogPinnedPermalinks(): Set<string> {
+  const data = useAllPluginInstancesData('draft-docs-plugin') as
+    | {default?: {blogPinnedPermalinks?: string[]}}
+    | undefined;
+  const list = data?.default?.blogPinnedPermalinks ?? [];
+  return React.useMemo(() => new Set(list.map(normalize)), [list]);
+}
+
+export type BlogSidebarItem = {title: string; permalink: string; [k: string]: unknown};
+
+/**
+ * Split sidebar items into [pinned, rest]. Pinned items keep their source order; rest is
+ * left untouched for the normal year grouping. Use in the BlogSidebar swizzle.
+ */
+export function usePartitionedBlogItems(items: BlogSidebarItem[]): [BlogSidebarItem[], BlogSidebarItem[]] {
+  const pinned = useBlogPinnedPermalinks();
+  return React.useMemo(() => {
+    const top: BlogSidebarItem[] = [];
+    const rest: BlogSidebarItem[] = [];
+    for (const item of items) {
+      (pinned.has(normalize(item.permalink)) ? top : rest).push(item);
+    }
+    return [top, rest];
+  }, [items, pinned]);
+}

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/blogSidebarLabel.ts
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/blogSidebarLabel.ts
@@ -52,6 +52,47 @@ function useBlogPinnedPermalinks(): Set<string> {
 
 export type BlogSidebarItem = {title: string; permalink: string; [k: string]: unknown};
 
+// permalink -> tag slugs, published by the plugin so the sidebar can scope to a tag page.
+function useBlogPostTags(): Record<string, string[]> {
+  const data = useAllPluginInstancesData('draft-docs-plugin') as
+    | {default?: {blogPostTags?: Record<string, string[]>}}
+    | undefined;
+  const raw = data?.default?.blogPostTags ?? {};
+  return React.useMemo(() => {
+    const out: Record<string, string[]> = {};
+    for (const [permalink, tags] of Object.entries(raw)) out[normalize(permalink)] = tags;
+    return out;
+  }, [raw]);
+}
+
+/**
+ * The tag slug the current page is filtered by, or null. Reads the URL: a blog tag page is
+ * `<route>/tags/<tagSlug>` (e.g. /thoughts/tags/technical-debt). Pass the current pathname.
+ */
+export function currentTagSlug(pathname: string): string | null {
+  const m = pathname.match(/\/tags\/([^/]+)\/?$/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/**
+ * Scope sidebar items to the active tag when on a tag page; otherwise return them unchanged.
+ * So the left "Posts" list matches the tag-filtered main area instead of showing everything.
+ */
+export function useTagScopedItems(
+  items: BlogSidebarItem[],
+  pathname: string,
+): {items: BlogSidebarItem[]; tag: string | null} {
+  const tagMap = useBlogPostTags();
+  const tag = currentTagSlug(pathname);
+  const scoped = React.useMemo(() => {
+    if (!tag) return items;
+    const filtered = items.filter((it) => (tagMap[normalize(it.permalink)] ?? []).includes(tag));
+    // If we somehow matched nothing (tag map missing), don't hide the whole sidebar.
+    return filtered.length ? filtered : items;
+  }, [items, tagMap, tag]);
+  return {items: scoped, tag};
+}
+
 /**
  * Split sidebar items into [pinned, rest]. Pinned items keep their source order; rest is
  * left untouched for the normal year grouping. Use in the BlogSidebar swizzle.


### PR DESCRIPTION
Two related blog-sidebar improvements (both in the BlogSidebar swizzle + draft-docs plugin).

## 1. A "Guides" section pins legends above the dated "Posts"
The "Start Here" legend sorted by date, so it sat under the 2026 year group. Now:
- A post pins via **`pinned: true`**; any **`kind: legend`** pins automatically.
- The plugin publishes the pinned set; the swizzle renders pinned items under a **Guides** heading at the top, then the dated posts under **Posts** with the year groups.

```
Guides
  🧭 Start Here
  🧭 Ask Myself
Posts
  2026 ...
```

## 2. Tag pages scope the sidebar + show a cancelable facet
On `/thoughts/tags/<tag>` the main area filtered to the tag but the sidebar listed every post. Now:
- The plugin publishes a `{permalink → tag slugs}` map.
- The swizzle reads the tag from the URL and **scopes the sidebar** to posts with that tag.
- The heading becomes a cancelable **facet chip** (`technical-debt ✕`); the × clears back to `/thoughts`.

Posts keep their real dates; only sidebar placement/scope changes.

## Verification
- Dev: Guides/Posts split renders; tag page shows only the tagged post + the facet; × restores the full sidebar (screenshots captured).
- Full prod `yarn build` → `[SUCCESS]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)