### PR TITLE
Fast WCAG-AA contrast guard for the theme color vars

### DIFF
--- a/.claude/hooks/check-contrast-hook.sh
+++ b/.claude/hooks/check-contrast-hook.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write on the theme CSS: WARN (never block) on a WCAG-AA contrast
+# regression in the theme's color variables.
+#
+# The e2e axe gate (test/e2e/accessibility.spec.ts) catches color-contrast failures, but only on a
+# full prod build + Playwright run (minutes). This is the FAST complement: when src/css/custom.css
+# is edited, it resolves the theme's critical fg/bg variable PAIRS (body/links/buttons/tea-ink on
+# their surfaces, light + dark) and computes the WCAG contrast ratio for each, surfacing any pair
+# that dropped below AA right at edit time — milliseconds, before the slow axe gate.
+#
+# Advisory only: it exits 0 so the edit is NEVER blocked (mirrors the other content hooks). The
+# blocking enforcement is `make check-contrast` (exit 2 on a failure) — run it before a deploy.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+# Scope: the theme's custom.css (the file that defines the palette vars the checker reads).
+case "$file_path" in
+  */bytesofpurpose-blog/src/css/custom.css) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(printf '%s' "$input" | jq -r '.cwd // empty')}"
+script="$proj/bytesofpurpose-blog/scripts/check-contrast.js"
+[ -f "$script" ] || exit 0   # not this repo / not set up → stay out of the way
+
+out=$(node "$script" "$file_path" 2>&1)
+rc=$?
+if [ "$rc" -eq 2 ]; then
+  {
+    echo "🎨 A11y contrast: a theme color pair dropped below WCAG AA"
+    echo "$out"
+    echo ""
+    echo "   This is the fast complement to the axe e2e gate (which would also fail this)."
+    echo "   Adjust the colors so each pair meets AA (4.5:1 text / 3.0:1 large+UI)."
+    echo "   (advice only — not blocking. Run \`make check-contrast\` for the gate.)"
+  } >&2
+fi
+
+# WARN-only: always succeed so the edit is never blocked.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,6 +53,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-contrast-hook.sh\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-glossary-links-hook.sh\"",
             "timeout": 20
           },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,18 @@ title/description duplicates. It skips client-redirect stubs + auto-generated li
 (tags/authors/pagination/storybook). When you add an SEO-affecting field or rule, update the shared
 lib + both validators in lockstep.
 
+**A11y contrast is guarded fast** by `scripts/check-contrast.js` (`make check-contrast`), the
+millisecond complement to the e2e axe gate (`test/e2e/accessibility.spec.ts`, which only runs on a
+full prod build). It reads the theme's color variables from `src/css/custom.css` (the `:root` light
+block + the `html[data-theme='dark']` block), resolves the critical foreground/background PAIRS
+(body/secondary/heading text on the page + cards, primary links, button text on the primary fill,
+`--tea-ink` on each pastel accent — both themes), and computes the WCAG 2 contrast ratio for each.
+Exit 2 if any pair drops below AA (4.5:1 text / 3.0:1 large+UI) — a regression the axe gate would
+also fail. The warn-tier PostToolUse hook `.claude/hooks/check-contrast-hook.sh` (registered in
+`.claude/settings.json`) runs it on a `custom.css` edit and surfaces failures without blocking; the
+blocking gate is `make check-contrast`. When you add a themed fg/bg surface meant to be readable,
+add its pair to the `PAIRS` manifest so the guard covers it.
+
 ## The site
 
 Docusaurus 3 blog/docs (`bytesofpurpose-blog/`) → GitHub Pages (`gh-pages`) →

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,12 @@ validate-structure: ## Lint the topic-based docs IA contract (absolute slugs, ca
 		if [ $$rc -eq 2 ]; then echo "✗ structure: ERROR-tier violations — see above."; exit 1; fi; \
 		exit 0
 
+check-contrast: ## Fast WCAG-AA contrast gate on the theme's color vars (complements the axe e2e gate)
+	@# Exit 2 if any critical fg/bg theme pair (body/links/buttons/tea-ink, light + dark) drops
+	@# below AA — a contrast regression the slow axe gate would also fail. The warn-tier hook
+	@# .claude/hooks/check-contrast-hook.sh runs this at edit time; this target is the blocking gate.
+	( cd ${SITEROOT} && node scripts/check-contrast.js )
+
 validate-seo: ## Lint SEO frontmatter across ALL content (description/title/keywords/image) — advisory
 	@# Mode 1 (source): the cheap, corpus-wide frontmatter audit (the blog instances the docs
 	@# validator skips + title/keywords/image). Always exits 0 — warn-tier advisory like the other

--- a/bytesofpurpose-blog/scripts/check-contrast.js
+++ b/bytesofpurpose-blog/scripts/check-contrast.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+/**
+ * check-contrast.js — a FAST, edit-time WCAG contrast guard for the theme's color variables.
+ *
+ * The e2e axe gate (test/e2e/accessibility.spec.ts) catches color-contrast failures, but only on a
+ * full prod build + Playwright run (minutes). This catches the most common regression — someone
+ * darkens a background or lightens a text color in src/css/custom.css and quietly drops a critical
+ * pairing below AA — in milliseconds, right when the CSS is edited.
+ *
+ * HOW: it reads the theme's CSS custom properties from the `:root` block (light mode) and the
+ * `html[data-theme='dark']` block (dark mode), resolves the PAIRS below to their hex values, and
+ * computes the WCAG 2 contrast ratio for each. A pair under its threshold is a finding.
+ *
+ * The PAIRS manifest is the contract: the foreground/background pairings the theme INTENDS to be
+ * readable (body text on the page, primary links on the page, button text on the primary fill, the
+ * tea-ink on each pastel accent, …). When you add a themed surface, add its pair here so the guard
+ * covers it. Thresholds: 4.5 for normal text, 3.0 for large text / UI components (WCAG AA).
+ *
+ * Usage:  node scripts/check-contrast.js [path/to/custom.css] [--json]
+ * Exit:   2 if any pair is below its threshold (a real AA regression); else 0.
+ *         (ERROR-tier: a contrast regression is a shipped a11y defect the axe gate would also fail.)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_CSS = path.join(ROOT, 'src', 'css', 'custom.css');
+
+const args = process.argv.slice(2);
+const JSON_OUT = args.includes('--json');
+const cssPath = args.find((a) => !a.startsWith('--')) || DEFAULT_CSS;
+
+// AA thresholds.
+const AA_TEXT = 4.5; // normal body text
+const AA_LARGE = 3.0; // large text (≥18.66px bold / ≥24px) + UI components / accent fills
+
+// The pairs the theme intends to be readable. `fg`/`bg` are CSS var names (or literal hex). `min`
+// is the AA threshold (AA_TEXT for body copy, AA_LARGE for large/decorative). `note` describes it.
+// Checked in BOTH themes; a pair whose vars don't exist in a theme is skipped for that theme.
+const PAIRS = [
+  {fg: '--ifm-font-color-base', bg: '--ifm-background-color', min: AA_TEXT, note: 'body text on the page'},
+  {fg: '--ifm-heading-color', bg: '--ifm-background-color', min: AA_LARGE, note: 'headings on the page (large)'},
+  {fg: '--ifm-color-content-secondary', bg: '--ifm-background-color', min: AA_TEXT, note: 'secondary text on the page'},
+  {fg: '--ifm-font-color-base', bg: '--ifm-card-background-color', min: AA_TEXT, note: 'body text on a card'},
+  {fg: '--ifm-color-primary', bg: '--ifm-background-color', min: AA_TEXT, note: 'primary (links) on the page'},
+  {fg: '--ifm-color-primary', bg: '--ifm-card-background-color', min: AA_TEXT, note: 'primary (links) on a card'},
+  {fg: '--ifm-button-color', bg: '--ifm-color-primary', min: AA_TEXT, note: 'button text on the primary fill'},
+  // Tea-party pastel accents: --tea-ink is the only text allowed to ride on them (AA).
+  {fg: '--tea-ink', bg: '--tea-mint', min: AA_TEXT, note: 'tea-ink on the mint accent'},
+  {fg: '--tea-ink', bg: '--tea-pink', min: AA_TEXT, note: 'tea-ink on the pink accent'},
+  {fg: '--tea-ink', bg: '--tea-green', min: AA_TEXT, note: 'tea-ink on the light-green accent'},
+];
+
+// ── CSS var parsing ─────────────────────────────────────────────────────────
+// Pull the body of a CSS rule by its selector (the first matching block).
+function ruleBody(css, selector) {
+  // Escape regex metachars in the selector, then grab the first {...} after it.
+  const esc = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = css.match(new RegExp(`${esc}\\s*\\{([^}]*)\\}`));
+  return m ? m[1] : '';
+}
+
+// Parse `--var: value;` declarations from a rule body into a map.
+function parseVars(body) {
+  const vars = {};
+  for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    vars[m[1]] = m[2].trim();
+  }
+  return vars;
+}
+
+// Resolve a var name (or literal) to an {r,g,b} color, following one level of var() reference and
+// the theme's own scale (so --brand-green etc. resolve). Returns null if it isn't a solid color.
+function resolveColor(token, vars) {
+  let v = token.trim();
+  // var(--x) reference
+  const ref = v.match(/^var\(\s*(--[\w-]+)\s*(?:,[^)]*)?\)$/);
+  if (ref) v = vars[ref[1]] || '';
+  // a bare var NAME passed in
+  if (v.startsWith('--')) v = vars[v] || '';
+  return parseColor(v.trim());
+}
+
+// Parse #hex / #rgb / rgb()/rgba() → {r,g,b}. (rgba with alpha < 1 can't be contrast-checked
+// against an unknown backdrop, so we treat alpha as opaque-over-bg only when alpha is 1.)
+function parseColor(v) {
+  if (!v) return null;
+  let m = v.match(/^#([0-9a-f]{6})$/i);
+  if (m) {
+    const n = parseInt(m[1], 16);
+    return {r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255};
+  }
+  m = v.match(/^#([0-9a-f]{3})$/i);
+  if (m) {
+    const [a, b, c] = m[1];
+    return {r: parseInt(a + a, 16), g: parseInt(b + b, 16), b: parseInt(c + c, 16)};
+  }
+  m = v.match(/^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)\s*(?:[,/]\s*([\d.]+)\s*)?\)$/i);
+  if (m) {
+    const alpha = m[4] === undefined ? 1 : parseFloat(m[4]);
+    if (alpha < 1) return null; // translucent → can't standalone-check
+    return {r: +m[1], g: +m[2], b: +m[3]};
+  }
+  return null;
+}
+
+// ── WCAG contrast math ──────────────────────────────────────────────────────
+function relLum({r, g, b}) {
+  const f = (c) => {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function contrast(a, b) {
+  const l1 = relLum(a);
+  const l2 = relLum(b);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ── run ─────────────────────────────────────────────────────────────────────
+function run() {
+  if (!fs.existsSync(cssPath)) {
+    console.error(`❌ no CSS file at ${cssPath}`);
+    process.exit(2);
+  }
+  const css = fs.readFileSync(cssPath, 'utf8');
+  const themes = [
+    {name: 'light', vars: parseVars(ruleBody(css, ':root'))},
+    {name: 'dark', vars: parseVars(ruleBody(css, "html[data-theme='dark']"))},
+  ];
+
+  const findings = [];
+  for (const {name, vars} of themes) {
+    if (!Object.keys(vars).length) continue;
+    for (const pair of PAIRS) {
+      const fg = resolveColor(pair.fg, vars);
+      const bg = resolveColor(pair.bg, vars);
+      if (!fg || !bg) continue; // var not defined in this theme (or translucent) → skip
+      const ratio = contrast(fg, bg);
+      if (ratio < pair.min) {
+        findings.push({
+          theme: name,
+          fg: pair.fg,
+          bg: pair.bg,
+          note: pair.note,
+          ratio: Math.round(ratio * 100) / 100,
+          min: pair.min,
+        });
+      }
+    }
+  }
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({css: path.relative(ROOT, cssPath), findings}, null, 2));
+  } else if (!findings.length) {
+    console.log(`✅ contrast: every theme pair meets WCAG AA (${path.relative(ROOT, cssPath)}).`);
+  } else {
+    console.log(`🎨 contrast: ${findings.length} pair(s) below WCAG AA in ${path.relative(ROOT, cssPath)}\n`);
+    for (const f of findings) {
+      console.log(`  [${f.theme}]  ${f.note}`);
+      console.log(`      ↳ ${f.fg} on ${f.bg} = ${f.ratio}:1, needs ≥ ${f.min}:1`);
+    }
+    console.log('\n❌ a contrast regression — the axe e2e gate would also fail this. Fix the colors.');
+  }
+  process.exit(findings.length ? 2 : 0);
+}
+
+run();


### PR DESCRIPTION
The millisecond complement to the e2e axe gate (which only catches color-contrast failures on a full prod build + Playwright run). When `src/css/custom.css` is edited, this catches a contrast regression in the theme's color variables right then.

## How it works
`scripts/check-contrast.js` reads the theme's CSS custom properties from the `:root` (light) and `html[data-theme='dark']` blocks, resolves a **manifest of the critical foreground/background pairs** the theme intends to be readable, and computes the **WCAG 2 contrast ratio** for each:
- body / secondary / heading text on the page + cards
- primary (links) on the page + cards
- button text on the primary fill
- `--tea-ink` on each pastel accent (mint / pink / green)
- …both light and dark themes (resolves `var()` refs + the `--brand-green` scale)

Exit 2 if any pair drops below AA (4.5:1 text / 3.0:1 large+UI). `make check-contrast` is the blocking gate; the warn-tier hook `.claude/hooks/check-contrast-hook.sh` (in `settings.json`) runs it on a `custom.css` edit and surfaces failures **without blocking**.

## Proof (always-prove-and-test)
- **PASSES** on the live AA-verified theme — agreeing with the manual contrast check from the re-theme.
- **Planted regressions bite**: near-white body text → 1.24:1, a too-light primary → 1.63:1, both exit 2 and surface through the hook end-to-end, then cleanly restored.

Documented in CLAUDE.md next to the SEO validator. **Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)