### PR TITLE
docs(skills): capture this session's publish/deploy/sidebar learnings

### DIFF
--- a/.claude/skills/author-blog-post/SKILL.md
+++ b/.claude/skills/author-blog-post/SKILL.md
@@ -64,6 +64,25 @@ sidebar_label: "What Is GTM?"  # SHORT (<= 3 CONTENT words) sidebar entry; NO em
   don't count). For the "What I Ask Myself" series, drop the repeated prefix
   (e.g. `sidebar_label: "Finding Purpose"`). Required mechanism: the blog plugin does NOT
   read `sidebar_label` natively; our `draft-docs` plugin + `BlogSidebar` swizzle do.
+- **`pinned: true`** lifts a post ABOVE the year groups into a top **"Guides"** section
+  (the dated posts sit under a **"Posts"** heading below). Any **`kind: legend`** pins
+  automatically (an index/keystone shouldn't be buried by its date). The post keeps its real
+  date; only sidebar PLACEMENT changes.
+
+> **Where the sidebar behaviors live (when you need to change one).** The Posts-sidebar
+> features are NOT Docusaurus defaults — they're a swizzle + plugin pair:
+> - **`plugins/draft-docs/index.js`** walks every blog post and publishes maps via global
+>   data: `blogSidebarLabels` (the rendered `<kind emoji> + (sidebar_label||title)`),
+>   `blogPinnedPermalinks` (pinned/legend posts), `blogDraftPermalinks` (the dev-only "D"
+>   badge), and `blogPostTags` (permalink → tag slugs).
+> - **`src/theme/BlogSidebar/{Desktop,Mobile}/index.tsx`** (+ the `blogSidebarLabel.ts`
+>   helpers) consume those: render the short label, the Guides/Posts split, and — on a
+>   `/thoughts/tags/<tag>` page — **scope the sidebar to that tag** and show a **cancelable
+>   facet chip** (`<tag> ✕`, the × clears back to `/thoughts`). So the sidebar matches the
+>   tag-filtered main area instead of listing every post.
+> Add a new per-post sidebar behavior by publishing a map in the plugin and reading it in
+> the swizzle (mirror how `pinned`/tags work). The `kind → emoji` itself comes from
+> `blog-kinds.json` (the plugin reads it); never hand-type an emoji in a title or label.
 
 **Validation (warn-tier, via `validate-post-outline.js` + its `Write|Edit` hook). All read
 their rules from `blog-kinds.json`, and the hook prints the FULL legend + the kind's contract

--- a/.claude/skills/deploy-site/SKILL.md
+++ b/.claude/skills/deploy-site/SKILL.md
@@ -52,7 +52,17 @@ Access bypass app); see the `manage-cloudflare-access` skill if that changes.
 4. **MDX content bugs fail the build late** (during SSR), e.g. bare `<br>` (use
    `<br/>`) or unescaped `{word}` in `.mdx` (wrap in backticks). Run `make check`
    and a full build before deploying. See the `author-blog-post` skill.
-5. Deploy publishes to the `gh-pages` branch via `yarn deploy` (USE_SSH, GIT_USER).
+5. **Stale `.docusaurus` route cache → `Module not found: @generated/…` build failure.**
+   A build that aborts with a flood of `Module not found: Error: Can't resolve
+   '@generated/docusaurus-plugin-content-docs/craft/p/craft-tags-*.json'` (or similar
+   `@generated/.../p/*.json`) is NOT a content bug — it's a stale `.docusaurus` generated-
+   routes cache disagreeing with the current content (common after un-drafting/renaming/
+   deleting posts, or switching branches). **Fix: fully clear the caches and rebuild:**
+   `rm -rf bytesofpurpose-blog/{.docusaurus,node_modules/.cache,build}` then re-run the
+   build. (`make build-premium` clears `node_modules/.cache` + `.docusaurus`, but a stale
+   `build/` or a partial clear can still bite — when in doubt, nuke all three.) Hit this
+   mid-deploy on the 2026-06 publish; the clear-and-rebuild resolved it cleanly.
+6. Deploy publishes to the `gh-pages` branch via `yarn deploy` (USE_SSH, GIT_USER).
 
 ## Procedure
 

--- a/.claude/skills/publish-site/SKILL.md
+++ b/.claude/skills/publish-site/SKILL.md
@@ -67,6 +67,22 @@ before deploy.
 > Blog vs docs: in a production build Docusaurus excludes `draft: true` from routes &
 > sitemap (verified — a draft doc 404s live). So un-drafting is what makes a page public.
 
+> **⚠️ Publish the whole link CLUSTER, not one post in isolation.** If a post you publish
+> links to ANOTHER draft (e.g. a `/thoughts` design-story post links its `/designs` HLD, or
+> any post links a sibling that's still `draft: true`), the link 404s in production because
+> the target is excluded from the prod build. The **prod build is what catches this**: a
+> bare `yarn build` (or `make build-premium`) prints `Broken link on source page path = …
+> -> linking to /<target>`. So after un-drafting, ALWAYS run a full prod build and grep for
+> `Broken link`; if a published post points at a draft, **un-draft the linked target too**
+> (publish the cluster together) — or, if the target isn't ready, soften/remove the link.
+> This bit the 2026-06 design-showcase publish: the 4 design-story posts shipped pointing at
+> draft HLDs; the fix was to publish the 5 linked `/designs` docs in the same pass. (Broken
+> ANCHORS, `-> linking to #section`, are warn-tier by site policy — `onBrokenAnchors: 'warn'`
+> in `docusaurus.config.js` — so they don't fail the build, but they're worth fixing in
+> freshly-published content: match the link's `#anchor` to the target heading's real
+> github-slugger id, e.g. a `### 13.3 Open Questions` heading is `#133-open-questions`,
+> and a heading with a dropped `&`/emoji between spaces yields a double hyphen `--`.)
+
 ## Step 3 — Deploy
 
 Hand off to the **deploy-site** skill (or inline):
@@ -94,5 +110,7 @@ PostHog beacon lives in the JS bundle (not inline HTML) — check
 |---|---|---|
 | Un-drafted page still 404s live | Deploy didn't run / propagation lag | Re-run `make deploy`; GH Pages takes 1–2 min. |
 | Build fails right after un-drafting | Draft had MDX breakers never built before | Fix per `author-blog-post` (`<br/>`, backtick `{braces}`); rebuild. |
+| `Broken link … -> linking to /<x>` after un-drafting | A published post links a still-`draft:true` target (excluded from prod) | Publish the whole cluster: un-draft the linked target too (or soften the link). |
+| `Module not found: @generated/…craft-tags-*.json` during the deploy build | Stale `.docusaurus` route cache | `rm -rf bytesofpurpose-blog/{.docusaurus,node_modules/.cache,build}` then rebuild (see `deploy-site`). |
 | `make deploy` aborts on secret-scan | A real or historical leak | See `manage-repo-security` / the leaked-creds memory; don't bypass. |
 | Scorer lists a finished post as "review" | Short but complete (e.g. a tight how-to) | Score is a hint, not a gate — publish if you judge it ready. |


### PR DESCRIPTION
Flush the hard-won lessons from the design-showcase split + publish + deploy into the owning skills.

## `publish-site`
- **Publish the whole link CLUSTER.** A published post that links a still-`draft:true` target (e.g. a `/thoughts` design-story → its `/designs` HLD) 404s in prod. The prod build's `Broken link` output catches it → un-draft the linked targets in the same pass. (This bit the design-showcase publish.)
- Troubleshooting rows for broken-link-on-publish and the stale-route build failure.

## `deploy-site`
- New **gotcha #5**: a `Module not found: @generated/…craft-tags-*.json` build failure is a **stale `.docusaurus` route cache** (common after un-draft/rename/delete/branch-switch), not a content bug. Fix: `rm -rf bytesofpurpose-blog/{.docusaurus,node_modules/.cache,build}` and rebuild. Hit this mid-deploy.

## `author-blog-post`
- Document the **BlogSidebar swizzle + draft-docs plugin** behaviors: `pinned:true`/`kind:legend` → a top **"Guides"** section above the dated **"Posts"**; tag pages **scope the sidebar** + show a **cancelable facet chip**; the plugin publishes the maps the swizzle reads. Plus where to look to change a per-post sidebar behavior, and that `kind→emoji` comes from `blog-kinds.json` (the one source of truth).

Docs-only (skill markdown). No code/content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)