### PR TITLE
Retitle the "my first X" thought ideas as questions (name-post)

### DIFF
--- a/bytesofpurpose-blog/thoughts/2022-01-16-hello-worlds.mdx
+++ b/bytesofpurpose-blog/thoughts/2022-01-16-hello-worlds.mdx
@@ -25,7 +25,7 @@ A collection of "my first" hello world examples for different technologies I hav
 
 ## The "my first" ideas
 
-- [My First iOS App](/thoughts/my-first-ios-app)
-- [My First Mac Menu Bar App](/thoughts/my-first-mac-menubar-app)
-- [My First NotePlan Plugin](/thoughts/my-first-noteplan-plugin)
-- [Tinkering with Browser Automation](/thoughts/tinker-browser-automation)
+- [Should I build my first iOS app?](/thoughts/my-first-ios-app)
+- [Should I build a Mac menu-bar app?](/thoughts/my-first-mac-menubar-app)
+- [Should I build a NotePlan plugin?](/thoughts/my-first-noteplan-plugin)
+- [Should I tinker with browser automation?](/thoughts/tinker-browser-automation)

--- a/bytesofpurpose-blog/thoughts/2022-01-16-tinker-browser-automation.md
+++ b/bytesofpurpose-blog/thoughts/2022-01-16-tinker-browser-automation.md
@@ -1,18 +1,20 @@
 ---
 slug: tinker-browser-automation
-title: '💡 Tinkering with Browser Automation'
-description: 'Experiments with browser automation tools like Automa for workflow automation'
+title: '💡 Should I Tinker with Browser Automation?'
+sidebar_label: '💡 Browser automation?'
+description: 'A thought I am weighing: should I tinker with browser-automation tools like Automa to script repetitive workflows?'
 authors: [oeid]
-tags: [browser-automation, automa, chrome-extension, automation, experiments, tinkering]
+tags: [browser-automation, automa, chrome-extension, automation, idea]
 date: 2022-01-16T10:00
-kind: reflection
+kind: idea
 board: ideas
 stage: backlog
 priority: low
 draft: true
 ---
 
-An unactioned idea: tinker with browser-automation tools like Automa to script repetitive workflows.
+A thought I keep coming back to: **should I tinker with browser-automation tools like Automa** to
+script the repetitive workflows I do by hand? I have not committed to it; here is what I am weighing.
 
 <!-- truncate -->
 

--- a/bytesofpurpose-blog/thoughts/2025-01-01-my-first-ios-app.md
+++ b/bytesofpurpose-blog/thoughts/2025-01-01-my-first-ios-app.md
@@ -1,18 +1,20 @@
 ---
 slug: my-first-ios-app
-title: '💡 My First iOS App'
-description: 'Learning to develop iOS applications with Swift, focusing on calendar and dashboard functionality.'
+title: '💡 Should I Build My First iOS App?'
+sidebar_label: '💡 iOS app?'
+description: 'A thought I am weighing: should I build my first iOS app, a calendar/dashboard I have wanted to make?'
 authors: [oeid]
-tags: [ios, swift, mobile, app-development, calendar, learning]
+tags: [ios, swift, mobile, app-development, calendar, idea]
 date: 2025-01-01T10:00
-kind: reflection
+kind: idea
 board: ideas
 stage: backlog
 priority: low
 draft: true
 ---
 
-An unactioned idea: build my first iOS app — a calendar/dashboard I have wanted to make.
+A thought I keep coming back to: **should I build my first iOS app?** A calendar/dashboard I have
+wanted to make. I have not committed to it; these are the questions and references I am weighing.
 
 <!-- truncate -->
 

--- a/bytesofpurpose-blog/thoughts/2025-01-01-my-first-mac-menubar-app.md
+++ b/bytesofpurpose-blog/thoughts/2025-01-01-my-first-mac-menubar-app.md
@@ -1,18 +1,20 @@
 ---
 slug: my-first-mac-menubar-app
-title: '💡 My First Mac Menu Bar App'
-description: 'Learning to create a macOS menu bar application with NotePlan task integration.'
+title: '💡 Should I Build a Mac Menu-Bar App?'
+sidebar_label: '💡 Menu-bar app?'
+description: 'A thought I am weighing: should I build my first macOS menu-bar app to show my NotePlan task counts at a glance?'
 authors: [oeid]
-tags: [macos, menu-bar, app, noteplan, swift, development]
+tags: [macos, menu-bar, app, noteplan, swift, idea]
 date: 2025-01-01T10:00
-kind: reflection
+kind: idea
 board: ideas
 stage: backlog
 priority: low
 draft: true
 ---
 
-An unactioned idea: build my first macOS menu-bar app showing my NotePlan task counts at a glance.
+A thought I keep coming back to: **should I build my first macOS menu-bar app?** One that shows my
+NotePlan task counts at a glance. I have not committed to it; these are the questions I am weighing.
 
 <!-- truncate -->
 

--- a/bytesofpurpose-blog/thoughts/2025-03-02-my-first-noteplan-plugin.mdx
+++ b/bytesofpurpose-blog/thoughts/2025-03-02-my-first-noteplan-plugin.mdx
@@ -1,22 +1,25 @@
 ---
 slug: my-first-noteplan-plugin
-title: '💡 My First NotePlan Plugin'
-description: 'Learning to develop NotePlan plugins for note management, templates, and frontmatter automation.'
+title: '💡 Should I Build a NotePlan Plugin?'
+sidebar_label: '💡 NotePlan plugin?'
+description: 'A thought I am weighing: should I build my first NotePlan plugin to help with templates, frontmatter, and emoji picking?'
 authors: [oeid]
-tags: [noteplan, plugin, note-taking, automation, templates, learning]
+tags: [noteplan, plugin, note-taking, automation, templates, idea]
 date: 2025-03-02T10:00
-kind: reflection
+kind: idea
 board: ideas
 stage: backlog
 priority: low
 draft: true
 ---
 
-An unactioned idea: build my first NotePlan plugin to help with templates, frontmatter, and emoji picking.
+A thought I keep coming back to: **should I build my first NotePlan plugin?** It would help with
+the templates, frontmatter, and emoji-picking I do by hand today. I have not committed to it; these
+are the questions and references I am weighing.
 
 <!-- truncate -->
 
-## Build a NotePlan Plugin
+## What would the plugin do?
 
 * [ ] Noteplan add shortcuts for /thisweek in my plugin ... >2025-W12
 


### PR DESCRIPTION
Applies the **name-post** rule you surfaced: a `/thoughts` idea should read as the **question being weighed**, not a completed initiative. *"My First NotePlan Plugin"* read as a thing I built; it's an unactioned thought, so it's now *"Should I Build a NotePlan Plugin?"*.

## What changed
- **Retitled** the 4 my-first/tinker idea posts to the question form (+ short sidebar_label): *Should I Build My First iOS App? / a Mac Menu-Bar App? / a NotePlan Plugin? / Should I Tinker with Browser Automation?* Each intro reframed to the questioning voice (a thought I keep coming back to, not committed yet).
- **Re-tagged** `kind: reflection` → `kind: idea` 💡 (they ARE ideas) + idea tags.
- Repointed the `hello-worlds` index labels to the new question titles (slugs unchanged → links resolve). Fixed an em-dash.

## Verification
`validate-post-naming` now **clean** (the "My First X" flags are gone), no em-dashes, no broken links. Dev: the noteplan post renders **"💡 Should I Build a NotePlan Plugin?"**. Posts stay draft until matured further (#59 un-drafts them as their own board cards). **No files deleted.**

**Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)