### PR TITLE
Un-draft the 12 concrete idea posts (now live on the Ideas board)

### DIFF
--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-alias-finder.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-alias-finder.md
@@ -2,7 +2,7 @@
 slug: idea-alias-finder
 title: 'Should I Build an Alias Finder for My Commands?'
 sidebar_label: 'Alias finder?'
-description: 'A tool that scans all my commands and proposes sensible two-letter acronym aliases, so the helpers I reach for most get short names without me inventing them by hand.'
+description: 'A tool that scans all my commands and proposes sensible two-letter acronym aliases, so the helpers I reach for most get short names without me inventing them.'
 authors: [oeid]
 tags: [ideas, scripting, automation, shell, tooling]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 I have more commands than I have short names for. Inventing aliases by hand is haphazard, so the

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-ambient-metric-displays.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-ambient-metric-displays.md
@@ -2,7 +2,7 @@
 slug: idea-ambient-metric-displays
 title: 'Should I Build Ambient Personal-Metric Displays?'
 sidebar_label: 'Metric displays?'
-description: 'Surface a personal metric where I will actually glance at it: a LaMetric motivator app on the desk display and a NotePlan menu-bar app showing the day''s metrics at a glance.'
+description: 'Surface a personal metric where I will actually glance at it: a LaMetric motivator on the desk display and a NotePlan menu-bar app showing the day''s metrics.'
 authors: [oeid]
 tags: [ideas, app, lametric, noteplan, self-quantifying]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 A metric I have to open an app to see is a metric I forget. I want the numbers I care about to

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-fast-cross-linking.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-fast-cross-linking.md
@@ -2,7 +2,7 @@
 slug: idea-fast-cross-linking
 title: 'Should I Make Cross-Linking Between My Notes Faster?'
 sidebar_label: 'Cross-linking?'
-description: 'Lower the friction of linking notes together: variable-driven glue links wired into iA Writer, a copy-all-locations helper feeding pbcopy, and auto-inserted VS Code headers in NotePlan files.'
+description: 'Lower the friction of linking notes: variable-driven glue links in iA Writer, a copy-all-locations helper feeding pbcopy, and auto VS Code headers in NotePlan.'
 authors: [oeid]
 tags: [ideas, scripting, automation, notes, knowledge-base]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 The thing that stops me cross-linking notes is friction: hunting for the right path, copying it,

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-instagram-metadata-scraper.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-instagram-metadata-scraper.md
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 There is metadata on Instagram posts I would like to work with programmatically, and no clean

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-port-portfolio-to-react.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-port-portfolio-to-react.md
@@ -2,7 +2,7 @@
 slug: idea-port-portfolio-to-react
 title: 'Should I Port My Portfolio to React?'
 sidebar_label: 'Portfolio to React?'
-description: 'A captured idea, since actioned: port my portfolio site over to React. Tracked here as a shipped idea on the board so the backlog reflects what actually got done.'
+description: 'A captured idea, since actioned: port my portfolio site to React. Tracked as a shipped idea on the board so the backlog reflects what actually got done.'
 authors: [oeid]
 tags: [ideas, react, frontend, portfolio, web]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: shipped
 priority: low
-draft: true
+draft: false
 ---
 
 A backlog line that I went on to act on: porting my portfolio over to React. It is here as a

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-portable-scripts.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-portable-scripts.md
@@ -2,7 +2,7 @@
 slug: idea-portable-scripts
 title: 'Should I Make My Scripts Portable Across Machines?'
 sidebar_label: 'Portable scripts?'
-description: 'Package my own reusable scripts so a brew install brings them along on any machine, and keep work tasks continuously backed up on a schedule so nothing local-only is ever lost.'
+description: 'Package my reusable scripts so a brew install brings them to any machine, and keep work tasks backed up on a schedule so nothing local-only is ever lost.'
 authors: [oeid]
 tags: [ideas, scripting, automation, backup, tooling]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 My useful helpers live on one machine. Every new laptop means re-collecting them by hand, and

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-shell-completion-system.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-shell-completion-system.md
@@ -2,7 +2,7 @@
 slug: idea-shell-completion-system
 title: 'Should I Build a Self-Describing Shell-Completion System?'
 sidebar_label: 'Shell completion?'
-description: 'One generic completion mechanism every command opts into: run it with --options and it returns its own flags, generated straight from the command''s own bash case statement.'
+description: 'One generic completion mechanism every command opts into: run it with --options and it returns its own flags, generated from its own bash case statement.'
 authors: [oeid]
 tags: [ideas, scripting, automation, shell, tooling]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 One completion mechanism, shared by every command I write, instead of hand-maintaining a

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-slack-to-markdown.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-slack-to-markdown.md
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 Good discussions happen in Slack threads, and I want to keep them in my notes. Pasting a thread

--- a/bytesofpurpose-blog/thoughts/2022-04-13-idea-stale-notes-detector.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-13-idea-stale-notes-detector.md
@@ -2,7 +2,7 @@
 slug: idea-stale-notes-detector
 title: 'Should I Build a Stale-Notes & Bad-Link Detector?'
 sidebar_label: 'Notes health check?'
-description: 'A regular health check over my personal book: surface stale areas by recent-edit count and catch broken links before they rot, both built on a working multi-directory find prune.'
+description: 'A regular health check over my personal book: surface stale areas by recent-edit count and catch broken links before they rot, on a multi-directory find prune.'
 authors: [oeid]
 tags: [ideas, scripting, automation, notes, knowledge-base]
 date: 2022-04-13
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 My personal book grows faster than I curate it. I want it to tell me where it is rotting

--- a/bytesofpurpose-blog/thoughts/2022-04-18-idea-bookmark-portability.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-18-idea-bookmark-portability.md
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 Switching browsers always strands my bookmarks. The export/import is doable through the UI, but

--- a/bytesofpurpose-blog/thoughts/2022-04-27-idea-other-work-streams.md
+++ b/bytesofpurpose-blog/thoughts/2022-04-27-idea-other-work-streams.md
@@ -2,7 +2,7 @@
 slug: idea-other-work-streams
 title: 'Should I Auto-Surface My Other Work Streams?'
 sidebar_label: 'Work streams?'
-description: 'Auto-generate an "other work streams" file from every note carrying a "today" tag, so the threads I am actively working stay visible in one place instead of scattered across notes.'
+description: 'Auto-generate an "other work streams" file from every note carrying a "today" tag, so my active threads stay visible in one place instead of scattered.'
 authors: [oeid]
 tags: [ideas, scripting, automation, notes, productivity]
 date: 2022-04-27
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 My active work is scattered across whatever notes I happened to be in. I want a single view of

--- a/bytesofpurpose-blog/thoughts/2022-07-08-idea-smarter-date-helpers.md
+++ b/bytesofpurpose-blog/thoughts/2022-07-08-idea-smarter-date-helpers.md
@@ -2,7 +2,7 @@
 slug: idea-smarter-date-helpers
 title: 'Should I Build Smarter Date-Tag Helpers?'
 sidebar_label: 'Date helpers?'
-description: 'Upgrade the date-tag tooling: a non-recursive "today" substituter, a "next workday" mode, a "next weekend" tag, and a cron that auto-stamps new ideas with their capture date.'
+description: 'Upgrade the date-tag tooling: a non-recursive "today" substituter, "next workday" and "next weekend" tags, and a cron that auto-stamps ideas with capture dates.'
 authors: [oeid]
 tags: [ideas, scripting, automation, dates, tooling]
 date: 2022-07-08
@@ -10,7 +10,7 @@ kind: idea
 board: ideas
 stage: backlog
 priority: low
-draft: true
+draft: false
 ---
 
 My auto-expanding date tags (`>2022-01-12` and friends) work, but the substituter is naive. A


### PR DESCRIPTION
## What & why

Publishes the 12 single-idea posts split out of the tooling-ideas backlog in #112 — flips `draft: true` → `false` so they go live and **card on the Ideas board** (board grows 5 → 17 cards, each with its theme tags).

## No redirects needed
Unlike *moved* posts, these are **brand-new slugs** with no prior URL — nothing points at them, so there's no redirect to add and no chain to collapse. (`validate-redirects` confirms: published-URL count grew 257 → 269, no `from:` shadows them.)

## Also: tightened descriptions
Un-drafting put these in the published SEO corpus, which surfaced 9 descriptions >160 chars (they'd truncate in search/social cards). Trimmed all 9 to ≤160 while preserving meaning. All 12 now pass `validate-seo`.

## Safety
- All 12 are **plain `.md` with no JSX** — zero MDX compile risk.
- Each is a finished, matured idea (motivation / value / scope / plan / success criteria), not a stub.

Validators pass: `validate-redirects`, `validate-idea-tags` (49/49), `validate-naming` (right voice), `validate-seo` (all 12 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)