### PR TITLE
Ideas board: per-idea cards + a 'first-time' classification badge

### DIFF
--- a/bytesofpurpose-blog/docusaurus.config.js
+++ b/bytesofpurpose-blog/docusaurus.config.js
@@ -588,6 +588,17 @@ const rehypePremiumEncrypt = require('./plugins/rehype-premium-encrypt');
             // the 5 still-draft idea posts get their redirects when they are un-drafted.)
             {from: "/docs/craft/product-management/ideas/hello-worlds", to: "/thoughts/hello-worlds"},
             {from: "/craft/product-management/ideas/hello-worlds", to: "/thoughts/hello-worlds"},
+            // The 4 "first-time" idea posts (my-first-* / tinker-*) were un-drafted (#59) so each is
+            // its own card on the Ideas board; now that they're published, their old /craft ideas
+            // doc URLs 301 to their /thoughts home.
+            {from: "/docs/craft/product-management/ideas/my-first-ios-app", to: "/thoughts/my-first-ios-app"},
+            {from: "/craft/product-management/ideas/my-first-ios-app", to: "/thoughts/my-first-ios-app"},
+            {from: "/docs/craft/product-management/ideas/my-first-mac-menubar-app", to: "/thoughts/my-first-mac-menubar-app"},
+            {from: "/craft/product-management/ideas/my-first-mac-menubar-app", to: "/thoughts/my-first-mac-menubar-app"},
+            {from: "/docs/craft/product-management/ideas/my-first-noteplan-plugin", to: "/thoughts/my-first-noteplan-plugin"},
+            {from: "/craft/product-management/ideas/my-first-noteplan-plugin", to: "/thoughts/my-first-noteplan-plugin"},
+            {from: "/docs/craft/product-management/ideas/tinker-browser-automation", to: "/thoughts/tinker-browser-automation"},
+            {from: "/craft/product-management/ideas/tinker-browser-automation", to: "/thoughts/tinker-browser-automation"},
             {from: "/initiatives/idea-track-script-usage", to: "/thoughts/idea-track-script-usage"},
             {from: "/blog/idea-track-script-usage", to: "/thoughts/idea-track-script-usage"},
             // "What I Ask Myself" (the question-set LEGEND post: the icon system + the practice)

--- a/bytesofpurpose-blog/scripts/generate-kanban-data.js
+++ b/bytesofpurpose-blog/scripts/generate-kanban-data.js
@@ -177,6 +177,10 @@ function build() {
           stage: resolveColumn(boardId, fm.stage, kind),
           priority: (fm.priority || 'medium').toString(),
           kind,
+          // Optional CLASSIFICATION of the card (a `class:` frontmatter field, e.g. `first-time`).
+          // A class groups a SUBSET of a board's cards by what kind of thing they are (e.g. the
+          // "first-time / new things" ideas) without being a card itself. Rendered as a badge.
+          class: fm.class ? fm.class.toString() : '',
           date: isoDate(fm.date),
         });
       }

--- a/bytesofpurpose-blog/src/components/KanbanBoard/KanbanBoard.module.css
+++ b/bytesofpurpose-blog/src/components/KanbanBoard/KanbanBoard.module.css
@@ -160,6 +160,19 @@
   color: var(--ifm-color-emphasis-600);
 }
 
+/* Classification badge (e.g. "🌱 First-time") — a subset grouping, tea-party mint like the
+   tag pills + ThoughtKind badges. */
+.classBadge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  background: var(--tea-mint, var(--ifm-color-emphasis-200));
+  color: var(--tea-ink, var(--ifm-color-emphasis-900));
+}
+
 /* Pills (priority + column badge) */
 .pill {
   display: inline-flex;

--- a/bytesofpurpose-blog/src/components/KanbanBoard/index.tsx
+++ b/bytesofpurpose-blog/src/components/KanbanBoard/index.tsx
@@ -63,6 +63,16 @@ const PRIORITY_LABEL: Record<string, string> = {
   low: 'Low',
 };
 
+// Card CLASSIFICATION → {emoji, label} for the class badge. A class groups a subset of a board's
+// cards by what KIND of thing they are (e.g. the "first-time / new things" ideas), without being a
+// card itself. An unknown class falls back to its raw value, title-cased.
+const CLASS_META: Record<string, {emoji: string; label: string}> = {
+  'first-time': {emoji: '🌱', label: 'First-time'},
+};
+function classMeta(cls: string): {emoji: string; label: string} {
+  return CLASS_META[cls] || {emoji: '', label: cls.charAt(0).toUpperCase() + cls.slice(1).replace(/-/g, ' ')};
+}
+
 const DATA = kanbanData as KanbanData;
 
 /* ── Card → modal CustomEvent (mirrors Question's openQuestionModal) ──────── */
@@ -125,6 +135,14 @@ function Card({card, columnLabel}: CardProps): React.JSX.Element {
       </span>
       {card.summary && <span className={styles.cardSummary}>{card.summary}</span>}
       <span className={styles.cardMeta}>
+        {card.class && (
+          <span className={styles.classBadge}>
+            {classMeta(card.class).emoji && (
+              <span aria-hidden="true">{classMeta(card.class).emoji} </span>
+            )}
+            {classMeta(card.class).label}
+          </span>
+        )}
         {card.priority && (
           <span className={clsx(styles.pill, styles[`priority_${card.priority}`])}>
             {priorityLabel}

--- a/bytesofpurpose-blog/src/components/KanbanBoard/types.ts
+++ b/bytesofpurpose-blog/src/components/KanbanBoard/types.ts
@@ -19,6 +19,8 @@ export interface KanbanCard {
   priority: string;
   /** The post kind (experiment-plan, experiment-result, …) — drives the kind emoji. */
   kind: string;
+  /** Optional classification grouping a subset of a board's cards (e.g. 'first-time'). Badge. */
+  class?: string;
   /** YYYY-MM-DD (may be empty). */
   date: string;
 }

--- a/bytesofpurpose-blog/thoughts/2022-01-16-hello-worlds.mdx
+++ b/bytesofpurpose-blog/thoughts/2022-01-16-hello-worlds.mdx
@@ -1,29 +1,29 @@
 ---
 slug: hello-worlds
-title: '💡 Hello Worlds'
-description: 'A collection of "my first" hello world examples for different technologies - learning-focused tinkering projects.'
+title: '💡 Hello Worlds: My First-Time Ideas'
+sidebar_label: '💡 Hello Worlds'
+description: 'A classification of a subset of my ideas: the "first-time" ones, about doing something for the first time or trying a new technology.'
 authors: [oeid]
-tags: [hello-world, tinkering, learning, first-steps, exploration]
+tags: [hello-world, first-time, learning, exploration]
 date: 2022-01-16
 kind: reflection
-board: ideas
-stage: backlog
-priority: low
 draft: false
 ---
 
-A collection of "my first" hello world examples for different technologies I have wanted to try. These are learning-focused tinkering projects: ideas to explore a new technology hands-on, not yet acted on.
+"Hello Worlds" is not an idea; it is a **classification** of a subset of my ideas: the ones about
+doing something for the **first time**, or trying a new technology hands-on. Each is its own
+**first-time** 🌱 card on the [Ideas board](/craft/product-management/ideas); this page is what that
+class means and where they are listed.
 
 <!-- truncate -->
 
-## What You'll Find Here
+## What makes an idea a "Hello World"
 
-- First-time implementations of various technologies
-- Learning experiences and discoveries
-- Hello world examples for different platforms and frameworks
-- Exploratory work to build understanding
+- It is about doing something for the FIRST time (my first iOS app, my first plugin).
+- It is exploratory: trying a new technology, framework, or platform to learn it hands-on.
+- It is unactioned: a thing I have wanted to try, not yet started.
 
-## The "my first" ideas
+## The first-time ideas
 
 - [Should I build my first iOS app?](/thoughts/my-first-ios-app)
 - [Should I build a Mac menu-bar app?](/thoughts/my-first-mac-menubar-app)

--- a/bytesofpurpose-blog/thoughts/2022-01-16-tinker-browser-automation.md
+++ b/bytesofpurpose-blog/thoughts/2022-01-16-tinker-browser-automation.md
@@ -7,10 +7,11 @@ authors: [oeid]
 tags: [browser-automation, automa, chrome-extension, automation, idea]
 date: 2022-01-16T10:00
 kind: idea
+class: first-time
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 A thought I keep coming back to: **should I tinker with browser-automation tools like Automa** to

--- a/bytesofpurpose-blog/thoughts/2025-01-01-my-first-ios-app.md
+++ b/bytesofpurpose-blog/thoughts/2025-01-01-my-first-ios-app.md
@@ -7,10 +7,11 @@ authors: [oeid]
 tags: [ios, swift, mobile, app-development, calendar, idea]
 date: 2025-01-01T10:00
 kind: idea
+class: first-time
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 A thought I keep coming back to: **should I build my first iOS app?** A calendar/dashboard I have

--- a/bytesofpurpose-blog/thoughts/2025-01-01-my-first-mac-menubar-app.md
+++ b/bytesofpurpose-blog/thoughts/2025-01-01-my-first-mac-menubar-app.md
@@ -7,10 +7,11 @@ authors: [oeid]
 tags: [macos, menu-bar, app, noteplan, swift, idea]
 date: 2025-01-01T10:00
 kind: idea
+class: first-time
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 A thought I keep coming back to: **should I build my first macOS menu-bar app?** One that shows my

--- a/bytesofpurpose-blog/thoughts/2025-03-02-my-first-noteplan-plugin.mdx
+++ b/bytesofpurpose-blog/thoughts/2025-03-02-my-first-noteplan-plugin.mdx
@@ -7,10 +7,11 @@ authors: [oeid]
 tags: [noteplan, plugin, note-taking, automation, templates, idea]
 date: 2025-03-02T10:00
 kind: idea
+class: first-time
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 A thought I keep coming back to: **should I build my first NotePlan plugin?** It would help with


### PR DESCRIPTION
*"Hello Worlds" is not an idea — it's a **classification** of a subset of ideas* (the ones about doing something for the first time / trying a new technology). So each first-time idea becomes its **own card** carrying a **"🌱 First-time"** badge, and the Hello Worlds index stops being a card.

## What changed
- **Card classification**: a `class:` frontmatter field (e.g. `class: first-time`), read onto the card by `generate-kanban-data.js` and rendered as a **tea-party-mint badge** by the KanbanBoard (`CLASS_META` map; unknown classes fall back to title-case). A class groups a subset of a board's cards without being a card itself.
- The **4 first-time ideas** (my-first-ios-app / mac-menubar-app / noteplan-plugin / tinker-browser-automation) get `class: first-time` and are **un-drafted** so each cards on the Ideas board (drafts don't card — they 404 in prod). Old `/craft` ideas URLs → `/thoughts`.
- The **hello-worlds index** drops `board: ideas` (stops being a card) and is reframed as the **classification page**: what makes an idea a "Hello World" + the list.

## Verification
**Screenshot-confirmed**: the Ideas board shows each first-time idea as its own card with a **"First-time" badge**, and Hello Worlds is **no longer a card** (5 cards, 4 badges, no collection card). generate-kanban (ideas=5); **validate-redirects 508/0**, naming validator clean, no em-dashes.

**Please review and merge when ready; I have not self-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)