### PR TITLE
fix(voice): consistent chooser-card titles + surface 'Where faith meets craft'

### DIFF
--- a/bytesofpurpose-blog/docusaurus.config.js
+++ b/bytesofpurpose-blog/docusaurus.config.js
@@ -1248,7 +1248,7 @@ const rehypePremiumEncrypt = require('./plugins/rehype-premium-encrypt');
               ],
             },
           ],
-          copyright: `Copyright © ${new Date().getFullYear()} BytesOfPurpose, Inc. Built with Docusaurus.`,
+          copyright: `Where faith meets craft. · Copyright © ${new Date().getFullYear()} BytesOfPurpose, Inc. Built with Docusaurus.`,
         },
         prism: {
           theme: lightTheme,

--- a/bytesofpurpose-blog/src/pages/index.tsx
+++ b/bytesofpurpose-blog/src/pages/index.tsx
@@ -47,14 +47,14 @@ const CHOOSER_CARDS: ReadonlyArray<{
     to: '/initiatives',
     img: '/img/cards/initiatives.png',
     alt: 'Omar conducting an orchestra from the podium',
-    title: "📝 Explore the Things I've Done",
+    title: '📝 Explore My Initiatives',
     body: 'The dated things I actually did.',
   },
   {
     to: '/thoughts',
     img: '/img/cards/thinking.png',
     alt: 'Omar in thought, hand to his chin',
-    title: '💭 Explore My Ideas',
+    title: '💭 Explore My Thoughts',
     body: "Ideas I've had but not acted on yet.",
   },
   {


### PR DESCRIPTION
## What & why

From the design-system **voice audit**. Three approved fixes (the navbar "My X" question was answered *keep the split*, so the navbar is untouched).

## Changes
**1. All 7 homepage chooser cards now read `[verb] My [noun]`** — fixing the two that broke the sibling pattern:
| Card | Before | After |
|---|---|---|
| `/initiatives` | "Explore the Things I've Done" | **Explore My Initiatives** |
| `/thoughts` | "Explore My Ideas" | **Explore My Thoughts** (aligns the card with its route + navbar label) |

The other five (Discover My Craft / Discover My Journey / Explore My Mindset / Sit With My Questions / Study My Designs) were already consistent.

**2. Surface the brand signature `"Where faith meets craft."`** — the audit found this stated signature phrase appears **nowhere** on the live site. Added to the footer copyright line (shows on every page), joined with the brand middot `·`.

## What's intentionally NOT changed
The navbar's bare nouns (Craft, Journey…) vs. the hero's "My X" — a deliberate compact-nav-vs-expressive-hero split (confirmed to keep).

## Verification
- Config + page compile; home serves 200.
- Card `aria-label`s derive from titles via `stripEmoji()`, and the homepage e2e asserts **hrefs**, not titles — so the rename is safe (no test breakage).
- Footer copyright is a standard server-rendered Docusaurus field (renders in prod build / browser; not visible in `docusaurus start` raw curl due to client hydration).

Independent of #115 / #116 / #117 / #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)