### PR TITLE
fix(designs): correct 12 broken intra-doc anchors in the 4 published HLDs

### DIFF
--- a/bytesofpurpose-blog/designs/2026-02-27-autonomous-build-agents.mdx
+++ b/bytesofpurpose-blog/designs/2026-02-27-autonomous-build-agents.mdx
@@ -328,7 +328,7 @@ flowchart TB
 ```
 
 :::note[Note]
-The user persona is itself an open decision ([D5](#d5-feedback--interaction--who-is-the-user)); initial scope assumes in-house implementors/consultants, with partners and clients as later expansions.
+The user persona is itself an open decision ([D5](#d5-feedback--interaction-who-is-the-user)); initial scope assumes in-house implementors/consultants, with partners and clients as later expansions.
 :::
 
 ## 2. Objectives
@@ -1479,7 +1479,7 @@ Via the Target System registry (Section 7.2). Each instance has its own entry wi
 
 **Q3: Which MCP server would we use?**
 For Option A, MCP is not required for the core flow. REST API integration (Table API + Metadata API) may suffice for read-only pre-flight and validation. <Assumption>Direct REST is simpler than full MCP for Option A.</Assumption>
-→ [§6.2 Architecture Options](#62-architecture-options) · [§B.2 MCP Support. Both Client AND Server](#b2-mcp-support--both-client-and-server)
+→ [§6.2 Architecture Options](#62-architecture-options) · [§B.2 MCP Support. Both Client AND Server](#b2-mcp-support-both-client-and-server)
 
 **Q4: What should be done on the client tenant vs on the internal build instance?**
 **Internal build instance:** All planning, reasoning, commit generation, work-item management, KT logging. **Client tenant:** Instance Commit apply (manual preview + commit), validation queries (read-only). **Shared repo:** Instance Commit transfer.

--- a/bytesofpurpose-blog/designs/2026-06-21-ecommerce-site-scanner-and-lead-generation-engine.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-21-ecommerce-site-scanner-and-lead-generation-engine.mdx
@@ -1048,7 +1048,7 @@ _This FAQ doubles as a **question-index** into the document: each answer links t
 → [§6.5 Key Design Decisions](#65-key-design-decisions) · [§13.1 Risks](#131-risks)
 
 **Q: What stops cost from exploding?** The fit gate before contact-finding (Section 10.1): paid calls only fire for leads that already pass size + ICP; plus cheap-first escalation throughout.
-→ [§10.1 Sequence Diagram. One Candidate Through the Pipeline](#101-sequence-diagram--one-candidate-through-the-pipeline)
+→ [§10.1 Sequence Diagram. One Candidate Through the Pipeline](#101-sequence-diagram-one-candidate-through-the-pipeline)
 
 **Q: How does this become the self-healing service?** The scanner's structured signal taxonomy (D4) *is* the action space for auto-remediation. Phase 1 builds and validates detection at scale; Phase 2 adds the "fix it" capability on top.
 → [§6.5 Key Design Decisions](#65-key-design-decisions) · [§3.2 Out of Scope](#32-out-of-scope)

--- a/bytesofpurpose-blog/designs/2026-06-22-markdown-review-studio.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-markdown-review-studio.mdx
@@ -93,7 +93,7 @@ The most consequential decisions, all **Decided**: comments are anchored by **in
 
 **Expected value:** a low-friction, repeatable review loop with durable, traceable, directly-actionable feedback: reusable across any markdown repository, not just this one (§1.7). Time savings are an <Assumption /> pending dogfooding.
 
-**Current status: In Review.** The single-user local mode is Phase 1; a hosted multi-user cloud mode is Phase 3. The biggest open questions concern comment-commit strategy, non-git target folders, and cloud pricing/secrets infrastructure: see [§10.3 Open Questions](#103-open-questions).
+**Current status: In Review.** The single-user local mode is Phase 1; a hosted multi-user cloud mode is Phase 3. The biggest open questions concern comment-commit strategy, non-git target folders, and cloud pricing/secrets infrastructure: see [§13.3 Open Questions](#133-open-questions).
 
 ---
 
@@ -1189,7 +1189,7 @@ A navigational index: if you're wondering about X, this is where the document de
 
 | Key question | Decision | Section |
 |--------------|----------|---------|
-| Where do comments physically live; in the `.md` or beside it? | D1 + D4 | [§6.5 D1](#d1--comment-anchoring-strategy--core-technical-bet), [§6.5 D4](#d4--comment-storage-hybrid-inline-anchors--sidecar-threads) |
+| Where do comments physically live; in the `.md` or beside it? | D1 + D4 | [§6.5 D1](#d1-comment-anchoring-strategy--core-technical-bet), [§6.5 D4](#d4-comment-storage-hybrid-inline-anchors--sidecar-threads) |
 | How do comments stay attached when the doc is edited? | D1 (inline markers + fuzzy fallback) | §6.5 D1, Appendix A |
 | What does a comment look like on disk? | Sidecar schema worked example | §6.5 D4 |
 | How are the four comment types (range/block/point/doc) anchored? | D1 "How it works" | §6.5 D1 |
@@ -1218,16 +1218,16 @@ A navigational index: if you're wondering about X, this is where the document de
 A: PR comments anchor to *diff lines*, not the *rendered* doc (Mermaid/tables/prose), require push+PR ceremony, and don't drive Claude. This tool comments on the rendered doc locally and closes the loop to Claude automatically. → [§4.2 Existing Tooling](#42-existing-tooling) · [§5.1 Problem Statement](#51-problem-statement)
 
 **Q: Why auto-apply instead of review-then-apply?**
-A: For a single-user local tool, git revert is a sufficient safety net and keeps the loop fast (§6.5 D5). A gated diff/accept mode is a Phase 3 option if needed. → [§6.5 D5: Edit apply model](#d5--edit-apply-model)
+A: For a single-user local tool, git revert is a sufficient safety net and keeps the loop fast (§6.5 D5). A gated diff/accept mode is a Phase 3 option if needed. → [§6.5 D5: Edit apply model](#d5-edit-apply-model)
 
 **Q: Why Claude Code CLI instead of the API?**
-A: It reuses the author's existing setup, skills, CLAUDE.md, co-design conventions, MCP, and repo-wide context, with minimal new code (§6.4). The orchestrator is behind an interface, so the API/Agent SDK can be swapped in later. → [§6.5 D2: Claude invocation mechanism](#d2--claude-invocation-mechanism) · [§6.4 Recommendation](#64-recommendation)
+A: It reuses the author's existing setup, skills, CLAUDE.md, co-design conventions, MCP, and repo-wide context, with minimal new code (§6.4). The orchestrator is behind an interface, so the API/Agent SDK can be swapped in later. → [§6.5 D2: Claude invocation mechanism](#d2-claude-invocation-mechanism) · [§6.4 Recommendation](#64-recommendation)
 
 **Q: What happens to a comment whose text Claude rewrote entirely?**
-A: The inline markers normally move with the text (D1). If Claude drops a marker, the `validateEdit` hook catches it (D9) and the server attempts fuzzy recovery (block → position → quote, Appendix A); if that fails the comment is marked `orphaned` and surfaced for re-placement; never silently dropped (§9.5 guardrail). → [§6.5 D1: Comment anchoring strategy](#d1--comment-anchoring-strategy--core-technical-bet) · [§6.5 D9: Edit-validation hooks](#d9--edit-validation-hooks) · [§9.5 Compliance & Constraints](#95-compliance--constraints)
+A: The inline markers normally move with the text (D1). If Claude drops a marker, the `validateEdit` hook catches it (D9) and the server attempts fuzzy recovery (block → position → quote, Appendix A); if that fails the comment is marked `orphaned` and surfaced for re-placement; never silently dropped (§11.5 guardrail). → [§6.5 D1: Comment anchoring strategy](#d1-comment-anchoring-strategy--core-technical-bet) · [§6.5 D9: Edit-validation hooks](#d9-edit-validation-hooks-) · [§11.5 Compliance & Constraints](#115-compliance--constraints)
 
 **Q: Won't the inline markers clutter my markdown?**
-A: They're terse HTML comments (`<!--rc:start id=ab12-->`); invisible in every renderer (GitHub, VS Code preview, the studio viewer). They appear only in the raw source and diffs; D4 allows committing marker/sidecar changes separately to keep `git log` clean. → [§6.5 D4: Comment storage](#d4--comment-storage-hybrid-inline-anchors--sidecar-threads)
+A: They're terse HTML comments (`<!--rc:start id=ab12-->`); invisible in every renderer (GitHub, VS Code preview, the studio viewer). They appear only in the raw source and diffs; D4 allows committing marker/sidecar changes separately to keep `git log` clean. → [§6.5 D4: Comment storage](#d4-comment-storage-hybrid-inline-anchors--sidecar-threads)
 
 ## Appendices
 

--- a/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
@@ -367,7 +367,7 @@ graph LR
 
 ## 4. Current State (As-Is)
 
-This section describes how DIY ecommerce merchants approach conversion optimization and experimentation **today**, and the tooling landscape they would have to navigate. See [Appendix A](#appendix-a--cro-tooling--methods-research) for the sourced market and method research behind this section.
+This section describes how DIY ecommerce merchants approach conversion optimization and experimentation **today**, and the tooling landscape they would have to navigate. See [Appendix A](#appendix-a-cro-tooling--methods-research) for the sourced market and method research behind this section.
 
 ### 4.1 How a DIY Merchant Optimizes Conversion Today
 
@@ -377,7 +377,7 @@ For a typical solo/small ecommerce merchant, the current state is one of three m
 
 2. **Guess and ship (no testing).** The owner reads a blog post, changes the headline or button, and ships it to 100% of traffic: with no control group and no measurement. If sales dip, they may never connect it to the change. Improvements and regressions are equally invisible. This is *worse* than nothing when a confident change quietly suppresses conversion.
 
-3. **Adopt a testing tool (rare, and it usually fails).** A motivated owner installs an A/B testing app (Shopify-native like **Shoplift**/**Intelligems**, or a platform like **VWO**/**Optimizely**: see [Appendix A](#appendix-a--cro-tooling--methods-research)). They then face: manual hypothesis creation, manual variant building, statistical dashboards built for analysts, and the patience to wait weeks for significance. Most tests are abandoned, mis-configured, or "decided" on noise. The tool assumes an expert operator who isn't there.
+3. **Adopt a testing tool (rare, and it usually fails).** A motivated owner installs an A/B testing app (Shopify-native like **Shoplift**/**Intelligems**, or a platform like **VWO**/**Optimizely**: see [Appendix A](#appendix-a-cro-tooling--methods-research)). They then face: manual hypothesis creation, manual variant building, statistical dashboards built for analysts, and the patience to wait weeks for significance. Most tests are abandoned, mis-configured, or "decided" on noise. The tool assumes an expert operator who isn't there.
 
 ```mermaid
 graph LR
@@ -392,7 +392,7 @@ graph LR
 
 ### 4.2 The Tooling Landscape
 
-Today's experimentation tools cluster into three groups, all built for a **human expert operator**, not an autonomous agent or a non-expert owner _([Appendix A](#appendix-a--cro-tooling--methods-research))_:
+Today's experimentation tools cluster into three groups, all built for a **human expert operator**, not an autonomous agent or a non-expert owner _([Appendix A](#appendix-a-cro-tooling--methods-research))_:
 
 | Group | Examples | Built for | Gap for our user |
 |-------|----------|-----------|------------------|
@@ -404,7 +404,7 @@ Today's experimentation tools cluster into three groups, all built for a **human
 
 ### 4.3 The Statistical Reality for Mid-Market Stores
 
-Because target stores span low- to mid-traffic, the **classic fixed-sample, frequentist** approach most tools default to is often a poor fit _([Appendix A](#appendix-a--cro-tooling--methods-research))_:
+Because target stores span low- to mid-traffic, the **classic fixed-sample, frequentist** approach most tools default to is often a poor fit _([Appendix A](#appendix-a-cro-tooling--methods-research))_:
 
 - A store with ~500 weekly users at a 2% baseline conversion needs on the order of **16 weeks** to detect even a large (50%) relative improvement with fixed-sample frequentist methods.[^a3] Most owners won't wait, so tests die inconclusive.
 - **Sequential** and **Bayesian** methods adapt during the test and can require **20 to 80% fewer users** than an equivalent fixed-sample test,[^a4] and they yield an intuitive output ("91% chance B beats A") instead of a p-value.[^a2]
@@ -626,7 +626,7 @@ This phasing mirrors CO-DESIGN-0002's philosophy: **earn the right to build the 
 - **Question:** How do we produce trustworthy decisions across low- to mid-traffic stores?
 - **Options:** Fixed-sample frequentist · Bayesian · Sequential · Multi-armed bandit · Hybrid (method chosen per store by traffic).
 - **Status:** **Leaning: hybrid, Bayesian/sequential default.** Bandits for eligible high-traffic, always-on optimizations.
-- **Rationale:** Sequential/Bayesian need 20 to 80% fewer users and give intuitive probabilities ([Appendix A](#appendix-a--cro-tooling--methods-research)); fixed-sample only where traffic supports it. Enforce minimum-runtime and stop rules to prevent peeking errors.
+- **Rationale:** Sequential/Bayesian need 20 to 80% fewer users and give intuitive probabilities ([Appendix A](#appendix-a-cro-tooling--methods-research)); fixed-sample only where traffic supports it. Enforce minimum-runtime and stop rules to prevent peeking errors.
 
 #### D3: Autonomy & guardrails model
 
@@ -640,7 +640,7 @@ This phasing mirrors CO-DESIGN-0002's philosophy: **earn the right to build the 
 - **Question:** How are hypotheses generated and prioritized?
 - **Options:** Scanner-findings-seeded · analytics-anomaly-driven · LLM-reasoned from best practice · all three combined; prioritized by **expected lift × confidence × ease**.
 - **Status:** **Leaning: combined, scanner-seeded, with an explicit prioritization score.**
-- **Rationale:** Grounding in the scanner's real findings + the store's own analytics avoids generic suggestions (G1); the score keeps the backlog ranked and biases toward high-lift tests on low-traffic stores ([Appendix A](#a1)).
+- **Rationale:** Grounding in the scanner's real findings + the store's own analytics avoids generic suggestions (G1); the score keeps the backlog ranked and biases toward high-lift tests on low-traffic stores ([Appendix A](#a1-tooling-landscape-2026)).
 
 #### D5: Variant generation
 


### PR DESCRIPTION
The 4 newly-published design HLDs had cross-section links whose anchor targets didn't match the github-slugger heading ids (wrong section numbers like #103→#133, extra hyphens like #d1--→#d1-, a couple short targets). Fixed all 12, computed with the real slugger.

Build now has **zero** broken anchors in the design docs (the one remaining is the pre-existing `/craft/premium-gating-demo`, unrelated). Unblocks the publish deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)