### PR TITLE
feat(validate-redirects): detect redirect chains (a→b→c) + suggest collapsing to a→c

### DIFF
--- a/.claude/hooks/validate-redirects-hook.sh
+++ b/.claude/hooks/validate-redirects-hook.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # PostToolUse hook for Edit|Write on docusaurus.config.js: surface ERROR-tier redirect problems
-# (a redirect whose `to:` target is missing or draft would FAIL the prod build). Catches the
-# break in seconds instead of at the next slow build.
+# (a redirect whose `to:` target is missing, draft, OR itself redirected again — a chain a→b→c
+# Docusaurus won't follow — would FAIL the prod build). Catches the break in seconds instead of
+# at the next slow build.
 #
 # Exit 2 marks the edit as failed + feeds stderr back so the model self-corrects (fix the target
 # or drop the redirect). Warn-tier findings (dead/duplicate redirects) are left for the full
@@ -26,10 +27,11 @@ rc=$?
 
 if [ "$rc" -eq 2 ]; then
   {
-    echo "🔀 Redirect problem: a redirect target is MISSING or DRAFT (would fail the prod build)."
+    echo "🔀 Redirect problem (would fail the prod build): a redirect target is MISSING, DRAFT, or"
+    echo "   itself redirected again (a chain a→b→c — Docusaurus does not follow chains)."
     printf '%s\n' "$out" | grep -A1 "error:redirect-"
     echo ""
-    echo "Fix the target (a moved slug?) or drop the redirect. Full check:"
+    echo "Fix the target (a moved slug? collapse the chain to a→c?) or drop the redirect. Full check:"
     echo "  ( cd $proj && make validate-redirects )"
   } >&2
   exit 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,12 +236,17 @@ instance routeBasePath) — keep it in lockstep if the instance layout changes.
 **Redirects are validated:** `scripts/validate-redirects.js` (`make validate-redirects`) reads
 the real redirects array from `docusaurus.config.js` and cross-checks every `to:` against the
 published-URL set (honoring `draft:`), catching the build-breakers — a redirect `to:` a missing
-or **draft** target (both ERROR-tier, would fail the prod build), a `from:` that shadows a real
-page, or a duplicate `from:` — in seconds instead of at the next full build. The PostToolUse
-hook `.claude/hooks/validate-redirects-hook.sh` (registered in `.claude/settings.json`) blocks an
-edit to `docusaurus.config.js` that introduces an ERROR-tier redirect. When you MOVE a page, you
-must also **repoint any existing redirect whose `to:` pointed at the old slug** (not just add a
-new `from`→new redirect) — the validator/hook now catches the ones you'd otherwise miss.
+or **draft** target, or a **chain** `a→b→c` (a `to:` that is itself redirected again, including
+through the programmatic `createRedirects` wildcards: Docusaurus does NOT follow chains, so `a→b`
+lands on a redirect stub = 404; the finding suggests the collapse `a→c`) — all three ERROR-tier,
+would fail the prod build — plus a `from:` that shadows a real page or a duplicate `from:` (warn),
+in seconds instead of at the next full build. The PostToolUse hook
+`.claude/hooks/validate-redirects-hook.sh` (registered in `.claude/settings.json`) blocks an edit
+to `docusaurus.config.js` that introduces an ERROR-tier redirect. When you MOVE a page, you must
+also **repoint any existing redirect whose `to:` pointed at the old slug** (not just add a new
+`from`→new redirect), and **collapse any chain** the move creates — the validator/hook now catches
+both. The chain check knows the wildcard prefix-rewrites (`WILDCARD_REWRITES` in the validator);
+keep that list in lockstep with `createRedirects` in `docusaurus.config.js`.
 into **domain sub-topics** (e.g. `Software Development` → `backend-development/`,
 `frontend-development/`, `scripting/`, `plugins/`, each with `research/projects/
 techniques/tinkering/`); the idea→ship LIFECYCLE is the separate `Product Management`

--- a/bytesofpurpose-blog/scripts/validate-redirects.js
+++ b/bytesofpurpose-blog/scripts/validate-redirects.js
@@ -14,6 +14,9 @@
  *                     doesn't exist, or its slug differs). [ERROR — this fails the prod build]
  *   - to-draft        a redirect `to:` a DRAFT page (excluded from prod → invalid prod build).
  *                     [ERROR]
+ *   - to-chain        a redirect `to:` (b) that is itself the `from:` of ANOTHER redirect (b→c),
+ *                     i.e. a chain a→b→c. Docusaurus does NOT follow chains: a→b lands on b, which
+ *                     is a redirect stub (a 404), not transitively on c. Collapse it to a→c. [ERROR]
  *   - from-collision  a redirect `from:` that equals a real published URL (the redirect shadows
  *                     a real page; the page wins, the redirect is dead). [warn]
  *   - from-duplicate  the same `from:` appears in more than one redirect. [warn]
@@ -22,7 +25,7 @@
  * the homepage, /404) are whitelisted so they don't false-positive.
  *
  * Usage:  node scripts/validate-redirects.js [--json]
- * Exit:   2 if any ERROR-tier finding (to-missing / to-draft); else 0 (warns don't block).
+ * Exit:   2 if any ERROR-tier finding (to-missing / to-draft / to-chain); else 0 (warns don't block).
  */
 
 const fs = require('fs');
@@ -159,6 +162,27 @@ function loadRedirects() {
   return cr && Array.isArray(cr[1].redirects) ? cr[1].redirects : [];
 }
 
+// The PREFIX-WILDCARD redirects emitted programmatically by the client-redirects plugin's
+// createRedirects(): every built /<routeBasePath>/* page also serves from its old prefix. These
+// are NOT in the explicit `redirects` array, so chain detection (below) needs to know them too —
+// an explicit redirect whose `to:` lands on one of these OLD prefixes would chain through it and
+// 404. Keep this list in lockstep with createRedirects() in docusaurus.config.js (the same
+// hand-maintained-list discipline as DOCS_INSTANCES above).
+const WILDCARD_REWRITES = [
+  {oldPrefix: '/self', newPrefix: '/journey'}, // /self/*   -> /journey/*
+  {oldPrefix: '/blog', newPrefix: '/initiatives'}, // /blog/*  -> /initiatives/*
+  {oldPrefix: '/legend', newPrefix: '/handbook'}, // /legend/* -> /handbook/* (the 2026-06 rename)
+];
+// If `to` falls under a wildcard's OLD prefix, it's redirected again to the NEW prefix (a chain).
+function wildcardTargetOf(to) {
+  for (const {oldPrefix, newPrefix} of WILDCARD_REWRITES) {
+    if (to === oldPrefix || to.startsWith(oldPrefix + '/')) {
+      return newPrefix + to.slice(oldPrefix.length);
+    }
+  }
+  return null;
+}
+
 // ── 3. Validate ────────────────────────────────────────────────────────────
 function main() {
   const json = process.argv.includes('--json');
@@ -173,13 +197,42 @@ function main() {
   // So the `to:` set is validated against published pages ONLY; do not treat a `from:` as a valid
   // target (that false-negative once shipped a build-breaking redirect to a moved-away slug).
 
+  // from → to map, for chain detection (a→b→c). Keep the FINAL target of each `from` so the
+  // suggested collapse points at the chain's end. (A duplicate `from` is itself flagged below;
+  // for chain purposes the last one wins, which matches "follow the chain to its end".)
+  const fromMap = new Map(redirects.map((r) => [norm(r.from), norm(r.to)]));
+  // One hop from `cur`: an explicit redirect's `from`, OR a programmatic wildcard old-prefix.
+  const nextHop = (cur) => (fromMap.has(cur) ? fromMap.get(cur) : wildcardTargetOf(cur));
+  // Resolve a path through the redirect chain to its terminal target (the page a→b→…→z lands on
+  // if chains DID transit). Bounded + cycle-guarded so a redirect loop can't spin forever.
+  const resolveChainEnd = (start) => {
+    const seen = new Set();
+    let cur = start;
+    let next;
+    while ((next = nextHop(cur)) && !seen.has(cur)) {
+      seen.add(cur);
+      cur = next;
+    }
+    return cur;
+  };
+
   for (const {from, to} of redirects) {
     const nFrom = norm(from);
     const nTo = norm(to);
     froms.set(nFrom, (froms.get(nFrom) || 0) + 1);
 
-    // to-missing / to-draft: the target must be a published page (or a whitelisted dynamic route).
-    if (!isWhitelisted(nTo, published)) {
+    // to-chain: the target (b) is redirected AGAIN — either it's another redirect's explicit
+    // `from:` (b→c), or it falls under a programmatic wildcard old-prefix (e.g. /legend/* that
+    // the rename's createRedirects sends to /handbook/*). Either way it's a chain a→b→c, and
+    // Docusaurus does NOT follow chains: a→b lands on b (a redirect stub = 404), not on c. Report
+    // it with the collapse suggestion (a→<chain end>). Checked before to-missing so the message is
+    // the actionable one (collapse the chain), not the generic "target missing".
+    const chainsAgain = nTo !== nFrom && (fromMap.has(nTo) || wildcardTargetOf(nTo));
+    if (chainsAgain) {
+      const end = resolveChainEnd(nTo);
+      findings.push({tier: 'error', id: 'to-chain', from, to, detail: `redirect target ${to} is itself redirected again (a chain ${nFrom} → ${nTo} → …). Docusaurus does not follow chains, so this lands on a redirect stub (a 404), not the chain's end. Collapse it: point ${from} directly to ${end}.`});
+    } else if (!isWhitelisted(nTo, published)) {
+      // to-missing / to-draft: the target must be a published page (or a whitelisted dynamic route).
       if (draft.has(nTo)) {
         findings.push({tier: 'error', id: 'to-draft', from, to, detail: `redirect target ${to} is a DRAFT page (excluded from the prod build → invalid). Publish it or drop the redirect.`});
       } else {


### PR DESCRIPTION
## What & why

Docusaurus does **not** follow redirect chains. If `a→b` and `b→c` both exist, `a→b` lands on `b`'s redirect *stub* (a 404), not transitively on `c`. This is the failure class hit **twice** recently, the `hello-worlds` build-break and the `/legend → /handbook` rename, so this teaches `validate-redirects.js` to catch it BEFORE the slow build does.

(Your request: "if a→b and b→c, rewrite that so it's a→c directly.")

## Changes

- **New `to-chain` ERROR-tier finding**: a redirect whose `to:` (`b`) is itself redirected again, either as another redirect's explicit `from:` OR through a programmatic `createRedirects` wildcard. The finding resolves the chain to its end and suggests the collapse: *"point `a` directly to `c`"*.
- **`WILDCARD_REWRITES`** teaches the detector the prefix-rewrites `createRedirects()` emits (`/self→/journey`, `/blog→/initiatives`, `/legend→/handbook`) — the validator otherwise only sees the explicit `redirects` array, so an explicit `to: /legend/X` chaining through the rename wildcard would slip past. Kept in lockstep with `createRedirects` (documented in CLAUDE.md).
- Chain resolution is **cycle-guarded** (a redirect loop can't spin forever).
- The PostToolUse hook already blocks on ERROR-tier, so it picks up `to-chain` automatically; updated its message + header to name the chain case.

## Verification (prove-don't-assert)

| Case | Result |
|---|---|
| Current config (no chains) | ✅ clean, 536 checked, 0 findings |
| Planted **explicit** chain `a→b→c` | `[error:redirect-to-chain]`, suggests collapse to `c` |
| Planted **wildcard** chain (`a→/legend/X`) | `[error:redirect-to-chain]`, resolves through the `/legend→/handbook` wildcard to `/handbook/X` |
| Hook end-to-end on a planted chain | exits **2** (blocks the edit) with the collapse message |

Example output:
```
[error:redirect-to-chain]  /wildcard-chain-test → /legend/glossary
    ↳ ... a chain /wildcard-chain-test → /legend/glossary → ... Docusaurus does not follow
      chains ... Collapse it: point /wildcard-chain-test directly to /handbook/glossary.
```

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)