### PR TITLE
Mindset quote-sets: <Quote>/<QuoteSet> kit + rebuilt /mindset

### DIFF
--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -325,6 +325,48 @@ series shares. Drop it in with no props:
   in the SAME change so the narrative doesn't drift from the icons. The component doc-comment
   and this skill both point at that post as the canonical legend.
 
+### Quote + QuoteSet (the quotes-that-moved-me kit)
+
+WHAT: the quote analog of the question kit, but a DELIBERATELY DIFFERENT CX. A question is
+something you ACT on (a clickable card with scheduling badges + a modal); a quote is something
+you RECEIVE and savor. So `<Quote>` is an **editorial pull-quote**: the quote text is the hero
+(large display type, a green left-border, generous space), the attribution is quiet beneath it,
+and "why it moved me" REVEALS on demand rather than competing with the quote. No badges, no
+priority sort, no modal. WHEN: a `quote-set` post (the `💬` kind in `blog-kinds.json`) or the
+`/mindset` page — anywhere you present curated quotes. HOW:
+
+```mdx
+## On the work itself
+
+<SectionBanner why="The lines I reach for when I am tempted to chase a breakthrough." />
+
+<QuoteSet>
+
+<Quote source="Will Durant" cite="often attributed to Aristotle"
+  reflection="It reframed mastery as something I build in the small reps rather than chase in a breakthrough.">
+We are what we repeatedly do. Excellence, then, is not an act, but a habit.
+</Quote>
+
+</QuoteSet>
+```
+
+- **`<Quote>` props:** the quote text is the children (write it plain, NO surrounding `"` —
+  the component renders the typographic quotation marks). `source` = attribution (quiet, with a
+  leading em-dash supplied by CSS). `cite` (optional) = the work/origin (rendered italic after
+  the source). `reflection` (optional) = why it moved me, hidden behind a "why it moved me ›"
+  toggle (a quiet reveal, not a modal). A quote with no `reflection` just shows the pull-quote.
+- **`<QuoteSet>`** wraps the quotes in a theme and lays them out as a VERTICAL READING FLOW
+  (room to breathe), not a grid. Optional `theme` prop renders a small eyebrow label when the
+  set is not already under an H2. No sort — quotes render in authored order (received, not
+  ranked). One `<QuoteSet>` per H2 section; blank lines around the tags so MDX parses blocks.
+- The `quote-set` kind's outline (validate-post-outline) wants themed H2 sections + `<Quote>`
+  cards + a `description`. The `/mindset` page is the front door that surfaces the quote-set
+  posts; quote sets are NOT a `/thoughts` thought-kind (they live with Mindset, not Thoughts).
+- Both are in `@omars-lab/blog-ui` and registered in `MDXComponents.tsx` — no import in `.mdx`.
+  Reflects on demand with `prefers-reduced-motion` respected (the chevron transition is gated).
+  The file must be `.mdx`. After changing the kit, rebuild the package (`yarn build` in
+  `packages/blog-ui`) + reinstall the `file:` dep so the blog picks up the new `dist/`.
+
 ### react-icons in blog-ui (bundling gotcha)
 
 The Question badges use `react-icons/gi`. `react-icons` is a **regular dependency** of

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,15 @@ storybook: ## Start Storybook development server (with optional type-check)
 build-storybook: ## Build Storybook for production
 	( cd ${SITEROOT} && yarn build-storybook )
 
+build-blog-ui: ## Rebuild the @omars-lab/blog-ui package so its dist/ is current before a site build
+	@# The blog consumes the BUILT dist/ of the file:../packages/blog-ui dep (dist/ is gitignored,
+	@# so a fresh clone or an un-rebuilt edit would ship STALE components). Rebuild it + reinstall
+	@# the file: dep so the blog's node_modules copy is fresh. This is a prerequisite of `build`
+	@# and `deploy` so the published site always has the current components (fail-closed: you can
+	@# never deploy stale blog-ui by forgetting to rebuild it).
+	( cd packages/blog-ui && yarn build )
+	( cd ${SITEROOT} && yarn add @omars-lab/blog-ui@file:../packages/blog-ui )
+
 init-site: ## Initialize a new Docusaurus site
 	test -d ${SITEROOT} || npx @docusaurus/init@latest init ${SITENAME} classic --typescript
 
@@ -257,7 +266,7 @@ generate-assets: ## Regenerate ALL dynamic data assets from frontmatter (changel
 	# NEVER hand-edit the outputs — edit the generator or the frontmatter source.
 	( cd ${SITEROOT} && yarn generate-assets )
 
-build: build-storybook ## Build the site for production
+build: build-blog-ui build-storybook ## Build the site for production
 	# Bundles your website into static files for production.
 	# Dynamic data assets are auto-generated via the npm 'prebuild' hook
 	# (npm run generate-assets) before building — see `make generate-assets`.
@@ -279,7 +288,7 @@ install-hooks: ## Enable the local pre-commit secret-scan hook
 	git config core.hooksPath .githooks
 	@echo "✓ pre-commit secret scanning enabled (core.hooksPath=.githooks)"
 
-deploy: secret-scan build-storybook ## Deploy the site to GitHub Pages (runs a secret scan first)
+deploy: secret-scan build-blog-ui build-storybook ## Deploy the site to GitHub Pages (runs a secret scan first)
 	# Publishes the website to GitHub pages.
 	@# `static/storybook/` is a GENERATED artifact (gitignored, not tracked) that
 	@# Docusaurus copies verbatim from static/ — `yarn deploy` does NOT regenerate it.

--- a/bytesofpurpose-blog/blog/2026-06-25-quotes-that-moved-me.mdx
+++ b/bytesofpurpose-blog/blog/2026-06-25-quotes-that-moved-me.mdx
@@ -1,0 +1,51 @@
+---
+slug: quotes-that-moved-me
+title: "Quotes That Moved Me"
+kind: quote-set
+sidebar_label: "Quotes"
+description: "A curated set of quotes that landed on me and stuck, with my reflection on why each one moved me and how it shapes the way I think."
+authors: [oeid]
+tags: [mindset, quotes]
+date: 2026-06-25
+draft: false
+---
+
+A running, curated set of the lines that actually moved me: not clever quotes I collected to sound
+deep, but the few that rearranged something in how I think. Each one has a short note on why it
+landed. Read the section that matches where your head is, and take what resonates.
+
+<!-- truncate -->
+
+## On the work itself
+
+<SectionBanner why="The lines I reach for when I am tempted to chase a breakthrough instead of keeping the systems that compound." />
+
+<QuoteSet>
+
+<Quote source="Will Durant" cite="often attributed to Aristotle" reflection="It reframed mastery as something I build in the small, unglamorous reps rather than chase in a single breakthrough. It is why I care more about the systems I keep than the bursts I manage.">
+We are what we repeatedly do. Excellence, then, is not an act, but a habit.
+</Quote>
+
+<Quote source="Marcus Aurelius" cite="via Ryan Holiday" reflection="The thing blocking me is usually the thing worth doing. When I notice resistance now I lean toward it instead of around it, because that friction tends to mark where the growth is.">
+The obstacle is the way.
+</Quote>
+
+</QuoteSet>
+
+## On doing it with others
+
+<SectionBanner why="A standing correction to my instinct to do everything myself." />
+
+<QuoteSet>
+
+<Quote source="African proverb" reflection="A quiet correction to my instinct to do everything myself. The work I am proudest of was slower because it was shared, and it lasted because of it.">
+If you want to go fast, go alone. If you want to go far, go together.
+</Quote>
+
+</QuoteSet>
+
+## Related
+
+For the raw deck I flip through when I need the right words in a hard moment, see
+[Affirmations for the Inner Game](/initiatives/affirmations-for-the-inner-game): hundreds of
+faith-based and motivational lines, grouped by theme.

--- a/bytesofpurpose-blog/docs/legend/README.mdx
+++ b/bytesofpurpose-blog/docs/legend/README.mdx
@@ -57,6 +57,7 @@ list and find the format you are in the mood for. Here is the legend:
 | 🎯 | Prediction | A falsifiable bet about the future: I call one outcome so I can check it later. A Thought. |
 | 🔍 | Critique | An evaluation of something that exists: what's wrong with it, or how it really works. A Thought. |
 | 🪞 | Principle | An observation maturing into a rule I live by. The raw feeder for a durable Craft lesson. A Thought. |
+| 💬 | Quote set | A themed set of quotes that moved me, with my reflection on why. Surfaced on Mindset. |
 | 🧩 | Framework | A reusable model for thinking about something. "A Framework for", "The Anatomy of". |
 | 💭 | Reflection | A personal essay or set of takeaways. "Notes From", "What X Taught Me", affirmations. |
 | 🏗️ | System design | An architecture or build write-up: how something was designed and shipped. |

--- a/bytesofpurpose-blog/scripts/lib/blog-kinds.json
+++ b/bytesofpurpose-blog/scripts/lib/blog-kinds.json
@@ -76,8 +76,17 @@
     },
     "reflection": {
       "emoji": "💭",
-      "description": "A personal essay or set of takeaways ('Notes From', 'What X Taught Me', affirmations).",
+      "description": "A personal essay or set of takeaways ('Notes From', 'What X Taught Me').",
       "outline": [
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "quote-set": {
+      "emoji": "💬",
+      "description": "A themed set of quotes that moved me, with my reflection on why ('quotes that moved me', affirmations). Surfaced on /mindset; each quote is a <Quote> pull-quote inside a <QuoteSet>.",
+      "outline": [
+        {"id": "sections", "label": "themed H2 sections (quotes grouped by theme, not a flat list)"},
+        {"id": "quote-cards", "label": "one or more <Quote> pull-quotes inside a <QuoteSet> (each quote is a component, not a bare blockquote)"},
         {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
       ]
     },

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -102,6 +102,8 @@ const CHECKS = {
   sections: (fm, body) => hasH2(body),
   'question-cards': (fm, body) => /<Question[\s>]/.test(body),
   'section-banner': (fm, body) => /<SectionBanner[\s>]/.test(body),
+  // quote-set
+  'quote-cards': (fm, body) => /<Quote[\s>]/.test(body),
   // framework
   'framework-laid-out': (fm, body) =>
     /^\s*\d+\.\s+\S/m.test(body) ||

--- a/bytesofpurpose-blog/src/pages/mindset.module.css
+++ b/bytesofpurpose-blog/src/pages/mindset.module.css
@@ -1,52 +1,73 @@
 .intro {
   max-width: 680px;
-  color: var(--ifm-color-emphasis-800);
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: var(--ifm-color-content, var(--ifm-color-emphasis-800));
 }
 
-.placeholderNote {
-  color: var(--ifm-color-emphasis-600);
-  font-style: italic;
+.sectionTitle {
+  margin-top: 2.5rem;
+  font-size: 1.4rem;
 }
 
-.quoteGrid {
+/* Featured quotes: a vertical reading flow of <Quote> pull-quotes (the component owns its own
+   styling; this just bounds the reading width so the lines do not stretch on wide screens). */
+.featured {
+  max-width: 720px;
+}
+
+/* The collections: cards linking to each quote-set post. */
+.collections {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+  max-width: 860px;
 }
 
-.quoteCard {
+.collectionCard {
+  position: relative;
   display: flex;
   flex-direction: column;
+  gap: 0.4rem;
+  padding: 1.1rem 2.2rem 1.1rem 1.1rem;
+  border-radius: 12px;
+  background: var(--ifm-card-background-color, var(--ifm-background-surface-color));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  text-decoration: none;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.collectionCard:hover {
+  text-decoration: none;
+  border-color: var(--brand-green, var(--ifm-color-primary));
+  transform: translateY(-2px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .collectionCard {
+    transition: none;
+  }
+  .collectionCard:hover {
+    transform: none;
+  }
 }
 
-/* The quote itself — the visual anchor of the card. */
-.quote {
-  margin: 0;
-  font-size: 1.15rem;
-  line-height: 1.5;
-  font-style: italic;
+.collectionTitle {
+  font-size: 1.05rem;
+  font-weight: 700;
   color: var(--ifm-heading-color);
 }
 
-.source {
-  margin: 0;
-  font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-700);
+.collectionBlurb {
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-700));
 }
 
-/* "Why it moved me" reflection. */
-.reflectionLabel {
-  margin: 0 0 0.25rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--ifm-color-emphasis-600);
-}
-
-.reflection {
-  margin: 0;
-  color: var(--ifm-color-emphasis-800);
-  line-height: 1.6;
+.collectionArrow {
+  position: absolute;
+  right: 1rem;
+  top: 1.1rem;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--ifm-color-primary);
 }

--- a/bytesofpurpose-blog/src/pages/mindset.tsx
+++ b/bytesofpurpose-blog/src/pages/mindset.tsx
@@ -2,45 +2,51 @@ import React, { useEffect } from 'react';
 import posthog from 'posthog-js';
 // @ts-ignore - Docusaurus theme module
 import Layout from '@theme/Layout';
-import Card from '@site/src/components/Card';
-import CardHeader from '@site/src/components/Card/CardHeader';
-import CardBody from '@site/src/components/Card/CardBody';
-import CardFooter from '@site/src/components/Card/CardFooter';
+import Link from '@docusaurus/Link';
+import { Quote } from '@omars-lab/blog-ui';
+import '@omars-lab/blog-ui/style.css';
 import styles from './mindset.module.css';
 
-// Placeholder data. These are sample entries showing the intended format
-// (a quote that moved me, its source, and my reflection on why). Real entries
-// will replace these over time.
-type Quote = {
+// A few featured quotes shown inline on the landing (the <Quote> pull-quote CX). The full,
+// growing collection lives in the quote-set posts linked below; this page is the front door.
+type Featured = {
   id: string;
   quote: string;
   source: string;
+  cite?: string;
   reflection: string;
 };
 
-const QUOTES: Quote[] = [
+const FEATURED: Featured[] = [
   {
-    id: 'sample-1',
-    quote:
-      'We are what we repeatedly do. Excellence, then, is not an act, but a habit.',
-    source: 'Will Durant (often attributed to Aristotle)',
+    id: 'habit',
+    quote: 'We are what we repeatedly do. Excellence, then, is not an act, but a habit.',
+    source: 'Will Durant',
+    cite: 'often attributed to Aristotle',
     reflection:
       'It reframed mastery as something I build in the small, unglamorous reps rather than chase in a single breakthrough. It is why I care more about the systems I keep than the bursts I manage.',
   },
   {
-    id: 'sample-2',
+    id: 'obstacle',
     quote: 'The obstacle is the way.',
-    source: 'Marcus Aurelius (via Ryan Holiday)',
+    source: 'Marcus Aurelius',
+    cite: 'via Ryan Holiday',
     reflection:
       'The thing blocking me is usually the thing worth doing. When I notice resistance now I lean toward it instead of around it, because that friction tends to mark where the growth is.',
   },
+];
+
+// The quote-set collections this page surfaces. Each is a published quote-set post.
+const COLLECTIONS: { title: string; blurb: string; to: string }[] = [
   {
-    id: 'sample-3',
-    quote:
-      'If you want to go fast, go alone. If you want to go far, go together.',
-    source: 'African proverb',
-    reflection:
-      'A quiet correction to my instinct to do everything myself. The work I am proudest of was slower because it was shared, and it lasted because of it.',
+    title: 'Quotes That Moved Me',
+    blurb: 'The curated set: the few lines that rearranged how I think, each with a note on why.',
+    to: '/initiatives/quotes-that-moved-me',
+  },
+  {
+    title: 'Affirmations for the Inner Game',
+    blurb: 'The raw deck I flip through when I need the right words: hundreds of lines, grouped by theme.',
+    to: '/initiatives/affirmations-for-the-inner-game',
   },
 ];
 
@@ -58,29 +64,30 @@ export default function MindsetPage() {
       <div className="container margin-vert--lg">
         <h1>🧠 My Mindset</h1>
         <p className={styles.intro}>
-          A collection of quotes that have moved me, with my own reflections on
-          why they landed and how they shape the way I think. Less a list of
-          clever lines than a record of the ideas I keep coming back to.
-        </p>
-        <p className={styles.placeholderNote}>
-          This page is just getting started. The entries below are samples that
-          show the format; more (and more personal) ones are on the way.
+          The lines that actually moved me, with my own reflection on why they landed and how they
+          shape the way I think. Less a list of clever quotes than a record of the ideas I keep
+          coming back to.
         </p>
 
-        <div className={styles.quoteGrid}>
-          {QUOTES.map((q) => (
-            <Card key={q.id} shadow="md" className={styles.quoteCard}>
-              <CardHeader>
-                <blockquote className={styles.quote}>{q.quote}</blockquote>
-              </CardHeader>
-              <CardBody>
-                <p className={styles.source}>{q.source}</p>
-              </CardBody>
-              <CardFooter>
-                <p className={styles.reflectionLabel}>Why it moved me</p>
-                <p className={styles.reflection}>{q.reflection}</p>
-              </CardFooter>
-            </Card>
+        <h2 className={styles.sectionTitle}>A few that stuck</h2>
+        <div className={styles.featured}>
+          {FEATURED.map((q) => (
+            <Quote key={q.id} source={q.source} cite={q.cite} reflection={q.reflection}>
+              {q.quote}
+            </Quote>
+          ))}
+        </div>
+
+        <h2 className={styles.sectionTitle}>The collections</h2>
+        <div className={styles.collections}>
+          {COLLECTIONS.map((c) => (
+            <Link key={c.to} to={c.to} className={styles.collectionCard}>
+              <span className={styles.collectionTitle}>{c.title}</span>
+              <span className={styles.collectionBlurb}>{c.blurb}</span>
+              <span className={styles.collectionArrow} aria-hidden="true">
+                &#8250;
+              </span>
+            </Link>
           ))}
         </div>
       </div>

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -26,6 +26,8 @@ import {
   Question,
   QuestionSection,
   PowerLegend,
+  Quote,
+  QuoteSet,
 } from '@omars-lab/blog-ui';
 import '@omars-lab/blog-ui/style.css';
 
@@ -86,4 +88,10 @@ export default {
   // /thoughts landing.
   ThoughtKind,
   ThoughtKindLegend,
+  // Quote kit — for "quotes that moved me" sets on /mindset. <Quote> is an editorial pull-quote
+  // (the quote is the hero; attribution quiet; the "why it moved me" reflection reveals on
+  // demand), and <QuoteSet> lays a themed set out as a vertical reading flow. Deliberately a
+  // different CX from <Question> (received/savored, not actioned).
+  Quote,
+  QuoteSet,
 };

--- a/bytesofpurpose-blog/yarn.lock
+++ b/bytesofpurpose-blog/yarn.lock
@@ -2803,9 +2803,10 @@
     fastq "^1.6.0"
 
 "@omars-lab/blog-ui@file:../packages/blog-ui":
-  version "0.1.0"
+  version "0.6.0"
   dependencies:
     clsx "^2.1.1"
+    react-icons "^5.6.0"
 
 "@opentelemetry/api-logs@0.208.0", "@opentelemetry/api-logs@^0.208.0":
   version "0.208.0"
@@ -11778,6 +11779,11 @@ react-gist@^1.2.4:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-icons@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.6.0.tgz#27bcc4acbc836e762548d76041cf9b9fef4e3837"
+  integrity sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==
 
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"

--- a/packages/blog-ui/src/components/Quote/index.tsx
+++ b/packages/blog-ui/src/components/Quote/index.tsx
@@ -1,0 +1,71 @@
+import React, {CSSProperties, ReactNode, useCallback, useState} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * Quote — one quote that moved me, presented as an EDITORIAL PULL-QUOTE, not a card.
+ *
+ * The CX is deliberately different from <Question>: a question is something you ACT on (a
+ * clickable prompt with scheduling badges and a modal); a quote is something you RECEIVE and
+ * savor. So the quote text is the hero (large display type, generous space), the attribution is
+ * quiet beneath it, and my reflection ("why it moved me") is a quieter layer that REVEALS on
+ * demand rather than competing with the quote.
+ *
+ *   <Quote source="Will Durant">
+ *     We are what we repeatedly do. Excellence, then, is not an act, but a habit.
+ *   </Quote>
+ *
+ *   <Quote source="Marcus Aurelius" reflection="The thing blocking me is usually the thing worth doing.">
+ *     The obstacle is the way.
+ *   </Quote>
+ *
+ * The quote text is the children. `source` is the attribution (quiet, beneath the quote).
+ * `reflection` (optional) is why it moved me — rendered behind a "why it moved me" toggle so the
+ * reading flow stays clean. `cite` (optional) is a link/work the quote is from.
+ */
+export interface QuoteProps {
+  /** The quote itself. */
+  children: ReactNode;
+  /** Attribution (who said/wrote it). Shown quietly beneath the quote. */
+  source?: string;
+  /** Why it moved me. Revealed on demand under a "why it moved me" toggle. */
+  reflection?: ReactNode;
+  /** Optional work/context the quote is from (a book, talk, proverb origin). */
+  cite?: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const Quote: React.FC<QuoteProps> = ({children, source, reflection, cite, className, style}) => {
+  const [open, setOpen] = useState(false);
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+
+  return (
+    <figure className={clsx(styles.quote, className)} style={style}>
+      <blockquote className={styles.text}>{children}</blockquote>
+      {(source || cite) && (
+        <figcaption className={styles.attribution}>
+          {source && <span className={styles.source}>{source}</span>}
+          {cite && <span className={styles.cite}>{cite}</span>}
+        </figcaption>
+      )}
+      {reflection && (
+        <div className={styles.reflectionWrap}>
+          <button
+            type="button"
+            className={styles.reflectionToggle}
+            onClick={toggle}
+            aria-expanded={open}>
+            why it moved me
+            <span className={clsx(styles.chevron, open && styles.chevronOpen)} aria-hidden="true">
+              &#8250;
+            </span>
+          </button>
+          {open && <div className={styles.reflection}>{reflection}</div>}
+        </div>
+      )}
+    </figure>
+  );
+};
+
+export default Quote;

--- a/packages/blog-ui/src/components/Quote/styles.module.css
+++ b/packages/blog-ui/src/components/Quote/styles.module.css
@@ -1,0 +1,105 @@
+/* Quote — an editorial pull-quote (the quote is the hero), riding on the tea-party theme tokens.
+   Deliberately NOT a card: generous space, large display type, quiet attribution, reflection on
+   reveal. The reading rhythm of a curated page, not a task grid. */
+
+.quote {
+  margin: 2.5rem 0;
+  padding: 0 0 0 1.25rem;
+  border-left: 3px solid var(--brand-green, var(--ifm-color-primary));
+}
+
+.text {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font-size: clamp(1.4rem, 1.1rem + 1.4vw, 2rem);
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  color: var(--ifm-heading-color);
+  font-style: normal;
+}
+
+/* Render the typographic quotation marks so authors don't type them. */
+.text::before {
+  content: '\201C';
+}
+.text::after {
+  content: '\201D';
+}
+
+.attribution {
+  margin-top: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.source {
+  font-weight: 600;
+  color: var(--ifm-color-content-secondary, var(--ifm-color-emphasis-700));
+}
+.source::before {
+  content: '\2014\00a0'; /* em-dash + nbsp, as the attribution lead-in */
+}
+
+.cite {
+  font-style: italic;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* ── Reflection (why it moved me) — quiet, on reveal ─────────────────── */
+
+.reflectionWrap {
+  margin-top: 0.75rem;
+}
+
+.reflectionToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  color: var(--ifm-color-primary);
+}
+.reflectionToggle:hover {
+  text-decoration: underline;
+}
+
+.chevron {
+  display: inline-block;
+  transition: transform 0.15s ease;
+  font-size: 1.1em;
+  line-height: 1;
+}
+.chevronOpen {
+  transform: rotate(90deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .chevron {
+    transition: none;
+  }
+}
+
+.reflection {
+  margin-top: 0.5rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 8px;
+  background: var(--ifm-color-primary-contrast-background, var(--ifm-color-emphasis-100));
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--ifm-color-content, var(--ifm-color-emphasis-800));
+}
+.reflection > :last-child {
+  margin-bottom: 0;
+}

--- a/packages/blog-ui/src/components/QuoteSet/index.tsx
+++ b/packages/blog-ui/src/components/QuoteSet/index.tsx
@@ -1,0 +1,37 @@
+import React, {ReactNode} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * QuoteSet — a themed set of quotes, laid out as a VERTICAL READING FLOW (each quote gets room
+ * to breathe), not a grid. The analog of <QuestionSection> for the quote kit, but intentionally
+ * simpler: quotes are received, not actioned, so there is no priority sort or modal machinery —
+ * just a calm, well-spaced column you read top to bottom.
+ *
+ *   ## Faith
+ *   <SectionBanner why="The quotes I reach for when I need to remember Who is in control." />
+ *   <QuoteSet>
+ *     <Quote source="…">…</Quote>
+ *     <Quote source="…">…</Quote>
+ *   </QuoteSet>
+ *
+ * An optional `theme` renders a small eyebrow label above the set (use it when the set is not
+ * already under an H2). Children render in authored order.
+ */
+export interface QuoteSetProps {
+  children: ReactNode;
+  /** Optional eyebrow label above the set (when not already under a heading). */
+  theme?: string;
+  className?: string;
+}
+
+const QuoteSet: React.FC<QuoteSetProps> = ({children, theme, className}) => {
+  return (
+    <section className={clsx(styles.set, className)}>
+      {theme && <p className={styles.theme}>{theme}</p>}
+      {children}
+    </section>
+  );
+};
+
+export default QuoteSet;

--- a/packages/blog-ui/src/components/QuoteSet/styles.module.css
+++ b/packages/blog-ui/src/components/QuoteSet/styles.module.css
@@ -1,0 +1,14 @@
+/* QuoteSet — a themed column of quotes, vertical reading flow with breathing room. */
+
+.set {
+  margin: 1.5rem 0 2.5rem;
+}
+
+.theme {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -46,3 +46,12 @@ export type {
 
 export {default as QuestionSection} from './components/QuestionSection';
 export type {QuestionSectionProps} from './components/QuestionSection';
+
+// Quote kit — the analog of the question kit, but for quotes that moved me. A quote is RECEIVED
+// and savored (an editorial pull-quote with a reveal-on-demand reflection), not actioned like a
+// question, so the CX is deliberately different (no badges/modal/priority sort).
+export {default as Quote} from './components/Quote';
+export type {QuoteProps} from './components/Quote';
+
+export {default as QuoteSet} from './components/QuoteSet';
+export type {QuoteSetProps} from './components/QuoteSet';


### PR DESCRIPTION
Turns the lackluster `/mindset` page (3 hardcoded placeholder cards + a "just getting started" note) into a real **"quotes that moved me"** experience — with a quote kit whose CX is **deliberately different** from the question kit.

## The quote CX (not a question card)
A question is *acted on* (a clickable card with scheduling badges + a modal); a quote is *received and savored*. So `<Quote>` is an **editorial pull-quote**: the quote is the hero (large display type, green left-border, generous space), the attribution is quiet beneath, and **"why it moved me" reveals on demand** — no badges, no modal, no priority sort. `<QuoteSet>` lays a themed set out as a **vertical reading flow**.

## What changed
- **`packages/blog-ui`**: new `<Quote>` + `<QuoteSet>` (reduced-motion respected, tea-party themed), registered in MDXComponents.
- **`kind: quote-set` 💬** in `blog-kinds.json` (+ outline CHECK + Start Here legend row, drift clean). *Not* a `/thoughts` thought-kind — quote sets live with Mindset.
- **Seed quote-set post** (`quotes-that-moved-me.mdx`): curated quotes **with reflections**, demonstrating the kit. The affirmations post stays as-is (a ~250-line deck, its own format); `/mindset` links to both.
- **`/mindset` rebuilt**: intro → featured `<Quote>` pull-quotes (bounded to 720px so lines don't over-stretch) → "the collections" cards. The hardcoded array + placeholder note are gone.
- **`upgrade-post` skill** documents the quote kit alongside the question kit.
- **Build robustness (fail-closed)**: blog-ui's `dist/` is gitignored and the blog consumes the *built* package, but `make build`/`deploy` didn't rebuild it. Added a **`build-blog-ui`** target as a prerequisite of `build` + `deploy`, so the site can never ship stale components.

## Verification
- Build clean; `validate-structure` (0 errors), `validate-redirects` (439 ok, 251 published), no em-dashes.
- **chrome-devtools**: `/mindset` renders the pull-quotes with a **working "why it moved me" reveal** (aria-expanded toggles, reflection shows); the quote-set post renders 3 `<Quote>` + 2 `<SectionBanner>`, no crash; **desktop** no overflow + 720px-bounded quotes; **mobile** reflows. Screenshot-verified both modes.

**No files deleted.** **Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)