### PR TITLE
fix(a11y): heroes must not auto-cycle under prefers-reduced-motion (P0)

### DIFF
--- a/bytesofpurpose-blog/src/pages/index.tsx
+++ b/bytesofpurpose-blog/src/pages/index.tsx
@@ -184,6 +184,7 @@ function ChooserFlash() {
   const [active, setActive] = useState(0);
   const [flashing, setFlashing] = useState(false);
   const [paused, setPaused] = useState(false);
+  const reduce = useReducedMotion();
   const stepTimers = useRef<number[]>([]);
 
   // ONE scene change: advance by `delta` (the auto-rotate uses +1; the arrows ±1), with the flash +
@@ -200,12 +201,14 @@ function ChooserFlash() {
   }, []);
 
   // Auto-rotate (paused on hover/focus). It re-arms whenever `active` changes, so a manual arrow nav
-  // (which changes `active`) resets the countdown instead of double-firing right after.
+  // (which changes `active`) resets the countdown instead of double-firing right after. Under
+  // prefers-reduced-motion we never arm the interval, so the hero holds on its first card (the arrows
+  // still let a reduced-motion user step through scenes by choice).
   useEffect(() => {
-    if (paused) return undefined;
+    if (paused || reduce) return undefined;
     const tick = window.setInterval(() => step(1), FLASH_INTERVAL_MS);
     return () => window.clearInterval(tick);
-  }, [paused, active, step]);
+  }, [paused, reduce, active, step]);
 
   useEffect(
     () => () => stepTimers.current.forEach((t) => window.clearTimeout(t)),
@@ -297,16 +300,19 @@ const BOUTIQUE_INTERVAL_MS = 12000; // time one project is shown before the stor
 function ChooserBoutique() {
   const [active, setActive] = useState(0);
   const [paused, setPaused] = useState(false);
+  const reduce = useReducedMotion();
 
   const step = useCallback((delta: number) => {
     setActive((i) => (i + delta + CHOOSER_CARDS.length) % CHOOSER_CARDS.length);
   }, []);
 
+  // Auto-cycle the storefront scenes — but never under prefers-reduced-motion (the gate holds on the
+  // first scene; the arrow keys still let a reduced-motion user step through by choice).
   useEffect(() => {
-    if (paused) return undefined;
+    if (paused || reduce) return undefined;
     const tick = window.setInterval(() => step(1), BOUTIQUE_INTERVAL_MS);
     return () => window.clearInterval(tick);
-  }, [paused, active, step]);
+  }, [paused, reduce, active, step]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -461,6 +467,24 @@ function useIsMobile(): boolean {
     return () => mq.removeEventListener('change', update);
   }, []);
   return mobile;
+}
+
+// Reactive companion to the one-shot prefersReducedMotion() read: returns the current
+// reduced-motion preference AND re-renders when the OS setting is toggled at runtime, so the
+// auto-advancing chooser heroes can STOP cycling the moment the user asks for no motion. SSR-safe
+// (false until mounted). The auto-rotate effects gate on this so the timer/interval never arms
+// under reduce — the scene pins to its first card instead of cross-fading forever.
+function useReducedMotion(): boolean {
+  const [reduce, setReduce] = useState(false);
+  useEffect(() => {
+    if (!window.matchMedia) return undefined;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduce(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+  return reduce;
 }
 
 // TEST/QA seam: `?hero-scene=N` forces the parallax engine to scene N (bypassing scroll), so e2e tests
@@ -635,7 +659,7 @@ function timerScene(
 }
 
 function useTimerScene(count: number, paused: boolean): SceneState {
-  const reduce = prefersReducedMotion();
+  const reduce = useReducedMotion();
   const SETTLE_MS = STUDIO_INTERVAL_MS; // hold on a step
   const CROSS_MS = STUDIO_FLASH_MS + STUDIO_FLASH_HOLD_MS; // the crossing (flash) to the next step
   const perStep = SETTLE_MS + CROSS_MS;
@@ -645,7 +669,10 @@ function useTimerScene(count: number, paused: boolean): SceneState {
   const lastRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (paused) {
+    // prefers-reduced-motion: never start the rAF clock. The scene stays pinned (settled, no flash,
+    // no cross-fade) on whatever step it is on — on first mount that is scene 0. This is the P0 fix:
+    // previously `reduce` only zeroed the flash while the clock kept advancing the scene forever.
+    if (paused || reduce) {
       lastRef.current = null; // so the next resume starts a fresh delta (no jump)
       return undefined;
     }
@@ -660,7 +687,7 @@ function useTimerScene(count: number, paused: boolean): SceneState {
     raf = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(raf);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [paused, count, perStep, SETTLE_MS, CROSS_MS, reduce]);
+  }, [paused, reduce, count, perStep, SETTLE_MS, CROSS_MS]);
 
   return scene;
 }

--- a/bytesofpurpose-blog/test/e2e/homepage.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/homepage.spec.ts
@@ -362,3 +362,66 @@ test.describe('Homepage hero: scroll-driven parallax (variant C)', () => {
     await expect(lit).toHaveCount(1);
   });
 });
+
+/*
+ * REDUCED-MOTION: the AUTO-cycling heroes must NOT self-advance under prefers-reduced-motion.
+ * The brand rule is "all motion respects prefers-reduced-motion, no exceptions." The flash + studio
+ * heroes used to keep auto-rotating under reduce (only the flash bloom was suppressed) — a P0. The fix
+ * gates each auto-advance (setInterval / rAF clock) on the preference so the scene PINS, while the
+ * arrow keys still let a reduced-motion user step through by choice (motion off ≠ navigation off).
+ */
+test.describe('Homepage hero: reduced-motion does not auto-advance', () => {
+  // These assert the USER-FACING symptom: under reduced motion the auto-cycling heroes must hold their
+  // scene instead of self-advancing. The windows are deliberately longer than one auto-step (studio
+  // advances at ~10s, flash at ~12s on the buggy build — verified empirically), so the test actually
+  // DISCRIMINATES: pre-fix the active destination rotates off scene 0; post-fix it stays put. The fix
+  // gates each auto-advance (setInterval / rAF clock) on prefers-reduced-motion; arrows still navigate.
+
+  test('studio timer house: active scene HOLDS on /craft (rAF clock gated)', async ({ browser }) => {
+    const context = await browser.newContext({ reducedMotion: 'reduce' });
+    const page = await context.newPage();
+    try {
+      await page.goto('/?ab-homepage-hero-anim=variant_c', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+      // The bare timer house (ChooserStudio) is ONE gate whose href is CHOOSER_CARDS[active].to; scene
+      // 0 → /craft. On the buggy build it rotates to /journey by ~10s even under reduce; the fix pins it.
+      const gate = page.locator('[data-hero-root]');
+      await expect(gate, 'the timer house starts on scene 0 (/craft)').toHaveAttribute('href', '/craft');
+      await page.waitForTimeout(11000); // past the ~10s point where the buggy build advances
+      await expect(
+        gate,
+        'reduced-motion: the timer house must NOT auto-advance (gate stays /craft)',
+      ).toHaveAttribute('href', '/craft');
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('flash variant: active scene HOLDS (no auto-rotate), but arrows still navigate', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ reducedMotion: 'reduce' });
+    const page = await context.newPage();
+    try {
+      await page.goto('/?ab-homepage-hero-anim=test', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+      const activeSrc = () =>
+        page.locator('[class*="flashArchImgActive"]').getAttribute('src');
+      const first = await activeSrc();
+      expect(first, 'an active arch scene should be showing').toBeTruthy();
+
+      // Wait past the auto-rotate interval (FLASH_INTERVAL_MS = 12s). Pre-fix the scene rotates here;
+      // the fix holds it. (13s keeps a margin over the 12s interval.)
+      await page.waitForTimeout(13000);
+      expect(await activeSrc(), 'reduced-motion: the flash hero must NOT auto-rotate').toBe(first);
+
+      // Navigation by CHOICE still works (only the auto-motion is off).
+      await page.keyboard.press('ArrowRight');
+      await expect
+        .poll(activeSrc, { timeout: 4000, message: 'arrows still navigate under reduced-motion' })
+        .not.toBe(first);
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## What & why

**P0 accessibility defect** surfaced by the design-system motion audit. The brand rule is "all motion respects `prefers-reduced-motion`, no exceptions," but the auto-advancing homepage heroes kept cycling scenes under reduced motion — only the camera *flash* was suppressed while the scene clock ran on, so the door/board still cross-faded and the active destination rotated.

**Verified live** (master, reduced-motion on): the studio timer house rotated `/craft` → `/journey` by ~10s.

## The fix
Add a reactive `useReducedMotion()` hook (mirrors the existing `useIsMobile`) and gate every auto-advance on it so the scheduler never arms:
- `ChooserFlash` `setInterval` → bail when `reduce`
- `ChooserBoutique` `setInterval` → bail when `reduce`
- `useTimerScene` rAF clock (the **default `/` hero**) → bail when `reduce`; the scene pins to its first card.

Arrow-key navigation still works under reduced motion (motion off ≠ navigation off).

## Tests (proven discriminating)
New `reduced-motion does not auto-advance` describe block in `homepage.spec.ts` (uses Playwright's real `reducedMotion: 'reduce'`):
- studio house gate **holds on `/craft`** across an 11s window (past the ~10s the buggy build advances);
- flash scene does **not** rotate across 13s (past the 12s interval), but arrows still navigate.

**Negative control:** I stood up a master worktree (pre-fix) and ran these exact tests against it — they **FAIL** there and **PASS** against this fix. So they genuinely catch the regression, not just pass vacuously.

## Verification
- `validate-hero-anchors` → 40/40 green (anchor-guarded hero file touched safely).
- `index.tsx` typechecks (only pre-existing, unrelated tsc errors elsewhere).
- Positive + negative e2e controls as above.

## Relationship to #115
Independent workstream, branched off master (does **not** depend on #115). Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)