### PR TITLE
Thoughts taxonomy: 7 kinds + ThoughtKind badge/legend + /thoughts landing

### DIFF
--- a/.claude/skills/groom-initiatives/SKILL.md
+++ b/.claude/skills/groom-initiatives/SKILL.md
@@ -42,6 +42,28 @@ right instance. A post opts into a board by its **kind** (experiments) or an exp
 (Synonyms are accepted, e.g. `draft`→`designed`, `live`→`running`, `done`→`concluded`,
 `wip`→`building` — see the generator's `STAGE_SYNONYMS`.)
 
+## The kinds of a Thought (the /thoughts taxonomy)
+
+A `/thoughts` post is an UNACTIONED thought, and there are KINDS of thought — set by the post's
+`kind:` frontmatter (the same kind system the rest of the site uses; the source of truth is
+`scripts/lib/blog-kinds.json`, where each thought kind carries `thought: true` + a `thoughtGloss`,
+and the validator + the `<ThoughtKindLegend>` render from it):
+
+| `kind:` | Emoji | The thought is… |
+|---|---|---|
+| `idea` | 💡 | something I might build or do (also the `board: ideas` kind) |
+| `question-set` | ❓ | a set of questions I ask myself (the question-set kit + the Legend) |
+| `simulation` | 🔮 | a hypothetical walk-through ("if X then Y then Z; what if 1,2,3") |
+| `prediction` | 🎯 | a falsifiable bet about the future |
+| `critique` | 🔍 | an evaluation of something that exists (what's wrong / how it works) |
+| `principle` | 🪞 | an observation maturing into a rule (the raw feeder for a durable Craft lesson) |
+| `design-story` | 📐 | how something would be structured (the shipped HLD lives in `/designs`) |
+
+The `/thoughts` landing (`/thoughts/about-my-thoughts`) is the reader-facing legend. When you
+publish or classify a `/thoughts` post, set the most specific kind; an `idea` graduates to an
+`/initiatives` project when acted on, a `principle` graduates UP into `/craft` when it holds. The
+**`organize-post`** skill classifies an arbitrary post into the right home + kind.
+
 ## Required frontmatter for a board card
 
 ```yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,13 +172,17 @@ The site is organized around ONE question: **does this stay true over time, or i
 thing I did?** Place content accordingly.
 - **DURABLE → `/craft` (how I see the world) + `/journey` (how I see myself).** Distilled
   learnings, frameworks, strategy, terminology — return-to knowledge. The lasting LESSON.
-- **TEMPORAL → `/initiatives` (the blog) + `/thoughts` (Thoughts & Ideas).** Dated things, the
+- **TEMPORAL → `/initiatives` (the blog) + `/thoughts` (Thoughts).** Dated things, the
   EVIDENCE. The temporal half splits AGAIN by **have I acted on it yet?**:
-  - **`/thoughts` (Thoughts & Ideas) = UNACTIONED ideas** I have HAD but NOT acted on (captures,
-    "should I…", "what would it take…", things that have not materialized). A candidate, not a
-    commitment. The route `/thoughts` is now this REAL blog instance (it used to be a legacy
-    redirect to `/initiatives`; that hop was retired — `/initiatives` emits only its `/blog/*`
-    legacy root now).
+  - **`/thoughts` (Thoughts) = UNACTIONED thoughts** I have HAD but NOT acted on. Navbar label is
+    just **"Thoughts"**; the collection holds KINDS of thought, each set by the post's `kind:`
+    (source of truth `scripts/lib/blog-kinds.json`, kinds flagged `thought: true`): `idea` 💡
+    (might build), `question-set` ❓ (questions I ask myself), `simulation` 🔮 (if X then Y then Z),
+    `prediction` 🎯 (a bet), `critique` 🔍 (what's wrong / how it works), `principle` 🪞 (an
+    observation becoming a rule), `design-story` 📐 (how it would be built). The reader legend is
+    the `/thoughts/about-my-thoughts` landing (renders `<ThoughtKindLegend>`). The route `/thoughts`
+    is now this REAL blog instance (it used to be a legacy redirect to `/initiatives`; that hop was
+    retired — `/initiatives` emits only its `/blog/*` legacy root now).
   - **`/initiatives` = ACTED-ON ideas** — the specific dated things I actually did (experiments,
     project logs, posts). An idea **graduates** from `/thoughts` to `/initiatives` the moment I
     start acting on it; each Initiative links **up** to the durable insight it informed.

--- a/bytesofpurpose-blog/docs/legend/README.mdx
+++ b/bytesofpurpose-blog/docs/legend/README.mdx
@@ -51,7 +51,12 @@ list and find the format you are in the mood for. Here is the legend:
 
 | Emoji | Kind | What it is |
 |---|---|---|
-| ❓ | Question set | A set of questions to ask yourself, grouped by theme. The "What I Ask Myself" series. |
+| 💡 | Idea | An unactioned idea: something I might build or do, captured before I act on it. A Thought. |
+| ❓ | Question set | A set of questions to ask yourself, grouped by theme. The "What I Ask Myself" series. A Thought. |
+| 🔮 | Simulation | A hypothetical walk-through: if X then Y then Z, what if 1, 2, 3. A Thought. |
+| 🎯 | Prediction | A falsifiable bet about the future: I call one outcome so I can check it later. A Thought. |
+| 🔍 | Critique | An evaluation of something that exists: what's wrong with it, or how it really works. A Thought. |
+| 🪞 | Principle | An observation maturing into a rule I live by. The raw feeder for a durable Craft lesson. A Thought. |
 | 🧩 | Framework | A reusable model for thinking about something. "A Framework for", "The Anatomy of". |
 | 💭 | Reflection | A personal essay or set of takeaways. "Notes From", "What X Taught Me", affirmations. |
 | 🏗️ | System design | An architecture or build write-up: how something was designed and shipped. |

--- a/bytesofpurpose-blog/docs/legend/what-i-ask-myself.mdx
+++ b/bytesofpurpose-blog/docs/legend/what-i-ask-myself.mdx
@@ -1,12 +1,10 @@
 ---
-slug: what-i-ask-myself
+slug: /what-i-ask-myself
 title: "What I Ask Myself"
-kind: legend
-sidebar_label: "Ask Myself"
+sidebar_label: "❓ Ask Myself"
+sidebar_position: 2
 description: "Why I treat self-questioning as a practice, how I run it, and the legend behind the little icons on every question I publish."
-authors: [oeid]
 tags: [self-reflection, question-set, ask-myself]
-date: 2026-01-24
 draft: false
 ---
 

--- a/bytesofpurpose-blog/scripts/lib/blog-kinds.json
+++ b/bytesofpurpose-blog/scripts/lib/blog-kinds.json
@@ -1,13 +1,68 @@
 {
-  "__doc__": "SINGLE SOURCE OF TRUTH for the blog post-kind taxonomy. Each kind declares its sidebar `emoji`, a one-line `description`, and an `outline` (the structural elements a post of that kind should contain). A post's emoji reflects its KIND (document type), not its topic, so the Posts sidebar is scannable by type. CONSUMERS: scripts/validate-post-outline.js reads emoji/description/outline from here (the outline `id`s map to test functions in that file's CHECKS registry); the draft-docs plugin reads `emoji` to prepend it to the sidebar label (authors never type the emoji); the validate-post-outline-hook surfaces these on a finding. The reader-facing mirror is the 'Start Here' post (blog/2026-06-24-a-guide-to-these-posts.mdx), whose kind->emoji table is drift-checked against this file. The author-blog-post skill POINTS here rather than re-listing. LOCKSTEP: to add/change a kind, edit (1) this file, (2) a matching CHECKS entry in validate-post-outline.js if it has a new outline id, (3) the Start Here legend table. Mirrors the docs emoji system (scripts/lib/emoji-map.json).",
+  "__doc__": "SINGLE SOURCE OF TRUTH for the blog post-kind taxonomy. Each kind declares its sidebar `emoji`, a one-line `description`, and an `outline` (the structural elements a post of that kind should contain). A kind that represents an UNACTIONED THOUGHT (a /thoughts-collection post) also carries `thought: true` and a `thoughtGloss` (the short reader-facing gloss shown in the Thoughts legend/badge). A post's emoji reflects its KIND (document type), not its topic, so the Posts sidebar is scannable by type. CONSUMERS: scripts/validate-post-outline.js reads emoji/description/outline from here (the outline `id`s map to test functions in that file's CHECKS registry); the draft-docs plugin reads `emoji` to prepend it to the sidebar label (authors never type the emoji); the validate-post-outline-hook surfaces these on a finding; the <ThoughtKind>/<ThoughtKindLegend> blog-ui components render the `thought: true` kinds (emoji + thoughtGloss) so the Thoughts legend can never drift from this file. The reader-facing mirror is the 'Start Here' post (blog/2026-06-24-a-guide-to-these-posts.mdx), whose kind->emoji table is drift-checked against this file. The author-blog-post skill POINTS here rather than re-listing. THOUGHTS TAXONOMY: the unactioned-thought kinds (thought: true) are the kinds of a /thoughts post — idea, question-set, simulation, prediction, critique, principle, design-story. An idea GRADUATES to /initiatives when acted on; a principle/observation graduates UP to durable /craft. LOCKSTEP: to add/change a kind, edit (1) this file, (2) a matching CHECKS entry in validate-post-outline.js if it has a new outline id, (3) the Start Here legend table, (4) the Thoughts legend if `thought: true`. Mirrors the docs emoji system (scripts/lib/emoji-map.json).",
   "kinds": {
+    "idea": {
+      "emoji": "💡",
+      "description": "An unactioned idea: something I might build or do, captured before I've acted on it. The raw front of the idea-to-ship lifecycle (a /thoughts post; graduates to an /initiatives project when I act on it).",
+      "thought": true,
+      "thoughtGloss": "Something I might build or do",
+      "outline": [
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
     "question-set": {
       "emoji": "❓",
       "description": "A set of introspective questions to ask yourself (the 'What I Ask Myself' / 'Questions for' series).",
+      "thought": true,
+      "thoughtGloss": "A question I ask myself",
       "outline": [
         {"id": "sections", "label": "themed H2 sections (questions grouped by theme, not a flat list)"},
         {"id": "question-cards", "label": "one or more <Question> cards (each question is a card, not a bare bullet)"},
         {"id": "section-banner", "label": "a <SectionBanner> (the per-section \"why these questions matter\" callout)"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "simulation": {
+      "emoji": "🔮",
+      "description": "A hypothetical walk-through of how something could unfold: 'if X then Y then Z; what if 1, 2, 3?'. Exploratory branching, no commitment (a /thoughts post). A pre-meditated action is a simulation resolved into 'if I'm ever in X, I will do Y'.",
+      "thought": true,
+      "thoughtGloss": "If X then Y then Z; what if 1, 2, 3?",
+      "outline": [
+        {"id": "scenario", "label": "a scenario / starting condition (an H2 or bold line stating the 'if X' the walk-through branches from)"},
+        {"id": "branches", "label": "the branches or steps it walks (if/then chains, numbered steps, or a decision list)"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "prediction": {
+      "emoji": "🎯",
+      "description": "A falsifiable bet about the future: 'I think X will happen'. Distinct from a simulation (which explores branches without committing); a prediction calls one outcome so it can be scored later (a /thoughts post).",
+      "thought": true,
+      "thoughtGloss": "A falsifiable bet about the future",
+      "outline": [
+        {"id": "claim", "label": "the prediction stated as a falsifiable claim (a bold **Prediction:** line or an H2 stating what will happen)"},
+        {"id": "rationale", "label": "the reasoning / when it resolves (why I believe it, and how/when I'll know if it was right)"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "critique": {
+      "emoji": "🔍",
+      "description": "An evaluative thought about something that already exists: what's wrong with X and what I'd change (critique), or how X actually works and what's really going on (analysis) (a /thoughts post).",
+      "thought": true,
+      "thoughtGloss": "What's wrong with X, or how X really works",
+      "outline": [
+        {"id": "subject", "label": "the subject under critique/analysis (named up front: what is being evaluated)"},
+        {"id": "assessment", "label": "the assessment (what's wrong / what I'd change, or how it works / what's really going on)"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "principle": {
+      "emoji": "🪞",
+      "description": "An observation maturing into a rule I live by: 'I noticed X tends to happen' becoming 'so I now always Y'. The raw feeder that graduates UP into a durable /craft framework once it holds (a /thoughts post).",
+      "thought": true,
+      "thoughtGloss": "An observation maturing into a rule I live by",
+      "outline": [
+        {"id": "observation", "label": "the observation (the pattern noticed: 'I noticed that X')"},
+        {"id": "principle", "label": "the principle it implies (the rule it suggests living by: 'so I now Y')"},
         {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
       ]
     },
@@ -38,6 +93,8 @@
     "design-story": {
       "emoji": "📐",
       "description": "The story/motivation BEHIND a design: a narrative front-door that links to the formal HLD in /designs (not the HLD itself, which lives in /designs).",
+      "thought": true,
+      "thoughtGloss": "How X would actually be structured",
       "outline": [
         {"id": "links-to-design", "label": "a link to the formal design doc in /designs (a design-story narrates the WHY and points to the HLD; the HLD itself lives in /designs)"},
         {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -146,6 +146,37 @@ const CHECKS = {
   outcome: (fm, body) =>
     /^#{1,4}\s+.*\b(outcomes?|results?|findings?|what happened)\b/im.test(body) ||
     /\*\*(outcomes?|results?|findings?)\b/im.test(body),
+  // simulation (a /thoughts kind): a scenario it branches from + the branches/steps it walks
+  scenario: (fm, body) =>
+    /^#{1,4}\s+.*\b(scenario|situation|setup|starting (point|condition)|if\b)/im.test(body) ||
+    /\*\*(scenario|situation|if)\b/im.test(body) ||
+    /\bif\b.+\bthen\b/i.test(body),
+  branches: (fm, body) =>
+    /\bif\b.+\bthen\b/i.test(body) || // if/then chains
+    /^\s*\d+\.\s+\S/m.test(body) || // numbered steps
+    /\b(what if|then maybe|otherwise|else)\b/i.test(body),
+  // prediction (a /thoughts kind): a falsifiable claim + the reasoning / when it resolves
+  claim: (fm, body) =>
+    /^#{1,4}\s+.*\b(prediction|i (predict|bet|expect)|will\b)/im.test(body) ||
+    /\*\*(prediction|i predict|i bet)\b/im.test(body),
+  rationale: (fm, body) =>
+    /^#{1,4}\s+.*\b(rationale|reasoning|why|because|resolves?|when (i('|’)ll know|this resolves))\b/im.test(body) ||
+    /\b(because|i (think|believe)|i('|’)ll know|resolves? (when|by))\b/i.test(body),
+  // critique (a /thoughts kind): the subject under evaluation + the assessment
+  subject: (fm, body) =>
+    /^#{1,4}\s+.*\b(subject|what i('|’)m (critiquing|analyzing)|the (problem|critique|analysis))\b/im.test(body) ||
+    hasH2(body), // any structured framing names the subject
+  assessment: (fm, body) =>
+    /^#{1,4}\s+.*\b(assessment|critique|analysis|what('|’)s wrong|what i('|’)d change|how it works|what('|’)s really going on)\b/im.test(body) ||
+    /\*\*(assessment|critique|analysis)\b/im.test(body),
+  // principle (a /thoughts kind): the observation noticed + the rule it implies
+  observation: (fm, body) =>
+    /^#{1,4}\s+.*\b(observation|i noticed|i('|’)ve noticed|the pattern)\b/im.test(body) ||
+    /\b(i noticed|i('|’)ve noticed|i keep seeing|tends to)\b/i.test(body),
+  principle: (fm, body) =>
+    /^#{1,4}\s+.*\b(principle|the rule|so i now|takeaway|what i (do|live by))\b/im.test(body) ||
+    /\*\*(principle|the rule)\b/im.test(body) ||
+    /\bso i now\b/i.test(body),
 };
 
 // OUTLINES is built FROM the JSON: for each kind, its outline specs (id + label) paired

--- a/bytesofpurpose-blog/src/components/ThoughtKind/index.tsx
+++ b/bytesofpurpose-blog/src/components/ThoughtKind/index.tsx
@@ -1,0 +1,132 @@
+import React, {CSSProperties} from 'react';
+import clsx from 'clsx';
+import {Tooltip} from '@omars-lab/blog-ui';
+import blogKinds from '../../../scripts/lib/blog-kinds.json';
+import styles from './styles.module.css';
+
+/**
+ * ThoughtKind — a small badge that labels a "thought" by its KIND (idea, question, simulation,
+ * prediction, critique, principle, design). The emoji + gloss come straight from the single
+ * source of truth (scripts/lib/blog-kinds.json: the kinds flagged `thought: true`), so the
+ * badge can never drift from the post-kind taxonomy the rest of the site uses.
+ *
+ *   <ThoughtKind kind="simulation" />            // emoji + label + hover gloss
+ *   <ThoughtKind kind="idea" showLabel={false}/> // emoji-only (still tooltipped)
+ *
+ * <ThoughtKindLegend /> renders ALL the thought kinds at once (drop it on the /thoughts
+ * landing) — the analog of <PowerLegend> for the question-set kit. Mirrors that pattern: the
+ * legend is generated from the taxonomy, never hand-authored as an approximate table.
+ */
+
+interface KindMeta {
+  emoji: string;
+  description: string;
+  thought?: boolean;
+  thoughtGloss?: string;
+}
+
+const KINDS = (blogKinds as {kinds: Record<string, KindMeta>}).kinds;
+
+// The thought kinds, in a deliberate reading order (generative → interrogative → evaluative →
+// distilling → design). Any kind flagged `thought: true` that isn't listed still falls through
+// to the end, so adding a thought kind to the JSON surfaces it here even before this list is
+// updated.
+const THOUGHT_ORDER = [
+  'idea',
+  'question-set',
+  'simulation',
+  'prediction',
+  'critique',
+  'principle',
+  'design-story',
+];
+
+export function thoughtKinds(): string[] {
+  const flagged = Object.keys(KINDS).filter((k) => KINDS[k]?.thought);
+  const ordered = THOUGHT_ORDER.filter((k) => flagged.includes(k));
+  const rest = flagged.filter((k) => !ordered.includes(k));
+  return [...ordered, ...rest];
+}
+
+/** Human label for a kind: the gloss's subject, derived from the kind id (idea → "Idea"). */
+function kindLabel(kind: string): string {
+  // question-set reads better as "Question"; design-story as "Design"; otherwise title-case.
+  const overrides: Record<string, string> = {
+    'question-set': 'Question',
+    'design-story': 'Design',
+    critique: 'Critique',
+  };
+  if (overrides[kind]) return overrides[kind];
+  return kind.charAt(0).toUpperCase() + kind.slice(1);
+}
+
+export interface ThoughtKindProps {
+  /** The kind id from blog-kinds.json (idea, question-set, simulation, prediction, critique, principle, design-story). */
+  kind: string;
+  /** Show the text label next to the emoji (default true). When false, emoji-only (still tooltipped). */
+  showLabel?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const ThoughtKind: React.FC<ThoughtKindProps> = ({kind, showLabel = true, className, style}) => {
+  const meta = KINDS[kind];
+  if (!meta || !meta.thought) {
+    // Not a known thought kind — render nothing rather than a misleading badge.
+    return null;
+  }
+  const label = kindLabel(kind);
+  const gloss = meta.thoughtGloss || meta.description;
+  return (
+    <Tooltip
+      content={
+        <>
+          <b>{label}</b>
+          <br />
+          {gloss}
+        </>
+      }>
+      <span className={clsx(styles.badge, className)} style={style} aria-label={`${label}: ${gloss}`}>
+        <span className={styles.emoji} aria-hidden="true">
+          {meta.emoji}
+        </span>
+        {showLabel && <span className={styles.label}>{label}</span>}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default ThoughtKind;
+
+export interface ThoughtKindLegendProps {
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * ThoughtKindLegend — the canonical reader-facing legend of the thought kinds, rendered straight
+ * from blog-kinds.json (the `thought: true` kinds). Drop it on the /thoughts landing. Same role
+ * <PowerLegend> plays for the question-set kit: generated from the source of truth so it can
+ * never drift from the badges the posts actually carry.
+ */
+export function ThoughtKindLegend({className, style}: ThoughtKindLegendProps): React.JSX.Element {
+  return (
+    <dl className={clsx(styles.legend, className)} style={style}>
+      {thoughtKinds().map((kind) => {
+        const meta = KINDS[kind];
+        const label = kindLabel(kind);
+        return (
+          <div key={kind} className={styles.legendRow}>
+            <dt className={styles.legendEmoji} aria-hidden="true">
+              {meta.emoji}
+            </dt>
+            <dd className={styles.legendText}>
+              <span className={styles.legendName}>{label}</span>
+              <span className={styles.legendGloss}>{meta.thoughtGloss || meta.description}</span>
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}

--- a/bytesofpurpose-blog/src/components/ThoughtKind/styles.module.css
+++ b/bytesofpurpose-blog/src/components/ThoughtKind/styles.module.css
@@ -1,0 +1,71 @@
+/* ThoughtKind badge + legend. Mirrors the question-set kit's badge/legend styling and rides on
+   the tea-party theme tokens (the mint pill + deep-green ink, AA-safe, same as the tag pills). */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.4;
+  background: var(--tea-mint, var(--ifm-color-emphasis-200));
+  color: var(--tea-ink, var(--ifm-color-emphasis-900));
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.emoji {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.label {
+  font-weight: 600;
+}
+
+/* ── Legend (all thought kinds at once) ──────────────────────────────── */
+
+.legend {
+  margin: 1.25rem 0;
+  padding: 0.5rem 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.legendRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.legendEmoji {
+  flex: 0 0 auto;
+  width: 1.6rem;
+  text-align: center;
+  font-size: 1.2rem;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.legendText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  margin: 0;
+}
+
+.legendName {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--ifm-heading-color);
+}
+
+.legendGloss {
+  font-size: 0.9rem;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-700));
+  line-height: 1.4;
+}

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -13,6 +13,7 @@ import PremiumGate from '@site/src/components/PremiumGate';
 import Premium from '@site/src/components/Premium';
 import KanbanBoard from '@site/src/components/KanbanBoard';
 import TaskList from '@site/src/components/TaskList';
+import ThoughtKind, {ThoughtKindLegend} from '@site/src/components/ThoughtKind';
 // Reusable design-post components now live in the published @omars-lab/blog-ui package
 // (single source of truth; the blog consumes it). The bundled styles are imported once.
 import {
@@ -78,4 +79,11 @@ export default {
   // rendered from the same source as the card badges so it can't drift. Used in the
   // "What I Ask Myself" keystone post.
   PowerLegend,
+  // Thoughts taxonomy: <ThoughtKind kind="simulation"/> is a badge labeling a thought by its
+  // KIND (idea/question/simulation/prediction/critique/principle/design), and
+  // <ThoughtKindLegend/> renders all of them. Both read straight from the `thought: true` kinds
+  // in scripts/lib/blog-kinds.json (the source of truth), so they can't drift. Used on the
+  // /thoughts landing.
+  ThoughtKind,
+  ThoughtKindLegend,
 };

--- a/bytesofpurpose-blog/thoughts/2026-06-25-about-my-thoughts.mdx
+++ b/bytesofpurpose-blog/thoughts/2026-06-25-about-my-thoughts.mdx
@@ -1,0 +1,59 @@
+---
+slug: about-my-thoughts
+title: "💭 About My Thoughts"
+description: "What lives here: thoughts I have had but not acted on yet, and the kinds of thought they come in (ideas, questions, simulations, predictions, critiques, principles, designs)."
+authors: [oeid]
+tags: [thoughts, meta, legend]
+date: 2026-06-25
+kind: legend
+draft: false
+---
+
+This is where I keep the thoughts I have had but not acted on yet. Not the dated things I
+actually did (those are [Initiatives](/initiatives)), and not the distilled lessons that held up
+over time (those are [Craft](/craft)). Just the raw, unactioned mental work: the things I have
+thought, before I have done anything about them.
+
+<!-- truncate -->
+
+## Why this is its own place
+
+A thought is a candidate, not a commitment. An idea I have not built, a question I am still
+sitting with, a scenario I have only played out in my head: none of those belong in the record
+of what I have done, but they are worth keeping. They are where the doing starts.
+
+The rule for where something lives is simple:
+
+- If I have **not acted on it**, it is a Thought (here).
+- The moment I **start acting on it**, it graduates into an [Initiative](/initiatives).
+- If a thought distills into a lesson that keeps holding up, it graduates UP into
+  [Craft](/craft).
+
+## The kinds of thought
+
+Not every thought is the same shape. Some are things I might build, some are questions I ask
+myself, some are hypotheticals I walk through. Each thought is tagged with its KIND, so you can
+see at a glance what kind of mental work it is. Here is the legend:
+
+<ThoughtKindLegend />
+
+A quick tour of what each one means:
+
+- **Ideas** are things I might build or do. The raw front of the idea-to-ship lifecycle; the
+  good ones graduate into Initiatives. The [Ideas board](/craft/product-management/ideas) indexes
+  them.
+- **Questions** are the ones I ask myself, kept in themed sets. The practice and the legend
+  behind them live in [What I Ask Myself](/legend/what-i-ask-myself).
+- **Simulations** are hypothetical walk-throughs: if X then Y then Z, what if 1, 2, 3. I play out
+  how something could unfold before it does. A pre-meditated action is a simulation I have
+  resolved into "if I am ever in X, I will do Y."
+- **Predictions** are falsifiable bets about the future: I call one outcome so I can check later
+  whether I was right.
+- **Critiques** are evaluative: what is wrong with something and what I would change, or how it
+  actually works and what is really going on.
+- **Principles** start as an observation ("I noticed X tends to happen") and mature into a rule I
+  live by. They are the raw feeders that graduate up into Craft once they hold.
+- **Designs** are how something would actually be structured, before it is built. The shipped
+  versions become full write-ups on [Designs](/designs).
+
+Browse the posts below, or jump straight to the [Ideas board](/craft/product-management/ideas).


### PR DESCRIPTION
Names the **kinds of unactioned thought** and wires them through the *existing* post-kind system, so the taxonomy has **one source of truth** (`scripts/lib/blog-kinds.json`) and can't drift.

### The taxonomy (7 thought kinds)
| `kind:` | Emoji | The thought is… |
|---|---|---|
| `idea` | 💡 | something I might build or do |
| `question-set` | ❓ | a set of questions I ask myself |
| `simulation` | 🔮 | if X then Y then Z; what if 1, 2, 3 |
| `prediction` | 🎯 | a falsifiable bet about the future |
| `critique` | 🔍 | what's wrong with X / how X really works |
| `principle` | 🪞 | an observation maturing into a rule I live by |
| `design-story` | 📐 | how X would actually be structured |

Each is flagged `thought: true` + a `thoughtGloss` in `blog-kinds.json`. Added the 5 new kinds + tagged the 2 existing ones; added validator CHECKS for the 8 new outline ids.

### Components (`src/components/ThoughtKind`, in the global MDX scope)
- **`<ThoughtKind kind="simulation"/>`** — a tea-party-themed badge (emoji + label + hover Tooltip gloss).
- **`<ThoughtKindLegend/>`** — the full legend. Both render **straight from `blog-kinds.json`** (the analog of `<PowerLegend>`), so the reader legend can never drift from the badges.

### Landing (`/thoughts/about-my-thoughts`)
A pinned intro post: Thoughts = unactioned mental work, the acted-on / durable graduation rules, and a per-kind tour rendering `<ThoughtKindLegend/>`. **(Screenshot-verified: all 7 kinds + emoji render, no crash.)**

### Recorded in guides + skills (lockstep)
Start Here legend table (drift check clean), CLAUDE.md tenet, `groom-initiatives` skill. Also fixes `what-i-ask-myself.mdx` frontmatter (the doc-shape rewrite that missed #82's commit).

### Verification
`validate-post-outline` (no drift, no missing CHECKS) · `validate-structure` (0 errors) · `validate-redirects` (387 ok, 250 published). Dev server renders the landing legend cleanly.

This is the foundation; **follow-ups tracked**: move the 25 question-set posts into `/thoughts` (#50), the `organize-post` classifier skill (#51).

**Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)