### PR TITLE
Navbar hover/focus summary popups

### DIFF
--- a/bytesofpurpose-blog/src/theme/NavbarItem/index.tsx
+++ b/bytesofpurpose-blog/src/theme/NavbarItem/index.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import ComponentTypes from '@theme/NavbarItem/ComponentTypes';
+import styles from './navbarSummary.module.css';
+
+// One-line summary per navbar item, keyed by its `label`. The source of truth for the hover
+// popups — keep in sync with the navbar items in docusaurus.config.js. An item with no entry
+// here renders normally (no popup).
+const SUMMARIES: Record<string, string> = {
+  Craft: 'How I see the world: durable learnings, frameworks, and strategy. The lasting lessons.',
+  Journey: 'How I see myself: faith and personal growth. Durable, inward.',
+  Initiatives: 'The temporal half: dated experiments, project logs, and posts. What I actually did.',
+  Mindset: 'The quotes and ideas that moved me.',
+  Legend: 'The map for the whole site: durable vs temporal, the post-kind emoji, and the glossaries.',
+  Designs: 'Full system-design write-ups: how something was architected and shipped.',
+  Vote: 'Tell me which upcoming posts you want next.',
+  Todos: 'A rollup of every tracked task across the site: open, done, and scheduled.',
+  Support: 'Ways to support the work: the shop, GitHub, LinkedIn, and a coffee.',
+};
+
+function normalizeComponentType(type: string | undefined, props: Record<string, unknown>): string {
+  if (!type || type === 'default') {
+    return 'items' in props ? 'dropdown' : 'default';
+  }
+  return type;
+}
+
+/**
+ * Swizzled @theme/NavbarItem: identical to upstream, except a navbar item whose `label` has a
+ * SUMMARY gets wrapped in a small hover/focus popup describing the section. The popup is a
+ * DESKTOP affordance (shown via CSS on hover + focus-within); it is suppressed on the mobile
+ * nav drawer (which has no hover) and on narrow screens, so it never interferes with touch nav.
+ * Accessible: the wrapper is non-focusable (the link inside keeps its own focus), and the popup
+ * also appears on keyboard focus-within so a tabbing user sees it.
+ */
+export default function NavbarItem({type, ...props}: {type?: string} & Record<string, any>): React.JSX.Element {
+  const componentType = normalizeComponentType(type, props);
+  const NavbarItemComponent = (ComponentTypes as Record<string, React.ComponentType<any>>)[componentType];
+  if (!NavbarItemComponent) {
+    throw new Error(`No NavbarItem component found for type "${type}".`);
+  }
+
+  const item = <NavbarItemComponent {...props} />;
+  const summary = typeof props.label === 'string' ? SUMMARIES[props.label] : undefined;
+
+  // Only desktop, left-positioned primary items get the popup (skip dropdowns + right-side
+  // utility controls, where a popover would be awkward).
+  if (!summary || componentType === 'dropdown' || props.position === 'right') {
+    return item;
+  }
+
+  return (
+    <span className={styles.navItemWrap}>
+      {item}
+      <span className={styles.summaryPopup} role="tooltip" aria-hidden="true">
+        {summary}
+      </span>
+    </span>
+  );
+}

--- a/bytesofpurpose-blog/src/theme/NavbarItem/navbarSummary.module.css
+++ b/bytesofpurpose-blog/src/theme/NavbarItem/navbarSummary.module.css
@@ -1,0 +1,71 @@
+/* Navbar item hover-summary popup. A DESKTOP affordance: shown on hover or keyboard
+   focus-within, positioned just below the item. Suppressed on narrow screens / the mobile
+   nav drawer (which has no hover and where a popover would fight the touch UI). */
+
+.navItemWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.summaryPopup {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(-4px);
+  z-index: var(--ifm-z-index-fixed, 200);
+
+  width: max-content;
+  max-width: 16rem;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  font-weight: 400;
+  white-space: normal;
+  text-align: left;
+
+  color: var(--ifm-tooltip-color, var(--ifm-font-color-base));
+  background: var(--ifm-background-surface-color, var(--ifm-background-color));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.16);
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+/* A small arrow pointing up at the item. */
+.summaryPopup::before {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-bottom-color: var(--ifm-color-emphasis-200);
+}
+
+/* Show on hover OR keyboard focus within the item (so tabbing users see it too). */
+.navItemWrap:hover .summaryPopup,
+.navItemWrap:focus-within .summaryPopup {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* The popup is a pointer-device affordance. On the mobile nav drawer (<= 996px is Docusaurus'
+   navbar breakpoint) the items stack vertically and there is no hover, so suppress it entirely
+   to avoid layout/overlap surprises in the drawer. */
+@media (max-width: 996px) {
+  .summaryPopup {
+    display: none;
+  }
+}
+
+/* Don't animate for users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .summaryPopup {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Hovering (or keyboard-focusing) a primary navbar item now shows a small popup summarizing what that section is, so a visitor gets oriented without clicking.

## What's here
- **Swizzled `@theme/NavbarItem`** — wraps an item whose `label` has a summary in a hover/focus popup. Items without a summary (and dropdowns / right-side utility controls) render unchanged. The summaries map covers **Craft, Journey, Initiatives, Mindset, Legend, Designs, Vote, Todos, Support**.
- **`navbarSummary.module.css`** — a theme-aware card positioned just below the item (with an up-arrow), revealed on `:hover` OR `:focus-within` (so keyboard users see it too). `role="tooltip"`. Suppressed (`display:none`) at ≤996px so it never interferes with the mobile nav drawer (no hover on touch). `prefers-reduced-motion` respected.

## Verification
- Typecheck + build clean.
- **CB3 visual check** — desktop (1280px): the popup renders below the item (e.g. Legend → "The map for the whole site: durable vs temporal, the post-kind emoji, and the glossaries."), all 9 items wired, and it reveals on keyboard focus too. Mobile (375px): the popup is `display:none` (drawer unaffected).

**Please review and merge when ready — I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)