### PR TITLE
Research board: research thoughts get the board/blog split (+ fix the stale research doc)

### DIFF
--- a/.claude/skills/groom-initiatives/SKILL.md
+++ b/.claude/skills/groom-initiatives/SKILL.md
@@ -31,8 +31,9 @@ the POST.
 
 | Board | Lives at | A card is a post (in…) with… | Columns (the `stage` values) |
 |---|---|---|---|
-| **experiments** | `/craft/product-management/experiments` | an `/initiatives` post, `kind: experiment-plan` 📝 / `experiment-result` 📊 | `proposed` → `designed` → `running` → `analyzing` → `concluded` |
+| **experiments** | `/craft/product-management/experiments` | an `/initiatives` post, `kind: experiment-plan` 📝 / `experiment-result` 📊 (POCs fold in here too) | `proposed` → `designed` → `running` → `analyzing` → `concluded` |
 | **ideas** | `/craft/product-management/ideas` | a **`/thoughts`** post + explicit `board: ideas` frontmatter | `backlog` → `exploring` → `building` → `shipped` |
+| **research** | `/craft/product-management/research` | a **`/thoughts`** post, `kind: research` 🔬 (or explicit `board: research`) | `backlog` → `researching` → `learned` |
 
 The generator (`generate-kanban-data.js`) scans BOTH blog dirs: `blog/` (→ `/initiatives`, the
 experiment posts) and `thoughts/` (→ `/thoughts`, the idea posts), and links each card to the

--- a/bytesofpurpose-blog/docs/craft/product-management/research/README.md
+++ b/bytesofpurpose-blog/docs/craft/product-management/research/README.md
@@ -1,7 +1,7 @@
 ---
 slug: /product-management/research
 title: '🔬 Research'
-description: 'Research planning and investigation to inform decisions about ideas - what must I research to act on my ideas?'
+description: 'The Research board: the things I want to research or learn before deciding, and the durable framework for how I run a research investigation.'
 authors: [oeid]
 tags: [research, planning, investigation, decision-making, ideas]
 draft: false
@@ -9,37 +9,31 @@ draft: false
 
 # Research
 
-Research is the second step in the development lifecycle. After having ideas, research helps you understand what you need to know before deciding whether to act on an idea, hold it, or discard it.
+A **research** is something I want to investigate or learn before deciding: a systematic
+investigation I have not run yet. "What must I find out to act on this idea, or to level up?"
 
-## What Is Research?
+## The Research board
 
-Research is **systematic investigation** to inform decision-making about ideas:
+The board below is the live index of my research. Each card is one research post (a 🔬 `research`
+thought on the [Thoughts](/thoughts) blog), and it moves across the board as the work moves: from
+**backlog** (something I want to research), through **researching** (actively investigating), to
+**learned** (the findings are captured). A card's column is its `stage`, read straight from the
+post's frontmatter, so the board can never drift from the posts it indexes. Click a card to open it.
 
-- 🔍 **Investigation** - Deep dives into technical topics, technologies, and approaches
-- 📊 **Information Gathering** - Collecting data, examples, and best practices
-- 🎯 **Decision Support** - Research should help you make informed decisions
-- 📋 **Planning Foundation** - Research helps you create actionable plans
+<KanbanBoard board="research" />
 
-## Development Progression
+| Column | What it means |
+|---|---|
+| Backlog | Something I want to research, not started. |
+| Researching | Actively investigating: reading, prototyping, gathering. |
+| Learned | The investigation is done; the findings are captured. |
 
-Understanding how ideas evolve through the development lifecycle:
-
-1. **Ideas** → Initial thoughts and concepts
-2. **Research** → Investigation and planning (you are here)
-3. **POCs** → Proof of concepts to validate approaches
-4. **Experiments** → Small, focused experiments for learning
-5. **Initiatives** → Ready to get started (blueprints, designs, execution plan)
-6. **Projects** → Actively being worked on
-
-## Research Outcomes
-
-At the end of research, you should be able to make a decision:
-
-- ✅ **Act on the idea** → Move to POC, experiment, or initiative
-- ⏸️ **Hold the idea** → Not ready yet, needs more information or different timing
-- ❌ **Discard the idea** → Not viable, not aligned with goals, or superseded
-
-Research should help you **put a plan together** for the next steps.
+This page is the **durable** half: the board that indexes the research and the framework for how I
+run an investigation. The research **posts themselves** are temporal, so they live on the
+[Thoughts](/thoughts) blog (each a card above), exactly the same split the
+[Experiments](/product-management/experiments) and [Ideas](/product-management/ideas) boards use.
+A research that concludes in a lasting lesson distills up into the relevant Craft topic; one that
+leads to building something graduates into an Initiative.
 
 ## What Must I Research?
 
@@ -119,23 +113,14 @@ When researching an idea, ensure you:
 
 ## Research → Next Steps
 
-After completing research, you should have enough information to:
+Once the research is **learned**, it graduates the same way any thought does:
 
-1. **Move to POC** - If you need to validate a specific approach
-2. **Start an Experiment** - If you need to test assumptions
-3. **Create an Initiative** - If you have enough information to plan execution
-4. **Hold the Idea** - If more information or better timing is needed
-5. **Discard the Idea** - If research shows it's not viable
-
-## What You'll Find Here
-
-- Research investigations into technical topics
-- Deep dives into technologies and approaches
-- Research findings and learnings
-- Decision frameworks based on research
-- Research plans and methodologies
-- **Learning Topics** - Learning goals, plans, and resources for various technologies and concepts (backend, frontend, business, software)
+1. **Act on it → an Initiative** - if I have enough to start building or experimenting.
+2. **Keep the lesson → Craft** - if the finding is durable knowledge worth returning to.
+3. **Hold it** - if more information or better timing is needed.
+4. **Discard it** - if the research shows it is not worth pursuing.
 
 ---
 
-**Remember**: Research is not about perfection, it's about gathering enough information to make an informed decision about whether and how to proceed with an idea.
+**Remember**: research is not about perfection, it is about learning enough to make an informed
+decision about whether and how to proceed.

--- a/bytesofpurpose-blog/docs/legend/README.mdx
+++ b/bytesofpurpose-blog/docs/legend/README.mdx
@@ -62,6 +62,7 @@ list and find the format you are in the mood for. Here is the legend:
 | Emoji | Kind | What it is |
 |---|---|---|
 | 💡 | Idea | An unactioned idea: something I might build or do, captured before I act on it. A Thought. |
+| 🔬 | Research | Something I want to research or learn before deciding. Carded on the Research board. A Thought. |
 | 🔮 | Simulation | A hypothetical walk-through: if X then Y then Z, what if 1, 2, 3. A Thought. |
 | 🎯 | Prediction | A falsifiable bet about the future: I call one outcome so I can check it later. A Thought. |
 | 🔍 | Critique | An evaluation of something that exists: what's wrong with it, or how it really works. A Thought. |

--- a/bytesofpurpose-blog/scripts/generate-kanban-data.js
+++ b/bytesofpurpose-blog/scripts/generate-kanban-data.js
@@ -62,6 +62,12 @@ const BOARDS = {
     kinds: [],
     columns: ['backlog', 'exploring', 'building', 'shipped'],
   },
+  research: {
+    // Research posts (kind: research 🔬 — things I want to investigate before deciding) auto-belong;
+    // any post can also opt in with `board: research`. Lifecycle: want-to → investigating → done.
+    kinds: ['research'],
+    columns: ['backlog', 'researching', 'learned'],
+  },
 };
 
 // Map a post's `stage` frontmatter to a board column. Accepts a few synonyms so authors
@@ -88,6 +94,13 @@ const STAGE_SYNONYMS = {
   wip: 'building',
   ship: 'shipped',
   shipped: 'shipped',
+  // research (backlog → researching → learned). `backlog` is shared with ideas; the columns
+  // researching/learned match directly. Friendly synonyms that don't collide with the above:
+  investigating: 'researching',
+  researching: 'researching',
+  learn: 'learned',
+  learnt: 'learned',
+  learned: 'learned',
 };
 
 function resolveColumn(board, stageRaw, kind) {

--- a/bytesofpurpose-blog/scripts/lib/blog-kinds.json
+++ b/bytesofpurpose-blog/scripts/lib/blog-kinds.json
@@ -55,6 +55,16 @@
         {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
       ]
     },
+    "research": {
+      "emoji": "🔬",
+      "description": "Something I want to research or learn before deciding: a systematic investigation I have not run yet (a /thoughts post, carded on the Research board). What must I find out to act on an idea?",
+      "thought": true,
+      "thoughtGloss": "Something I want to research before deciding",
+      "outline": [
+        {"id": "research-questions", "label": "the questions to investigate (what I need to find out, as a list or H2 sections)"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
     "principle": {
       "emoji": "🪞",
       "description": "An observation maturing into a rule I live by: 'I noticed X tends to happen' becoming 'so I now always Y'. The raw feeder that graduates UP into a durable /craft framework once it holds (a /thoughts post).",

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -104,6 +104,9 @@ const CHECKS = {
   'section-banner': (fm, body) => /<SectionBanner[\s>]/.test(body),
   // quote-set
   'quote-cards': (fm, body) => /<Quote[\s>]/.test(body),
+  // research: the questions to investigate (a list, a checklist, or H2/H3 question sections)
+  'research-questions': (fm, body) =>
+    /^\s*[-*]\s+\S/m.test(body) || /^\s*[-*]\s+\[[ xX]\]/m.test(body) || hasH2(body) || /\?/.test(body),
   // framework
   'framework-laid-out': (fm, body) =>
     /^\s*\d+\.\s+\S/m.test(body) ||

--- a/bytesofpurpose-blog/src/components/ThoughtKind/index.tsx
+++ b/bytesofpurpose-blog/src/components/ThoughtKind/index.tsx
@@ -31,7 +31,7 @@ const KINDS = (blogKinds as {kinds: Record<string, KindMeta>}).kinds;
 
 // Reading order per collection. A flagged kind not listed falls through to the end, so adding a
 // kind to the JSON surfaces it even before these lists are updated.
-const THOUGHT_ORDER = ['idea', 'simulation', 'prediction', 'critique', 'design-story'];
+const THOUGHT_ORDER = ['idea', 'research', 'simulation', 'prediction', 'critique', 'design-story'];
 const MINDSET_ORDER = ['question-set', 'quote-set', 'principle'];
 
 function kindsFor(flag: 'thought' | 'mindset', order: string[]): string[] {

--- a/bytesofpurpose-blog/thoughts/2021-09-07-learning-software.md
+++ b/bytesofpurpose-blog/thoughts/2021-09-07-learning-software.md
@@ -1,15 +1,24 @@
 ---
-slug: /product-management/research/learning-software
-title: '🔬 Learning Software'
-description: 'Learning goals and resources for software development best practices, architecture, and scaling.'
+slug: learning-software
+title: '🔬 What Should I Learn About Software?'
+sidebar_label: '🔬 Learning software'
+description: 'A research thought I am weighing: what should I learn about software development best practices, architecture, and scaling?'
 authors: [oeid]
-tags: [software-development, architecture, best-practices, learning, scaling]
+tags: [software-development, architecture, best-practices, research, scaling]
 date: 2021-09-07T10:00
+kind: research
+board: research
+stage: backlog
+priority: low
 draft: true
 ---
 
-# Learning Software
-- What general concepts can I learn about software?
+A research thought: **what should I learn about software** to level up on best practices,
+architecture, and scaling? These are the questions and resources I am gathering before I dig in.
+
+<!-- truncate -->
+
+## What general concepts can I learn about software?
 
 # Best Practices
 - [x] Print SDE thingy ... @done(2021-09-07T15:52:51-05:00)


### PR DESCRIPTION
Adds the **Research board**, mirroring the Ideas + Experiments pattern: the durable board lives in `/craft`, the temporal research posts live in `/thoughts`. A **research** is something I want to investigate or learn before deciding (an unactioned thought), not a phase of a defunct pipeline.

## What changed
- **New `research` thought-kind 🔬** in `blog-kinds.json` (`thought: true`) + its outline CHECK + the Start Here legend row (drift clean) + the `<ThoughtKindLegend>` order.
- **New `research` board** in `generate-kanban-data.js` (columns **backlog → researching → learned**; `kind: research` auto-belongs, or `board: research`).
- **Moved** the `learning-software` doc `/craft` → `/thoughts` as a research post (git mv): retitled to the question voice (*"What Should I Learn About Software?"*), `kind: research`. Stays draft; cards once un-drafted.
- **Rewrote** the `/craft/.../research` README into the durable **Research board page**: `<KanbanBoard board="research"/>` + column legend + the actioned framing, and **removed the stale pipeline** ("Development Progression", "second step in the development lifecycle" — the same defunct model #62 found) **while preserving the genuinely durable research framework** (what to research, plan structure, methods, checklist).
- `groom-initiatives` skill: added the research board row.

## Verification
The board **renders its 3 columns** (screenshot-checked: stale pipeline gone, framework intact); generate-kanban shows the research board; **validate-redirects 500/0**, validate-structure 0 errors, no outline drift, no em-dashes. **Content moved/reshaped, not lost.**

**Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)