### PR TITLE
test(showcases): e2e proof each /legend/components/* showcase renders + repoint stale graph specs (#71 phase 3)

### DIFF
--- a/.claude/skills/maintain-showcase/SKILL.md
+++ b/.claude/skills/maintain-showcase/SKILL.md
@@ -153,3 +153,4 @@ count. The JSON is gitignored, so the change you COMMIT is the `usage_pattern` e
 | `src/components/UsedIn/component-usage.json` | generated output (gitignored; never hand-edit) |
 | `scripts/lib/blog-kinds.json` | defines `kind: showcase` 🎛️ |
 | `scripts/validate-post-outline.js` | the `demonstrates` check for showcases |
+| `test/e2e/showcase-components.spec.ts` | the e2e proof: each showcase loads at its slug, `<UsedIn>` renders (populated + empty), the live demos render (mermaid svg / Card / TOCInline). In the `dev` Playwright project; run via `make test-e2e`. Add a row to its `SHOWCASES` list when you add a showcase. |

--- a/bytesofpurpose-blog/playwright.config.ts
+++ b/bytesofpurpose-blog/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
       // graph-* specs + the DebugMenu spec. The DebugMenu renders ONLY on the
       // dev server (localhost + non-prod build) — it's stripped from prod — so it
       // must run here against :3000, not the build-backed projects.
-      testMatch: /(graph-.*|debug-menu|draft-sidebar|blog-draft-badge|craft-self-split|navbar-auth|reconstruction-posts|co-design-imports)\.spec\.ts$/,
+      testMatch: /(graph-.*|debug-menu|draft-sidebar|blog-draft-badge|craft-self-split|navbar-auth|reconstruction-posts|co-design-imports|showcase-components)\.spec\.ts$/,
       use: { ...devices['Desktop Firefox'], baseURL: DEV_BASE },
     },
     {

--- a/bytesofpurpose-blog/test/e2e/README.md
+++ b/bytesofpurpose-blog/test/e2e/README.md
@@ -9,7 +9,7 @@ the GraphRenderer docs tests and the PostHog/A-B analytics tests. They have
 
 | Project | Specs | Server it talks to | Why |
 |---|---|---|---|
-| `dev` | `graph-*.spec.ts`, `debug-menu.spec.ts` | Docusaurus **dev** server (`yarn start`, :3000) — auto-started | render docs pages incl. hot/draft content; the DebugMenu renders ONLY on localhost+dev (stripped from prod), so it must run here |
+| `dev` | `graph-*.spec.ts`, `debug-menu.spec.ts`, `showcase-components.spec.ts` | Docusaurus **dev** server (`yarn start`, :3000) — auto-started | render docs pages incl. hot/draft content; the DebugMenu renders ONLY on localhost+dev (stripped from prod), so it must run here; the showcases include draft:true docs + a client-rendered `<UsedIn>` (needs a real browser) |
 | `prod` | `accessibility`, `seo` | a **production build** served on :4173 | build-only transforms (e.g. the task-list aria-label rehype plugin) DON'T run in `yarn start`, so these must scan a real build |
 | `posthog-prod` | `posthog-events`, `support-ab-test` | a **`POSTHOG_TEST_MODE=1` production build** served on :4173 | PostHog only inits in a prod build; its bot filter must be off for events to land |
 
@@ -56,6 +56,11 @@ PH_BASE_URL=http://localhost:4173 yarn playwright test --project=posthog-prod
 
 ## Test files
 
+- **`showcase-components.spec.ts`** — the component showcases under `/legend/components/*`
+  (the "🎛️ Components" reference): each showcase loads at its new slug (no 404/crash), its
+  `<UsedIn>` "Used in" block renders (both the populated-with-links and the honest-empty
+  paths), and the live demos render (mermaid → `<svg>`, Card markup, inline TOCInline) (dev).
+  Owned by the `maintain-showcase` skill.
 - **`debug-menu.spec.ts`** — the floating localhost-only DebugMenu: renders on
   localhost, lists the registered experiment, and toggling a variant actually
   flips the rendered `<Support/>` copy (control ↔ test) + clear-overrides reverts (dev)

--- a/bytesofpurpose-blog/test/e2e/graph-renderer.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/graph-renderer.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from '@playwright/test';
 test.describe('GraphRenderer E2E Tests', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the graph component page
-    const response = await page.goto('/craft/blogging/embed-structural-components/graph', {
+    const response = await page.goto('/legend/components/structural/graph', {
       waitUntil: 'domcontentloaded',
     });
     

--- a/bytesofpurpose-blog/test/e2e/graph-title-rendering.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/graph-title-rendering.spec.ts
@@ -19,7 +19,7 @@ import {
 test.describe('GraphRenderer Title Rendering E2E', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the graph component page
-    const response = await page.goto('/craft/blogging/embed-structural-components/graph', {
+    const response = await page.goto('/legend/components/structural/graph', {
       waitUntil: 'domcontentloaded',
     });
     

--- a/bytesofpurpose-blog/test/e2e/showcase-components.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/showcase-components.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Component-showcase rendering (dev project, :3000).
+ *
+ * The showcases under docs/legend/components/* are the site's component reference (the
+ * "🎛️ Components" section under Legend). Each is a `kind: showcase` doc that demonstrates ONE
+ * embeddable ability live AND carries an auto-generated "Used in" list (the <UsedIn> component,
+ * fed by generate-component-usage.js → component-usage.json).
+ *
+ * What this proves (Phase 3 of #71):
+ *   1. Each showcase URL loads (200, no React crash) at its NEW /legend/components/* slug
+ *      (the Phase-1 move; a regression here would mean a broken slug or a missing redirect).
+ *   2. The <UsedIn> "Used in" block renders on every showcase — with REAL post links where the
+ *      technique is used, and the honest empty line where it isn't (the two code paths).
+ *   3. The live DEMONSTRATION renders for the interactive ones (mermaid → an <svg>; Card → the
+ *      card markup; TOCInline → an inline table of contents) — not just prose.
+ *
+ * Runs against the dev server (:3000, drafts visible) because some showcases are draft:true and
+ * <UsedIn> renders client-side (needs a real browser, not the SSR shell).
+ */
+
+// Representative showcases across the four groups. `usedIn` says whether the generated index
+// has entries for this slug (so we assert the populated path) or not (the honest-empty path).
+// (Counts come from component-usage.json at authoring time; the assertion only checks
+// populated-vs-empty, not an exact count, so it stays robust as the corpus grows.)
+const SHOWCASES: Array<{ slug: string; label: string; usedIn: boolean }> = [
+  { slug: '/legend/components/structural/card', label: 'Card', usedIn: false },
+  { slug: '/legend/components/structural/details', label: 'Details', usedIn: true },
+  { slug: '/legend/components/structural/timeline', label: 'Timeline', usedIn: false },
+  { slug: '/legend/components/structural/table-of-content', label: 'Table of Contents', usedIn: false },
+  { slug: '/legend/components/structural/links', label: 'Linking Posts', usedIn: true },
+  { slug: '/legend/components/diagrams/diagrams-mermaid', label: 'Mermaid', usedIn: true },
+  { slug: '/legend/components/diagrams/diagrams-flow-charts', label: 'Flow Charts', usedIn: true },
+  { slug: '/legend/components/external/videos-youtube', label: 'YouTube', usedIn: true },
+  { slug: '/legend/components/code/code-gists', label: 'Gists', usedIn: false },
+];
+
+async function loadShowcase(page: Page, slug: string) {
+  const response = await page.goto(slug, { waitUntil: 'domcontentloaded' });
+  if (!response || response.status() !== 200) {
+    throw new Error(`Showcase ${slug} failed to load. Status: ${response?.status()}, URL: ${page.url()}`);
+  }
+  await page.waitForLoadState('networkidle');
+  // No React error boundary.
+  const crashed = await page.locator('text=This page crashed').isVisible().catch(() => false);
+  expect(crashed, `${slug} crashed (React error boundary)`).toBe(false);
+}
+
+// The <UsedIn> block: a labelled "Used in" region. Scope to the article so we don't match the
+// navbar/sidebar. The component renders a "Used in" heading then either a <ul> of links or the
+// empty line.
+function usedInBlock(page: Page) {
+  // styles.module.css → class `usedIn` (hashed at build, so match by the heading text instead).
+  return page.locator('main').getByText('Used in', { exact: true }).first();
+}
+
+test.describe('Component showcases (/legend/components/*)', () => {
+  for (const { slug, label, usedIn } of SHOWCASES) {
+    test(`${label}: loads + renders its "Used in" block`, async ({ page }) => {
+      await loadShowcase(page, slug);
+
+      // The doc body rendered (an <article>/main with content).
+      await expect(page.locator('main')).toBeVisible();
+
+      // The "Used in" block is present on every showcase.
+      const heading = usedInBlock(page);
+      await expect(heading, `${slug} is missing its <UsedIn> "Used in" block`).toBeVisible({ timeout: 10000 });
+
+      if (usedIn) {
+        // Populated path: at least one real post link under the block, and NOT the empty line.
+        const emptyLine = page.getByText('Not used in a published post yet.');
+        await expect(emptyLine, `${slug} should have usages but shows the empty line`).toHaveCount(0);
+        // The block's sibling list has at least one link.
+        const list = page.locator('main ul').filter({ has: page.locator('a') });
+        expect(await list.count(), `${slug} should render a non-empty used-in list`).toBeGreaterThan(0);
+      } else {
+        // Honest-empty path: the quiet "not used yet" line shows.
+        await expect(
+          page.getByText('Not used in a published post yet.'),
+          `${slug} has no usages and should show the honest empty line`,
+        ).toBeVisible();
+      }
+    });
+  }
+
+  test('Mermaid showcase renders a live diagram (an <svg>)', async ({ page }) => {
+    await loadShowcase(page, '/legend/components/diagrams/diagrams-mermaid');
+    // Docusaurus renders mermaid to an inline <svg> (class contains "mermaid").
+    const svg = page.locator('.docusaurus-mermaid-container svg, svg[id^="mermaid"], .mermaid svg').first();
+    await expect(svg, 'mermaid showcase should render an <svg> diagram').toBeVisible({ timeout: 15000 });
+  });
+
+  test('Card showcase renders the live card demo (not just prose)', async ({ page }) => {
+    await loadShowcase(page, '/legend/components/structural/card');
+    // The Card component renders avatar/card markup; the demo uses the "Docux Card component" text.
+    await expect(page.getByText('Docux Card component').first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Table of Contents showcase renders an inline TOC', async ({ page }) => {
+    await loadShowcase(page, '/legend/components/structural/table-of-content');
+    // <TOCInline> renders a nav/list of in-page anchors inside the article body.
+    const inlineToc = page.locator('main .table-of-contents, main nav ul a[href^="#"]').first();
+    await expect(inlineToc, 'TOCInline should render an in-body table of contents').toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## What & why

Phase 3 of #71 (final phase). Adds the e2e proof that the component showcases under `/legend/components/*` (the "🎛️ Components" reference, moved in #102, given a `<UsedIn>` index in #103) actually render and function.

## Changes

**New `test/e2e/showcase-components.spec.ts`** (dev project, :3000 — drafts visible, and `<UsedIn>` renders client-side so it needs a real browser). Across a representative set of showcases spanning all four groups:
- **Loads at the new slug** — each `/legend/components/*` URL returns 200 with no React crash (a regression here = a broken slug or missing redirect).
- **`<UsedIn>` renders on every showcase**, proving BOTH code paths:
  - the **populated** path — a non-empty list of real post links where the technique is used (`details`, `links`, `mermaid`, `flow-charts`, `videos-youtube`);
  - the **honest-empty** path — the quiet "Not used in a published post yet." line where it isn't (`card`, `timeline`, `table-of-content`, `code-gists`).
- **Live demos render** for the interactive ones: mermaid → an `<svg>`, the Card demo markup, an inline `TOCInline` table of contents (not just prose).

**Fixed a stale-slug regression from Phase 1:** `graph-renderer.spec.ts` and `graph-title-rendering.spec.ts` still navigated to the pre-move `/craft/blogging/embed-structural-components/graph`. Repointed both to `/legend/components/structural/graph` (the showcase's real slug) — they were silently hitting a redirect stub.

**Wiring + docs:** added `showcase-components` to the `dev` project's `testMatch` (so it runs under `make test-e2e` / `make test-regression`), documented it in the e2e README (spec list + project table), and pointed the `maintain-showcase` skill at it (add a `SHOWCASES` row when adding a showcase).

## Verification

```
showcase-components.spec.ts   12/12 passed (17.3s)
graph-renderer + graph-title  14 passed, 1 pre-existing skip (1.2m)  ← against the new slug
```

Completes #71 (Phase 1 #102, Phase 2 #103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)