### PR TITLE
Fix: make start/start-prod rebuild blog-ui too (fail-closed, all run paths)

### DIFF
--- a/.claude/skills/serve-locally/SKILL.md
+++ b/.claude/skills/serve-locally/SKILL.md
@@ -20,6 +20,14 @@ production deploy (gh-pages) see `deploy-site`; for post-deploy live checks see
 - Override the port: `make start PORT=8080`.
 - `make start` builds Storybook first (so `/storybook/` works) and runs the `prestart`
   hook (regenerates changelog/ideas/logo data) — so the first boot takes a minute or two.
+- **`make start` ALSO rebuilds `@omars-lab/blog-ui` first** (the `build-blog-ui` prereq). The blog
+  consumes the package's BUILT `dist/`, which is gitignored — so a fresh clone, or editing a
+  blog-ui component (`<Quote>`, `<Question>`, `<Walkthrough>`, …) without rebuilding, would render a
+  STALE component with no warning. `start` / `start-prod` / `build` / `deploy` all depend on
+  `build-blog-ui` so this can't happen by omission (fail-closed). If you change a blog-ui component
+  mid-session (the dev server is already up), run `make build-blog-ui` and the HMR picks up the new
+  `dist/`; you don't need a full restart for that (a restart is only for the stale-route-table
+  gotcha below).
 - **Drafts render ONLY on the dev server** (`make start` / `make start-prod`), with a
   "DRAFT PAGE" banner and a `D` sidebar badge. They are excluded from `make build`/
   `make serve` and from production. So if you're previewing a `draft: true` page, you MUST

--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,12 @@ clean: ## Clean build artifacts and dependencies
 	( cd ${SITEROOT} && rm -rf node_modules yarn.lock package-lock.json )
 
 PORT ?= 3000
-start: build-storybook ## Start the development server (use PORT=8080 to specify a custom port)
+start: build-blog-ui build-storybook ## Start the development server (use PORT=8080 to specify a custom port)
 	# Starts the development server, includes drafts and monitors and auto deploys updates
 	# Builds Storybook first so it's available at /storybook/
+	# Rebuilds @omars-lab/blog-ui first (its dist/ is gitignored + consumed built) so the dev
+	# server always renders the CURRENT components, never a stale dist from a fresh clone or an
+	# un-rebuilt edit — see `make build-blog-ui`.
 	# Dynamic data assets are auto-generated via the npm 'prestart' hook
 	# (npm run generate-assets) before starting — see `make generate-assets`.
 	@# Dev/prod parity for premium: export STATICRYPT_PASSPHRASE from the gitignored .env so
@@ -268,8 +271,9 @@ start: build-storybook ## Start the development server (use PORT=8080 to specify
 	( cd ${SITEROOT} && STATICRYPT_PASSPHRASE=$$SP CF_ACCESS_CLIENT_ID=$$CID CF_ACCESS_CLIENT_SECRET=$$CSEC yarn start --port ${PORT} )
 
 PORT ?= 3000
-start-prod: ## Start the development server with NODE_ENV=production
+start-prod: build-blog-ui ## Start the development server with NODE_ENV=production
 	# Starts the development server in production mode, includes drafts and monitors and auto deploys updates
+	# Rebuilds @omars-lab/blog-ui first (gitignored dist/, consumed built) so it isn't stale.
 	( cd ${SITEROOT} && NODE_ENV=production yarn start --port ${PORT} )
 
 clear: ## Clear Docusaurus cache


### PR DESCRIPTION
Closes the gap caught in review: the prod paths (`build`/`deploy`) got `build-blog-ui` as a prerequisite, but the **dev server** (`make start`/`start-prod`) did not. The blog consumes the package's **built** `dist/` (gitignored), so starting the dev server after editing a blog-ui component — or on a fresh clone — would render a **stale** component with no warning.

Now `start`/`start-prod` depend on `build-blog-ui` too, so **every path that runs the site rebuilds the package first** (fail-closed). Documented in the `serve-locally` skill, including the mid-session shortcut (`make build-blog-ui` → HMR picks up the new `dist/`, no restart needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)