### PR TITLE
fix(thoughts): re-date 4 imported scan posts to their true origin (breadcrumb-traced)

### DIFF
--- a/bytesofpurpose-blog/blog/2018-01-01-a-taxonomy-of-learning-resources.mdx
+++ b/bytesofpurpose-blog/blog/2018-01-01-a-taxonomy-of-learning-resources.mdx
@@ -6,7 +6,7 @@ sidebar_label: "Learning Resources"
 description: "The full menu of places you can learn from, and the questions worth asking before you commit time to any of them."
 authors: [oeid]
 tags: [productivity]
-date: 2026-01-27
+date: 2018-01-01
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2019-01-01-affirmations-for-the-inner-game.md
+++ b/bytesofpurpose-blog/blog/2019-01-01-affirmations-for-the-inner-game.md
@@ -6,7 +6,7 @@ sidebar_label: "Inner Game"
 description: "A collection of faith-based and motivational affirmations I've returned to over the years, organized by theme: faith, strength, discipline, failure, focus, confidence, and living fully."
 authors: [oeid]
 tags: [mindset]
-date: 2026-01-27
+date: 2019-01-01
 # image: /img/REPLACE-ME.jpg  # add a social/card image before publishing
 draft: true
 ---

--- a/bytesofpurpose-blog/blog/2020-03-23-the-song-of-life.md
+++ b/bytesofpurpose-blog/blog/2020-03-23-the-song-of-life.md
@@ -6,7 +6,7 @@ sidebar_label: "Song of Life"
 description: "A set of philosophical reflections on life, death, purpose, words, and the strange symmetry between programs and existence."
 authors: [oeid]
 tags: [philosophy, mindset]
-date: 2026-01-27
+date: 2020-03-23
 draft: true
 ---
 

--- a/bytesofpurpose-blog/blog/2020-05-26-a-framework-for-prioritizing.md
+++ b/bytesofpurpose-blog/blog/2020-05-26-a-framework-for-prioritizing.md
@@ -6,7 +6,7 @@ sidebar_label: "Prioritizing"
 description: "Prioritizing isn't a one-time ranking. It's a set of recurring questions: what factors matter, how to evaluate candidates, when to de-prioritize, and how to get better at it over time."
 authors: [oeid]
 tags: [productivity]
-date: 2026-01-28
+date: 2020-05-26
 draft: true
 ---
 


### PR DESCRIPTION
## What

Four imported "scan" posts were dated **2026-01** (the import/reorg commit) but their content is years older. Re-dated them to their true origin using the new **`find-true-date`** breadcrumb tracer (committed to the hats repo separately).

| Post | was | now | evidence |
|---|---|---|---|
| the-song-of-life | 2026-01-27 | **2020-03-23** | git pickaxe (content first appeared in history) |
| a-framework-for-prioritizing | 2026-01-28 | **2020-05-26** | git pickaxe |
| affirmations-for-the-inner-game | 2026-01-27 | **2019-01-01** | in-note `>2019` annotation |
| a-taxonomy-of-learning-resources | 2026-01-27 | **2018-01-01** | in-note (earliest of 2018-2022 span) |

`git --follow` dead-ends at the Jan-2026 reorg, so the **pickaxe** (`git log --all -S"<distinctive line>"`) is what recovered the real dates for content git couldn't trace through a reword/move.

Filename prefix + frontmatter `date:` updated; **slugs unchanged** (URLs preserved). `what-i-ask-myself` and `how-i-ask-others-questions` are genuinely 2026 (newly written) and were **not** touched.

## Verification
- Dev: the-song-of-life renders "March 23, 2020"; sidebar groups posts under their true years (2018/2019/2020).
- Outline validator clean; full prod `yarn build` → `[SUCCESS]`. Posts remain `draft: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)