### PR TITLE
Reconcile Bytes of Purpose Design System into the repo (tokens + brand-consistency fixes)

### DIFF
--- a/bytesofpurpose-blog/src/components/Carousel/styles.module.css
+++ b/bytesofpurpose-blog/src/components/Carousel/styles.module.css
@@ -59,7 +59,7 @@
 
 .cardLink:hover {
   border-color: var(--ifm-color-primary);
-  transform: translateY(-2px);
+  transform: var(--lift-subtle);
   box-shadow: var(--ifm-global-shadow-lw);
   text-decoration: none;
   color: inherit;

--- a/bytesofpurpose-blog/src/components/Changelog/Changelog.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/Changelog.module.css
@@ -25,7 +25,7 @@
 
 .entryCard:hover {
   box-shadow: var(--ifm-global-shadow-md);
-  transform: translateY(-2px);
+  transform: var(--lift-subtle);
 }
 
 .entryHeader {

--- a/bytesofpurpose-blog/src/components/Changelog/QuarterSection/QuarterSection.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/QuarterSection/QuarterSection.module.css
@@ -216,7 +216,7 @@
 
 .entryCard:hover {
   box-shadow: var(--ifm-global-shadow-md);
-  transform: translateY(-2px);
+  transform: var(--lift-subtle);
 }
 
 /* Mobile: Minimal, horizontally wide rectangular cards */

--- a/bytesofpurpose-blog/src/components/HomepageFeatures/HomepageFeatures.module.css
+++ b/bytesofpurpose-blog/src/components/HomepageFeatures/HomepageFeatures.module.css
@@ -37,7 +37,7 @@
 .featureCard:hover {
   text-decoration: none;
   color: inherit;
-  transform: translateY(-4px);
+  transform: var(--lift-card);
   box-shadow: var(--ifm-global-shadow-md);
   border-color: var(--ifm-color-primary-lighter);
 }

--- a/bytesofpurpose-blog/src/components/LatestPosts/LatestPosts.module.css
+++ b/bytesofpurpose-blog/src/components/LatestPosts/LatestPosts.module.css
@@ -41,7 +41,7 @@
 .postCard:hover {
   text-decoration: none;
   color: inherit;
-  transform: translateY(-4px);
+  transform: var(--lift-card);
   box-shadow: var(--ifm-global-shadow-md);
   border-color: var(--ifm-color-primary-lighter);
 }

--- a/bytesofpurpose-blog/src/components/SvgVariantGrid/styles.module.css
+++ b/bytesofpurpose-blog/src/components/SvgVariantGrid/styles.module.css
@@ -14,7 +14,7 @@
 .colonnade {
   position: relative;
   padding: 120px 14px;                /* tall: pillars run well above & below the cards */
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: linear-gradient(180deg,
     color-mix(in srgb, var(--ifm-color-primary) 8%, var(--svg-bg)),

--- a/bytesofpurpose-blog/src/css/FancyButton.module.css
+++ b/bytesofpurpose-blog/src/css/FancyButton.module.css
@@ -3,8 +3,6 @@
  * https://codepen.io/merkund/pen/EGpOEr
 **/
 
-@import url("https://fonts.googleapis.com/css?family=Raleway:500");
-
 .FancyButton {
   -webkit-appearance: none;
   background: -webkit-gradient(to right, #a2ccb6 0%, #fceeb5 50%, #ee786e 100%);
@@ -15,7 +13,7 @@
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
   color: #fff;
   cursor: pointer;
-  font: 1.5em Raleway, sans-serif;
+  font: 1.5em var(--font-sans-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   height: 5rem;

--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -85,6 +85,100 @@
     rgba(212, 175, 55, 0.1),
     rgba(184, 134, 11, 0.05)
   );
+
+  /* ========================================================================
+     Named design-system token layer (reconciled from the "Bytes of Purpose
+     Design System" on claude.ai/design). The raw VALUES already matched what
+     the repo shipped inline; this block gives them the DS's documented names so
+     repo CSS speaks the same vocabulary. Aliases reuse existing Infima tokens
+     rather than duplicating values, so there is a single source of truth.
+     ======================================================================== */
+
+  /* Semantic color aliases */
+  --bop-divider: rgba(26, 26, 26, 0.1);
+  --text-body: var(--ifm-font-color-base);
+  --text-heading: var(--ifm-heading-color);
+  --text-secondary: var(--ifm-color-content-secondary);
+  --text-link: var(--ifm-color-primary);
+  --surface-page: var(--ifm-background-color);
+  --surface-card: var(--ifm-card-background-color);
+  --accent-tint: var(--ifm-color-primary-contrast-background);
+
+  /* Spacing scale (soft 4px base) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 2.5rem;
+  --space-8: 3.5rem;
+  --space-9: 5rem;
+
+  /* Radii (--ifm-global-radius / --ifm-button-border-radius defined above) */
+  --radius-sm: 0.4rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 14px; /* hero / card corner */
+  --radius-pill: 3em;
+  --radius-full: 9999px;
+
+  /* Type families (alias the Infima families set above) */
+  --font-serif-display: var(--ifm-heading-font-family);
+  --font-sans-body: var(--ifm-font-family-base);
+  --font-mono: var(--ifm-font-family-monospace);
+
+  /* Display / heading scale (Fraunces) */
+  --text-display: 4rem;
+  --text-h1: 2.75rem;
+  --text-h2: 2rem;
+  --text-h3: 1.5rem;
+  --text-h4: 1.3rem;
+  --text-h5: 1.1rem;
+  --text-h6: 1rem;
+
+  /* Body / UI scale (Geist) */
+  --text-lead: 1.5rem;
+  --text-body-lg: 1.125rem;
+  --text-body-md: 1rem;
+  --text-body-sm: 0.95rem;
+  --text-caption: 0.85rem;
+  --text-eyebrow: 0.8rem;
+
+  /* Weights */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  /* Tracking */
+  --tracking-tight: -0.01em;
+  --tracking-heading: -0.005em;
+  --tracking-normal: 0;
+  --tracking-eyebrow: 0.18em;
+
+  /* Line heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.25;
+  --leading-body: 1.7;
+  --leading-tight: 1.45;
+
+  /* Borders (hairline tracks the repo's existing emphasis-200 color) */
+  --border-hairline: 1px solid var(--ifm-color-emphasis-200);
+  --border-accent: 2px solid var(--ifm-color-primary);
+
+  /* Elevation — ALIAS the Infima shadows above, do not duplicate */
+  --shadow-sm: var(--ifm-global-shadow-lw);
+  --shadow-md: var(--ifm-global-shadow-md);
+  --shadow-arch: drop-shadow(0 6px 16px rgba(26, 26, 26, 0.18));
+
+  /* Motion */
+  --ease-standard: ease;
+  --ease-out: cubic-bezier(0.2, 0.7, 0.3, 1);
+  --duration-fast: 0.12s;
+  --duration-base: 0.18s;
+  --duration-slow: 0.2s;
+  --lift-card: translateY(-4px); /* hero/feature card hover */
+  --lift-subtle: translateY(-2px); /* list/article hover */
 }
 
 /* Dark mode: lift the primary so links/buttons keep AA contrast on dark
@@ -135,6 +229,12 @@ html[data-theme='dark'] {
     rgba(212, 175, 55, 0.14),
     rgba(184, 134, 11, 0.06)
   );
+
+  /* Named DS token layer — dark overrides. Only tokens whose value differs in
+     dark are listed; the rest inherit through var() indirection. (--shadow-md
+     re-aliases the dark Infima shadow set above at this block's top.) */
+  --bop-divider: rgba(255, 255, 255, 0.12);
+  --shadow-md: var(--ifm-global-shadow-md);
 }
 
 /* Headings use Fraunces (the editorial display serif). Apply it explicitly so it
@@ -167,7 +267,8 @@ h6 {
   font-size: 0.9rem;
   line-height: 1.2;
   text-decoration: none;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  transition: background-color var(--duration-slow) ease,
+    transform var(--duration-slow) ease;
 }
 
 .navbar-coffee:hover {
@@ -303,12 +404,13 @@ html:not([data-theme='dark']) .token.literal-property.property {
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: var(--ifm-global-radius);
   background: var(--ifm-card-background-color);
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: box-shadow var(--duration-slow) ease,
+    transform var(--duration-slow) ease;
 }
 
 .blog-list-page article:hover {
   box-shadow: var(--ifm-global-shadow-md);
-  transform: translateY(-2px);
+  transform: var(--lift-subtle);
 }
 
 .blog-list-page article header h2 {

--- a/bytesofpurpose-blog/src/pages/changelog.module.css
+++ b/bytesofpurpose-blog/src/pages/changelog.module.css
@@ -25,7 +25,7 @@
 
 .entryCard:hover {
   box-shadow: var(--ifm-global-shadow-md);
-  transform: translateY(-2px);
+  transform: var(--lift-subtle);
 }
 
 .entryHeader {

--- a/bytesofpurpose-blog/src/pages/index.module.css
+++ b/bytesofpurpose-blog/src/pages/index.module.css
@@ -1213,7 +1213,7 @@
   width: 300px;
   text-align: center;
   padding: 1.5rem 1.5rem 1.6rem;
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: var(--ifm-card-background-color);
   border: 1px solid var(--ifm-color-emphasis-200);
   color: var(--ifm-font-color-base);
@@ -1224,7 +1224,7 @@
 
 .chooserCard:hover {
   border-color: var(--ifm-color-primary);
-  transform: translateY(-4px);
+  transform: var(--lift-card);
   box-shadow: var(--ifm-global-shadow-md);
   text-decoration: none;
   color: var(--ifm-font-color-base);

--- a/bytesofpurpose-blog/src/pages/index.module.css
+++ b/bytesofpurpose-blog/src/pages/index.module.css
@@ -1246,8 +1246,8 @@
   max-width: 220px;
   height: auto;
   border-radius: 110px 110px 14px 14px;
-  filter: drop-shadow(0 6px 16px rgba(26, 26, 26, 0.18));
-  transition: transform 0.2s ease;
+  filter: var(--shadow-arch);
+  transition: transform var(--duration-slow) ease;
 }
 
 .chooserCard:hover .chooserCardImage {

--- a/bytesofpurpose-blog/src/pages/support.module.css
+++ b/bytesofpurpose-blog/src/pages/support.module.css
@@ -58,7 +58,7 @@
 }
 
 .channelCard:hover {
-  transform: translateY(-4px);
+  transform: var(--lift-card);
   box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.12);
   border-color: var(--ifm-color-primary-lighter);
   text-decoration: none;

--- a/bytesofpurpose-blog/src/pages/support.tsx
+++ b/bytesofpurpose-blog/src/pages/support.tsx
@@ -98,8 +98,8 @@ export default function SupportPage(): React.JSX.Element {
             <h1>Support my work</h1>
             <p>
               Hi, I'm Omar. I write here about software, problem-solving, and
-              building things in the open, and I run almost entirely on coffee
-              ☕. If anything here helped you, here are a few ways to say thanks.
+              building things in the open, and I run almost entirely on coffee.
+              If anything here helped you, here are a few ways to say thanks.
               No pressure, every one of them genuinely means a lot.
             </p>
           </div>

--- a/bytesofpurpose-blog/src/pages/vote.tsx
+++ b/bytesofpurpose-blog/src/pages/vote.tsx
@@ -34,8 +34,8 @@ export default function VotePage() {
         </p>
         <p className={styles.signalNote}>
           <em>
-            Votes are signal-only for now; clicking 👍 records your interest
-            (no live tally is shown yet).
+            Votes are signal-only for now; clicking the vote button records
+            your interest (no live tally is shown yet).
           </em>
         </p>
 


### PR DESCRIPTION
## What & why

The **"Bytes of Purpose Design System"** on claude.ai/design was reverse-engineered *from this repo*, so its raw brand values already matched what we ship. The genuine **drift** was that the DS codified a **named-token vocabulary** the repo never adopted (it inlined the literals). This PR reconciles that, plus fixes a handful of concrete brand-consistency violations surfaced by five read-only DS-aspect audits.

## Commit 1 — token vocabulary (`92a3cf97`)
- Add the DS named-token layer to `custom.css` (`:root` + dark): semantic aliases (`--text-*`, `--surface-*`, `--accent-tint`, `--bop-divider`), spacing (`--space-1..9`), radii (`--radius-*`), the Fraunces/Geist type + weight/tracking/leading scales, and motion (`--ease-*`, `--duration-*`, `--lift-card/-subtle`).
- **Alias, don't duplicate:** `--shadow-sm/-md` point at the existing `--ifm-global-shadow-lw/-md` (single source of truth).
- **Migrate 14 high-confidence call-sites** to the tokens (hover lifts → `--lift-*`, 14px corners → `--radius-lg`, clear `0.2s` → `--duration-slow`). Every swap resolves to its exact prior literal → **computed CSS unchanged**.
- **Deliberately excluded** (dead/duplicate): `--bop-border` (0 call-sites; repo uses `--ifm-color-emphasis-200`), duplicate shadow tokens, the unused DS easing curve, and `.bop-eyebrow`/`.bop-rule` (the hero already has an inline eyebrow; no tri-color rule exists to back `.bop-rule`).

## Commit 2 — audit-driven brand fixes (`76f052de`)
- **type P0:** `FancyButton` (used by the live `VoteButton`) shipped **Raleway** → swapped to `var(--font-sans-body)` (Geist) + dropped the Raleway `@import`.
- **arch token gap:** the hero arch image inlined the arch drop-shadow → now `var(--shadow-arch)`.
- **voice P1:** removed two mid-sentence decorative emoji (support hero ☕, vote note 👍) — brand uses emoji only as a single leading glyph.

## Verification
- `node scripts/check-contrast.js` → **AA pass** (no color values changed).
- `node scripts/validate-hero-anchors.js` → **40/40 green** (hero-guarded file touched safely).
- Dev server **compiled the CSS modules cleanly** (`:3111`).
- Grep-proof: every introduced `var()` is defined; tokens resolve to prior literals; braces balanced.

## Audit results — what's clean vs. deferred
Five DS aspects were audited across `bytesofpurpose-blog/src` + `packages/blog-ui/src`:

| Aspect | Result |
|---|---|
| **Color discipline** | ✅ **Fully clean** — pastels accent-fill-only, `--tea-ink` the only text on them, gold confined to premium surfaces. |
| **Type system** | Fixed Raleway P0. Deferred: `.storybook-*` Nunito Sans (scaffolding, unmounted); eyebrow-tracking divergence (0.18em met in 1 of 23 labels — a consistency sweep, partly intentional). |
| **Arch / elevation** | Arch clean (+ token fix). Deferred: resting shadows on TimeLine/media-frames/Graph viewports; non-token card radii (widespread `8px`); the `0 4px 12px` changelog shadow repeated 6×. |
| **Voice** | Fixed 2 mid-sentence emoji. Surfaced (judgment calls, not changed): navbar bare-noun vs. homepage "My X" split; `/initiatives` card wording; the `/thoughts` card labeled "Ideas"; `Where faith meets craft` not used anywhere. |
| **Reduced motion** | ⚠️ **Deferred — separate PR.** P0: the homepage hero variants auto-cycle under `prefers-reduced-motion` (only the flash is suppressed). The hero is A/B-tested + anchor-guarded, so this needs its own careful change. Also P1: SignInModal/Question modal `popIn`, FancyButton gradient sweep unguarded. |

**The deferred items are intentionally NOT in this PR** — they're either broad consistency sweeps, judgment calls on your voice, or the anchor-guarded hero motion fix. Happy to take any of them as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)