### PR TITLE
Redirect-JSON validator + hook (catch invalid/draft/colliding targets early)

### DIFF
--- a/.claude/hooks/validate-redirects-hook.sh
+++ b/.claude/hooks/validate-redirects-hook.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write on docusaurus.config.js: surface ERROR-tier redirect problems
+# (a redirect whose `to:` target is missing or draft would FAIL the prod build). Catches the
+# break in seconds instead of at the next slow build.
+#
+# Exit 2 marks the edit as failed + feeds stderr back so the model self-corrects (fix the target
+# or drop the redirect). Warn-tier findings (dead/duplicate redirects) are left for the full
+# `make validate-redirects`; the hook only blocks on the build-breaking ERROR tier.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+# Only the Docusaurus config (where the redirects array lives).
+case "$file_path" in
+  */bytesofpurpose-blog/docusaurus.config.js) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(printf '%s' "$input" | jq -r '.cwd // empty')}"
+script="$proj/bytesofpurpose-blog/scripts/validate-redirects.js"
+[ -f "$script" ] || exit 0
+
+out=$(cd "$proj/bytesofpurpose-blog" && node scripts/validate-redirects.js 2>&1)
+rc=$?
+
+if [ "$rc" -eq 2 ]; then
+  {
+    echo "🔀 Redirect problem: a redirect target is MISSING or DRAFT (would fail the prod build)."
+    printf '%s\n' "$out" | grep -A1 "error:redirect-"
+    echo ""
+    echo "Fix the target (a moved slug?) or drop the redirect. Full check:"
+    echo "  ( cd $proj && make validate-redirects )"
+  } >&2
+  exit 2
+fi
+
+# Clean or warn-only: don't block.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-glossary-links-hook.sh\"",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-redirects-hook.sh\"",
+            "timeout": 30
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,15 @@ generative-ai`). Every doc still carries an absolute (leading-slash) slug, and a
 paired with a `{from,to}` client-redirect so old URLs never break. The `draft-docs`
 plugin computes permalinks per-instance (first path segment under `docs/` = the
 instance routeBasePath) — keep it in lockstep if the instance layout changes.
+**Redirects are validated:** `scripts/validate-redirects.js` (`make validate-redirects`) reads
+the real redirects array from `docusaurus.config.js` and cross-checks every `to:` against the
+published-URL set (honoring `draft:`), catching the build-breakers — a redirect `to:` a missing
+or **draft** target (both ERROR-tier, would fail the prod build), a `from:` that shadows a real
+page, or a duplicate `from:` — in seconds instead of at the next full build. The PostToolUse
+hook `.claude/hooks/validate-redirects-hook.sh` (registered in `.claude/settings.json`) blocks an
+edit to `docusaurus.config.js` that introduces an ERROR-tier redirect. When you MOVE a page, you
+must also **repoint any existing redirect whose `to:` pointed at the old slug** (not just add a
+new `from`→new redirect) — the validator/hook now catches the ones you'd otherwise miss.
 into **domain sub-topics** (e.g. `Software Development` → `backend-development/`,
 `frontend-development/`, `scripting/`, `plugins/`, each with `research/projects/
 techniques/tinkering/`); the idea→ship LIFECYCLE is the separate `Product Management`

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ validate-footnotes: ## Verify evidence-footnote permalinks resolve (pinned SHA +
 validate-glossary: ## Find posts whose first use of a defined glossary term isn't linked (warn-tier candidates; judge + link via the link-glossary-terms skill)
 	( cd ${SITEROOT} && node scripts/validate-glossary-links.js $(DIRS) )
 
+validate-redirects: ## Check the client-redirects array for invalid/draft/colliding/duplicate targets (catches build-breakers early)
+	@# exit 2 == ERROR-tier (a redirect target that's missing or draft would fail the prod build).
+	( cd ${SITEROOT} && node scripts/validate-redirects.js )
+
 validate-em-dash: ## Scan ALL public-facing content (prose + components) for AI-voice em-dashes (—)
 	@# Repo-wide complement to the edit-only .claude/hooks/em-dash-voice-hook.sh, which never
 	@# sweeps the existing corpus. Exit 1 on any hit. Flags everything, code blocks included.

--- a/bytesofpurpose-blog/scripts/validate-redirects.js
+++ b/bytesofpurpose-blog/scripts/validate-redirects.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+/**
+ * validate-redirects.js — catch broken client-redirects BEFORE the full build does.
+ *
+ * Docusaurus only validates redirects at build time ("createRedirects to invalid paths",
+ * "Duplicate routes"), which is slow and surfaces late. This walks the SAME redirects array
+ * (read straight from docusaurus.config.js, not regex-parsed) and cross-checks each entry
+ * against the set of REAL published URLs (every doc/blog/design/page permalink, honoring
+ * `draft:`), so a bad redirect is caught in seconds.
+ *
+ * Findings:
+ *   - to-missing      a redirect `to:` target that no published page/doc produces (the page
+ *                     doesn't exist, or its slug differs). [ERROR — this fails the prod build]
+ *   - to-draft        a redirect `to:` a DRAFT page (excluded from prod → invalid prod build).
+ *                     [ERROR]
+ *   - from-collision  a redirect `from:` that equals a real published URL (the redirect shadows
+ *                     a real page; the page wins, the redirect is dead). [warn]
+ *   - from-duplicate  the same `from:` appears in more than one redirect. [warn]
+ *
+ * The `to:` set is built from content; KNOWN dynamic targets that aren't files (tag pages,
+ * the homepage, /404) are whitelisted so they don't false-positive.
+ *
+ * Usage:  node scripts/validate-redirects.js [--json]
+ * Exit:   2 if any ERROR-tier finding (to-missing / to-draft); else 0 (warns don't block).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const ROOT = path.join(__dirname, '..');
+
+// ── 1. The real published URL set ──────────────────────────────────────────
+// Docs instances: <dir under docs/> → its routeBasePath. (Mirrors docusaurus.config.js.)
+const DOCS_INSTANCES = [
+  {dir: 'docs/craft', base: '/craft'},
+  {dir: 'docs/journey', base: '/journey'},
+  {dir: 'docs/legend', base: '/legend'},
+];
+const BLOG_INSTANCES = [
+  {dir: 'blog', base: '/initiatives'},
+  {dir: 'designs', base: '/designs'},
+];
+
+function walk(absDir, out = []) {
+  if (!fs.existsSync(absDir)) return out;
+  for (const e of fs.readdirSync(absDir, {withFileTypes: true})) {
+    if (e.name === 'node_modules') continue;
+    const fp = path.join(absDir, e.name);
+    if (e.isDirectory()) walk(fp, out);
+    else if (/\.mdx?$/.test(e.name)) out.push(fp);
+  }
+  return out;
+}
+
+const norm = (u) => (u.length > 1 ? u.replace(/\/$/, '') : u); // strip trailing slash (except '/')
+
+// Build the published-URL set + the draft-URL set.
+function collectUrls() {
+  const published = new Set();
+  const draft = new Set();
+
+  // Docs: an absolute (leading-slash) slug is INSTANCE-RELATIVE → base + slug. Otherwise the
+  // permalink is base + <dir path> (+ slug rename of the last segment). We resolve the common
+  // cases: explicit absolute slug (the repo's convention) and a path-derived fallback.
+  for (const {dir, base} of DOCS_INSTANCES) {
+    for (const fp of walk(path.join(ROOT, dir))) {
+      const {data} = safeMatter(fp);
+      if (!data) continue;
+      let url;
+      if (typeof data.slug === 'string' && data.slug.startsWith('/')) {
+        url = data.slug === '/' ? base : base + data.slug;
+      } else {
+        // path-derived: docs/<instance>/<a>/<b>/file(.md) → base/<a>/<b>/<slug|file>
+        const rel = path.relative(path.join(ROOT, dir), fp).replace(/\.mdx?$/, '');
+        const segs = rel.split(path.sep).filter((s) => !/^README$|^index$/i.test(s));
+        const last = typeof data.slug === 'string' ? data.slug.replace(/^\//, '') : segs.pop();
+        url = [base, ...segs, last].filter(Boolean).join('/');
+        if (/README|index/i.test(path.basename(fp)) && segs.length === 0 && !data.slug) url = base;
+      }
+      (data.draft === true ? draft : published).add(norm(url));
+    }
+  }
+
+  // Blog/designs: permalink = base + (slug || de-dated filename).
+  for (const {dir, base} of BLOG_INSTANCES) {
+    for (const fp of walk(path.join(ROOT, dir))) {
+      if (path.basename(fp).startsWith('_')) continue;
+      const {data} = safeMatter(fp);
+      if (!data) continue;
+      const fileSlug = path
+        .basename(fp)
+        .replace(/\.mdx?$/, '')
+        .replace(/^\d{4}-\d{2}-\d{2}-/, '');
+      const slug = (data.slug || fileSlug).toString().replace(/^\//, '');
+      (data.draft === true ? draft : published).add(norm(`${base}/${slug}`));
+    }
+  }
+
+  // src/pages/*.{mdx,tsx,js} → top-level routes (/welcome, /mindset, /support, …).
+  const pagesDir = path.join(ROOT, 'src', 'pages');
+  if (fs.existsSync(pagesDir)) {
+    for (const e of walkPages(pagesDir)) published.add(norm(e));
+  }
+
+  return {published, draft};
+}
+
+function walkPages(absDir, base = '', out = []) {
+  for (const e of fs.readdirSync(absDir, {withFileTypes: true})) {
+    if (e.name.startsWith('_') || e.name.includes('.test.')) continue;
+    const fp = path.join(absDir, e.name);
+    if (e.isDirectory()) {
+      walkPages(fp, `${base}/${e.name}`, out);
+    } else if (/\.(mdx?|tsx?|jsx?)$/.test(e.name)) {
+      const name = e.name.replace(/\.(mdx?|tsx?|jsx?)$/, '');
+      // index → the dir route; otherwise /<name>. Honor an explicit `slug:` in mdx pages.
+      let route;
+      if (/\.mdx?$/.test(e.name)) {
+        const {data} = safeMatter(fp);
+        if (data && typeof data.slug === 'string') route = data.slug;
+      }
+      if (!route) route = name === 'index' ? base || '/' : `${base}/${name}`;
+      out.push(route);
+    }
+  }
+  return out;
+}
+
+function safeMatter(fp) {
+  try {
+    return matter(fs.readFileSync(fp, 'utf8'));
+  } catch {
+    return {data: null};
+  }
+}
+
+// Targets that are real at runtime but not produced by a content file. Don't flag these.
+function isWhitelisted(to, published) {
+  if (to === '/' || to === '/404' || to === '/404.html') return true;
+  // Tag pages (/<instance>/tags/...) + the docs tag indexes are generated, not files.
+  if (/\/tags(\/|$)/.test(to)) return true;
+  // The changelog instance generates per-entry pages from changelog/.
+  if (to === '/changelog' || to.startsWith('/changelog/')) return true;
+  // A redirect whose target is itself another redirect's `from` resolves transitively; allow
+  // if the eventual target is published (handled by the caller via the chain check).
+  return published.has(norm(to));
+}
+
+// ── 2. Read the real redirects from the config ─────────────────────────────
+function loadRedirects() {
+  const cfg = require(path.join(ROOT, 'docusaurus.config.js'));
+  const plugins = cfg.plugins || [];
+  const cr = plugins.find(
+    (p) => Array.isArray(p) && typeof p[0] === 'string' && p[0].includes('client-redirects'),
+  );
+  return cr && Array.isArray(cr[1].redirects) ? cr[1].redirects : [];
+}
+
+// ── 3. Validate ────────────────────────────────────────────────────────────
+function main() {
+  const json = process.argv.includes('--json');
+  const {published, draft} = collectUrls();
+  const redirects = loadRedirects();
+  const findings = [];
+
+  const froms = new Map(); // from → count (for duplicate detection)
+  // A `from` that is itself redirected elsewhere counts as a valid transitive target.
+  const fromSet = new Set(redirects.map((r) => norm(r.from)));
+
+  for (const {from, to} of redirects) {
+    const nFrom = norm(from);
+    const nTo = norm(to);
+    froms.set(nFrom, (froms.get(nFrom) || 0) + 1);
+
+    // to-missing / to-draft: the target must be a published page (or a whitelisted dynamic
+    // route, or a transitive redirect that eventually lands somewhere published).
+    if (!isWhitelisted(nTo, published) && !fromSet.has(nTo)) {
+      if (draft.has(nTo)) {
+        findings.push({tier: 'error', id: 'to-draft', from, to, detail: `redirect target ${to} is a DRAFT page (excluded from the prod build → invalid). Publish it or drop the redirect.`});
+      } else {
+        findings.push({tier: 'error', id: 'to-missing', from, to, detail: `redirect target ${to} does not match any published page/doc/blog/design/page URL. Fix the target (a moved slug?) or drop the redirect.`});
+      }
+    }
+
+    // from-collision: the `from` shadows a real published page (the page wins; redirect is dead).
+    if (published.has(nFrom)) {
+      findings.push({tier: 'warn', id: 'from-collision', from, to, detail: `redirect FROM ${from} is also a real published page; the page wins and this redirect never fires.`});
+    }
+  }
+
+  for (const [from, n] of froms) {
+    if (n > 1) findings.push({tier: 'warn', id: 'from-duplicate', from, to: '', detail: `redirect FROM ${from} appears ${n} times; only one fires.`});
+  }
+
+  if (json) {
+    console.log(JSON.stringify({counts: {redirects: redirects.length, published: published.size, draft: draft.size}, findings}, null, 2));
+    process.exit(0);
+  }
+
+  const errors = findings.filter((f) => f.tier === 'error');
+  const warns = findings.filter((f) => f.tier === 'warn');
+
+  if (!findings.length) {
+    console.log(`✅ redirects: ${redirects.length} checked against ${published.size} published URLs — no problems.`);
+    process.exit(0);
+  }
+
+  console.error(`🔀 redirects: ${errors.length} error(s), ${warns.length} warning(s) across ${redirects.length} redirects.`);
+  for (const f of [...errors, ...warns]) {
+    console.error(`\n  [${f.tier}:redirect-${f.id}]  ${f.from}${f.to ? ` → ${f.to}` : ''}`);
+    console.error(`      ↳ ${f.detail}`);
+  }
+  console.error('\n(ERROR-tier = would fail the prod build; warn = dead/duplicate redirect. Source of truth: the redirects array in docusaurus.config.js.)');
+  process.exit(errors.length ? 2 : 0);
+}
+
+main();


### PR DESCRIPTION
You asked whether we need a hook to maintain/validate the redirects JSON — yes. Redirect breakage was only caught at full build time (slow + late), and it bit the Legend-instance move (a redirect pointing at a moved/draft target). This catches it in seconds.

## What's here
- **`scripts/validate-redirects.js`** — reads the real redirects array from `docusaurus.config.js` (via `require`, not regex) and cross-checks each entry against the published-URL set it builds by walking docs (craft/journey/legend, slug-aware) + blog + designs + pages, honoring `draft:`. Findings:
  - `to-missing` / `to-draft` — **ERROR** (a target that's missing or draft would fail the prod build)
  - `from-collision` / `from-duplicate` — warn (a dead/shadowed/duplicate redirect)
  - Whitelists dynamic targets (tag pages, `/changelog`, `/`, `/404`) + transitive redirect chains.
  - `make validate-redirects`; exit 2 on ERROR.
- **`.claude/hooks/validate-redirects-hook.sh`** — PostToolUse on `docusaurus.config.js` edits; blocks (exit 2) an edit that introduces a missing/draft redirect target, naming the offender. Registered in `.claude/settings.json`.
- **CLAUDE.md** — documents the validator + the "repoint existing redirects whose `to:` pointed at the old slug on a move" rule (the gap that bit the Legend move).

## Verification
- Passes on the real set: **375 redirects checked against 248 published URLs, 0 problems**.
- **Planted tests prove it bites**: a redirect to a missing path → `to-missing` (exit 2); a redirect to a real **draft** page → `to-draft` (exit 2) — the exact two failure modes the Legend move hit. The hook fires on a bad-redirect config edit and stays silent on a clean one.

**Please review and merge when ready — I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)