### PR TITLE
fix(css): converge card elevation on the brand shadow tokens

### DIFF
--- a/bytesofpurpose-blog/src/components/Changelog/Changelog.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/Changelog.module.css
@@ -24,7 +24,7 @@
 }
 
 .entryCard:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--ifm-global-shadow-md);
   transform: translateY(-2px);
 }
 
@@ -1024,7 +1024,7 @@
 }
 
 .quarterColumn:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--ifm-global-shadow-md);
 }
 
 .quarterSelected {

--- a/bytesofpurpose-blog/src/components/Changelog/QuarterSection/QuarterSection.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/QuarterSection/QuarterSection.module.css
@@ -85,7 +85,7 @@
 }
 
 .quarterColumn:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--ifm-global-shadow-md);
 }
 
 .quarterSelected {
@@ -215,7 +215,7 @@
 }
 
 .entryCard:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--ifm-global-shadow-md);
   transform: translateY(-2px);
 }
 

--- a/bytesofpurpose-blog/src/components/TimeLine/styles.module.css
+++ b/bytesofpurpose-blog/src/components/TimeLine/styles.module.css
@@ -67,8 +67,10 @@
   padding: 12px 20px;
   background: var(--ifm-background-color);
   position: relative;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: var(--ifm-global-radius);
+  /* Brand elevation: a content card rests on the quiet step + a hairline, not a heavier ad-hoc
+     shadow (the brand earns deeper shadow on hover, and this card is non-interactive). */
+  box-shadow: var(--ifm-global-shadow-lw);
   border: 1px solid var(--ifm-color-emphasis-200);
   width: 100%;
   max-width: none;

--- a/bytesofpurpose-blog/src/pages/changelog.module.css
+++ b/bytesofpurpose-blog/src/pages/changelog.module.css
@@ -24,7 +24,7 @@
 }
 
 .entryCard:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--ifm-global-shadow-md);
   transform: translateY(-2px);
 }
 
@@ -617,7 +617,7 @@
 }
 
 .quarterColumn:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--ifm-global-shadow-md);
 }
 
 .quarterSelected {


### PR DESCRIPTION
## What & why

Elevation-consistency sweep from the design-system arch/elevation audit. The brand uses a quiet two-step shadow system (`--ifm-global-shadow-lw` / `-md`) and earns deeper shadow **on hover, not at rest** — but a few card surfaces used ad-hoc shadows that drifted from it.

## Changes
- **Changelog cards/columns** — the repeated ad-hoc hover shadow `0 4px 12px rgba(0,0,0,0.1)` (6 sites across `Changelog.module.css`, `QuarterSection`, and the `changelog` page) now references `var(--ifm-global-shadow-md)`. A small visual convergence onto the brand's medium step.
- **TimeLine content card** — dropped its heavier resting `0 2px 8px` ad-hoc shadow for the quiet `var(--ifm-global-shadow-lw)` step (the card is non-interactive, so it rests on the faint step + its hairline rather than over-elevating), and its radius now uses `var(--ifm-global-radius)`.

## Scope
Uses the Infima shadow/radius tokens that **already exist on master**, so this PR is **independent of #115** (the DS token-vocabulary PR).

**Out of scope (deliberate):**
- Media frames (`Mockup` / `Gif` / `Walkthrough`) — they intentionally rest-elevate (raised screenshots/scenes).
- Modals / toasts / popovers — correct floating-UI elevation.
- The no-op `8px → token` radius migration on the other card surfaces — better done uniformly alongside the `--radius-*` token layer (once #115 lands), rather than a partial sweep here.

## Verification
- `node scripts/check-contrast.js` → AA pass.
- Dev server compiles cleanly; `/changelog` serves 200; the 6 hover shadows + TimeLine resting shadow confirmed resolving to the tokens.

Independent of #115 and #116; merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)