### PR TITLE
Focus word-highlight that sweeps in on quote hover

### DIFF
--- a/bytesofpurpose-blog/blog/2026-06-25-quotes-that-moved-me.mdx
+++ b/bytesofpurpose-blog/blog/2026-06-25-quotes-that-moved-me.mdx
@@ -23,7 +23,7 @@ landed. Read the section that matches where your head is, and take what resonate
 <QuoteSet>
 
 <Quote source="Will Durant" cite="often attributed to Aristotle" reflection="It reframed mastery as something I build in the small, unglamorous reps rather than chase in a single breakthrough. It is why I care more about the systems I keep than the bursts I manage.">
-We are what we repeatedly do. Excellence, then, is not an act, but a habit.
+We are what we <Focus>repeatedly do</Focus>. Excellence, then, is not an act, but a <Focus>habit</Focus>.
 </Quote>
 
 <Quote source="Marcus Aurelius" cite="via Ryan Holiday" reflection="The thing blocking me is usually the thing worth doing. When I notice resistance now I lean toward it instead of around it, because that friction tends to mark where the growth is.">
@@ -39,7 +39,7 @@ The obstacle is the way.
 <QuoteSet>
 
 <Quote source="African proverb" reflection="A quiet correction to my instinct to do everything myself. The work I am proudest of was slower because it was shared, and it lasted because of it.">
-If you want to go fast, go alone. If you want to go far, go together.
+If you want to go fast, <Focus>go alone</Focus>. If you want to go far, <Focus>go together</Focus>.
 </Quote>
 
 </QuoteSet>

--- a/bytesofpurpose-blog/src/pages/mindset.tsx
+++ b/bytesofpurpose-blog/src/pages/mindset.tsx
@@ -3,15 +3,17 @@ import posthog from 'posthog-js';
 // @ts-ignore - Docusaurus theme module
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import { Quote } from '@omars-lab/blog-ui';
+import { Quote, Focus } from '@omars-lab/blog-ui';
 import '@omars-lab/blog-ui/style.css';
 import styles from './mindset.module.css';
 
 // A few featured quotes shown inline on the landing (the <Quote> pull-quote CX). The full,
 // growing collection lives in the quote-set posts linked below; this page is the front door.
+// `quote` is a ReactNode so the powerful words can be wrapped in <Focus> (they highlight-sweep
+// when the quote is hovered).
 type Featured = {
   id: string;
-  quote: string;
+  quote: React.ReactNode;
   source: string;
   cite?: string;
   reflection: string;
@@ -20,7 +22,12 @@ type Featured = {
 const FEATURED: Featured[] = [
   {
     id: 'habit',
-    quote: 'We are what we repeatedly do. Excellence, then, is not an act, but a habit.',
+    quote: (
+      <>
+        We are what we <Focus>repeatedly do</Focus>. Excellence, then, is not an act, but a{' '}
+        <Focus>habit</Focus>.
+      </>
+    ),
     source: 'Will Durant',
     cite: 'often attributed to Aristotle',
     reflection:
@@ -28,7 +35,11 @@ const FEATURED: Featured[] = [
   },
   {
     id: 'obstacle',
-    quote: 'The obstacle is the way.',
+    quote: (
+      <>
+        The <Focus>obstacle</Focus> is the <Focus>way</Focus>.
+      </>
+    ),
     source: 'Marcus Aurelius',
     cite: 'via Ryan Holiday',
     reflection:

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -28,6 +28,7 @@ import {
   PowerLegend,
   Quote,
   QuoteSet,
+  Focus,
 } from '@omars-lab/blog-ui';
 import '@omars-lab/blog-ui/style.css';
 
@@ -94,4 +95,6 @@ export default {
   // different CX from <Question> (received/savored, not actioned).
   Quote,
   QuoteSet,
+  // <Focus> marks the powerful word(s) in a <Quote>; a highlight sweeps in under them on hover.
+  Focus,
 };

--- a/packages/blog-ui/src/components/Quote/Focus.tsx
+++ b/packages/blog-ui/src/components/Quote/Focus.tsx
@@ -1,0 +1,27 @@
+import React, {ReactNode} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * Focus — mark the powerful word(s) in a <Quote> so they draw the eye. By default the word looks
+ * normal; when the reader HOVERS the quote, a colored highlight underline SWEEPS in left-to-right
+ * under each focus word, pulling attention to the parts worth focusing on.
+ *
+ *   <Quote source="Will Durant">
+ *     We are what we <Focus>repeatedly do</Focus>. Excellence, then, is not an act, but a <Focus>habit</Focus>.
+ *   </Quote>
+ *
+ * The sweep is driven by the parent .quote:hover (see styles.module.css), so hovering anywhere on
+ * the quote animates ALL its focus words together. Respects prefers-reduced-motion: with motion
+ * reduced, the highlight is shown statically (full, no animation) so the emphasis still reads.
+ */
+export interface FocusProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const Focus: React.FC<FocusProps> = ({children, className}) => {
+  return <span className={clsx(styles.focus, className)}>{children}</span>;
+};
+
+export default Focus;

--- a/packages/blog-ui/src/components/Quote/styles.module.css
+++ b/packages/blog-ui/src/components/Quote/styles.module.css
@@ -103,3 +103,45 @@
 .reflection > :last-child {
   margin-bottom: 0;
 }
+
+/* ── Focus words: a highlight that sweeps in on hover ────────────────── */
+
+/* A focus word looks normal by default; a green highlight underline is drawn behind it but
+   clipped to 0 width, anchored left. The sweep happens on the PARENT .quote:hover, so hovering
+   anywhere on the quote animates all its focus words together. */
+.focus {
+  position: relative;
+  font-weight: 600;
+  white-space: nowrap;
+  /* The highlight lives in a background-image sized to 0% width; hover grows it to 100%. */
+  background-image: linear-gradient(var(--tea-mint, #adfff5), var(--tea-mint, #adfff5));
+  background-repeat: no-repeat;
+  background-position: 0 88%;
+  background-size: 0% 0.32em;
+  transition: background-size 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+  /* tiny nudge so the highlight reads as "under" the word, not through it */
+  padding-bottom: 0.02em;
+}
+
+.quote:hover .focus {
+  background-size: 100% 0.32em;
+}
+
+/* Stagger: later focus words start a touch after earlier ones, so the eye is led across. */
+.quote:hover .focus:nth-of-type(2) {
+  transition-delay: 0.12s;
+}
+.quote:hover .focus:nth-of-type(3) {
+  transition-delay: 0.24s;
+}
+.quote:hover .focus:nth-of-type(n + 4) {
+  transition-delay: 0.36s;
+}
+
+/* Reduced-motion: no sweep — show the highlight statically so the emphasis still reads. */
+@media (prefers-reduced-motion: reduce) {
+  .focus {
+    background-size: 100% 0.32em;
+    transition: none;
+  }
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -53,5 +53,10 @@ export type {QuestionSectionProps} from './components/QuestionSection';
 export {default as Quote} from './components/Quote';
 export type {QuoteProps} from './components/Quote';
 
+// <Focus> marks the powerful word(s) inside a <Quote>; a highlight sweeps in under them when the
+// quote is hovered (reduced-motion safe). Only meaningful inside a <Quote>.
+export {default as Focus} from './components/Quote/Focus';
+export type {FocusProps} from './components/Quote/Focus';
+
 export {default as QuoteSet} from './components/QuoteSet';
 export type {QuoteSetProps} from './components/QuoteSet';


### PR DESCRIPTION
Lets a quote mark its **powerful words**, which highlight-sweep on hover.

A focus word looks normal by default; when the reader **hovers the quote**, a green highlight underline **sweeps in left-to-right** under each focus word (staggered, so the eye is led across). Driven by the parent `.quote:hover` so hovering anywhere animates all the focus words together. **prefers-reduced-motion safe** (highlight shown statically, no sweep).

## What changed
- **packages/blog-ui**: a `Focus` component + the sweep CSS (`background-size` 0%->100% on `.quote:hover`, `nth-of-type` stagger, reduced-motion fallback). Exported from the package.
- **Registered `Focus` in MDXComponents** — both the import *and* the export object (a quote-set MDX post reads components from the exported map; a missing export crashes the page with "Expected component Focus to be defined" — caught + fixed).
- **Demoed it**: the seed quote-set post + the `/mindset` featured quotes wrap their key words.

## Verification
Dev (cache-cleared): `/mindset` + the quote-set post render the focus words **hidden by default** (`background-size: 0%`), **no crash**; the `.quote:hover -> 100%` sweep rule is in the compiled CSS; reduced-motion shows the highlight statically. The quote-set outline check still passes.

**Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
