### PR TITLE
refactor(css): card radii reference --radius-md token (no-op)

### DIFF
--- a/bytesofpurpose-blog/src/components/Changelog/Changelog.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/Changelog.module.css
@@ -17,7 +17,7 @@
 
 .entryCard {
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   background: var(--ifm-background-color);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
@@ -1018,7 +1018,7 @@
   scroll-snap-align: start;
   background: var(--ifm-background-color);
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   transition: all 0.3s ease;
 }

--- a/bytesofpurpose-blog/src/components/Changelog/QuarterSection/QuarterSection.module.css
+++ b/bytesofpurpose-blog/src/components/Changelog/QuarterSection/QuarterSection.module.css
@@ -67,7 +67,7 @@
   scroll-snap-align: start;
   background: var(--ifm-background-color);
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   transition: all 0.3s ease;
 }
@@ -208,7 +208,7 @@
 
 .entryCard {
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   background: var(--ifm-background-color);
   transition: box-shadow 0.2s ease, transform 0.2s ease;

--- a/bytesofpurpose-blog/src/components/KanbanBoard/KanbanBoard.module.css
+++ b/bytesofpurpose-blog/src/components/KanbanBoard/KanbanBoard.module.css
@@ -167,7 +167,7 @@
   background: var(--ifm-card-background-color, var(--ifm-background-color));
   border: 1px solid var(--ifm-color-emphasis-200);
   border-left: 4px solid var(--ifm-color-primary);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   font: inherit;
   color: inherit;

--- a/bytesofpurpose-blog/src/pages/changelog.module.css
+++ b/bytesofpurpose-blog/src/pages/changelog.module.css
@@ -17,7 +17,7 @@
 
 .entryCard {
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   background: var(--ifm-background-color);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
@@ -611,7 +611,7 @@
   scroll-snap-align: start;
   background: var(--ifm-background-color);
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 1.5rem;
   transition: all 0.3s ease;
 }


### PR DESCRIPTION
## What & why

Follow-up to the DS token reconciliation (#115, now merged). The `--radius-md` token (`0.5rem` == `8px`) now exists, so the card surfaces that hardcoded `border-radius: 8px` reference it instead.

**Pure no-op:** `--radius-md` resolves to the same `8px`, so nothing changes visually — this just puts card corners on the named token, finishing the radius half of the token reconciliation.

## Migrated (7 genuine card surfaces)
- `.entryCard` ×3 (Changelog, QuarterSection, changelog page)
- `.quarterColumn` ×3
- KanbanBoard `.card`

## Left as-is (not cards)
The `.toggle`, heatmap containers, filter tiles, badges, Graph viewport/menu, modal links, DebugMenu list, and the hero parallax layer — their `8px` is incidental, not the brand card corner.

## Verification
- `check-contrast` AA pass.
- Value is identical (`0.5rem` = `8px`), so there is no visual change — confirmed by the diff being only `8px → var(--radius-md)`.

Closes the last deferred item from the arch/elevation audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)