### PR TITLE
feat(guard): validate-ds-tokens — catch hardcoded values that have a DS token

### DIFF
--- a/.claude/hooks/validate-ds-tokens-hook.sh
+++ b/.claude/hooks/validate-ds-tokens-hook.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write: WARN (never block) when a CSS edit hardcodes a value that has a
+# canonical design-system token (a re-drift).
+#
+# The DS reconciliation gave the brand's values NAMES (--lift-*, the shadow tokens, --radius-*,
+# --brand-green, the font families, --tea-ink); nothing stopped the literals creeping back. This hook
+# runs scripts/validate-ds-tokens.js on a CSS edit and surfaces any hardcoded value with a token, so
+# the moment you type `translateY(-4px)` or a brand-green hex you're nudged to the token. Warn-tier
+# (exits 0, never blocks); the blocking gate is `make validate-ds-tokens`.
+#
+# Scope: .css/.scss under bytesofpurpose-blog/src/ and packages/blog-ui/src/. The validator is scoped
+# to the EDITED file (fast + focused) so the warning is about what you just touched.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+case "$file_path" in
+  */bytesofpurpose-blog/src/*.css|*/bytesofpurpose-blog/src/*.scss|*/packages/blog-ui/src/*.css|*/packages/blog-ui/src/*.scss) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(printf '%s' "$input" | jq -r '.cwd // empty')}"
+script="$proj/bytesofpurpose-blog/scripts/validate-ds-tokens.js"
+[ -f "$script" ] || exit 0   # not this repo / not set up → stay out of the way
+
+out=$(cd "$proj/bytesofpurpose-blog" && node scripts/validate-ds-tokens.js "$file_path" 2>&1)
+if printf '%s' "$out" | grep -q 'should reference a token'; then
+  {
+    echo "🎨 ds-tokens: this CSS hardcodes a value that has a design-system token:"
+    printf '%s\n' "$out" | grep -E '•|→ use'
+    echo ""
+    echo "   Reach for the token (values match, so the swap is non-breaking)."
+    echo "   See the implement-with-design-system skill. (advice only — not blocking."
+    echo "   Run \`make validate-ds-tokens\` for the gate.)"
+  } >&2
+fi
+
+# WARN-only: always succeed so the edit is never blocked.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-ds-tokens-hook.sh\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-url-params-hook.sh\"",
             "timeout": 20
           },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,25 @@ the validator declares scope but can't enforce the gate, so honour it. Current p
 (ingress attribution). If a read is NOT a url param (e.g. an HTTP header), add it to `IGNORE_KEYS`
 in the validator.
 
+## ⚠️ Operating convention: reach for a design-system token, not a hardcoded value
+
+The brand's values have NAMES (the design-system token layer in
+`bytesofpurpose-blog/src/css/custom.css`: `--lift-card/-subtle`, the two-step shadows
+`--ifm-global-shadow-lw/-md` + `--shadow-arch`, `--radius-sm/-md/-lg`, `--duration-*`/`--ease-*`,
+`--space-*`, the `--text-*` scale, `--brand-green`/`--ifm-color-primary`, the Fraunces/Geist/Geist
+Mono families, `--tea-ink`). **When you'd type one of those literals in CSS, use the token instead**
+— values match, so it's non-breaking, and `custom.css` stays the single source of truth. This is
+warn-tier fail-closed: the PostToolUse `Write|Edit` hook `.claude/hooks/validate-ds-tokens-hook.sh`
+runs `scripts/validate-ds-tokens.js` (file-scoped) on a CSS edit and **warns** when a literal has a
+canonical token; the blocking gate is `make validate-ds-tokens` (exits 2). The validator is
+deliberately CONSERVATIVE (false positives kill a guard) — it flags only context-unambiguous literals
+(the exact hover-lift transforms, the quiet/ad-hoc card shadows, the arch drop-shadow, brand-green
+hexes, a **pastel used as `color:`** — a DISCIPLINE violation since pastels are accent fills only — and
+off-brand font families); bare `8px`/`0.2s`/`1rem` are left to judgment + the skill. When you add a
+new token worth guarding, add a rule to the `RULES` manifest in the SAME change. The owning skill is
+**`implement-with-design-system`** (the literal→token map + the discipline rules + the repo-reality
+gotchas); this convention is the enforcement.
+
 ## ⚠️ Operating convention: every board tag gets a tooltip gloss in the registry
 
 Each theme **tag** that appears on an Ideas/Experimentation board card (the chips on the card +

--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,12 @@ validate-hero-anchors: ## Check the maintain-homepage-hero skill is in lockstep 
 validate-url-params: ## Check every query param read in src/ is registered in the URL-param registry (src/lib/url-params.ts)
 	( cd ${SITEROOT} && node scripts/validate-url-params.js )
 
+validate-ds-tokens: ## Check authored CSS doesn't hardcode values that have a design-system token (lifts/shadows/brand-green/fonts/pastel-as-text)
+	@# Exit 2 if a CSS literal has a canonical token (a re-drift). The warn-tier hook
+	@# .claude/hooks/validate-ds-tokens-hook.sh runs this file-scoped on a CSS edit. See the
+	@# implement-with-design-system skill for the literal->token map.
+	( cd ${SITEROOT} && node scripts/validate-ds-tokens.js )
+
 validate-idea-tags: ## Check every board (ideas/experiments) tag has a tooltip gloss in the tag registry (src/lib/idea-tags.ts)
 	@# Exit 2 if a board-post tag has no entry in IDEA_TAG_GLOSS (its chip tooltip would teach
 	@# nothing). Orphan glosses (no post uses the tag) are warn-only. The warn-tier hook

--- a/bytesofpurpose-blog/scripts/validate-ds-tokens.js
+++ b/bytesofpurpose-blog/scripts/validate-ds-tokens.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * validate-ds-tokens.js — keep the repo's CSS speaking the design-system's NAMED token vocabulary
+ * instead of re-drifting into hardcoded literals.
+ *
+ * The design-system reconciliation (see the implement-with-design-system skill) gave the brand's
+ * values NAMES (--lift-*, the shadow tokens, --radius-*, --duration-*, --brand-green,
+ * the font families, --tea-ink). Audits then removed the hardcoded copies. Nothing stopped them from
+ * creeping back — until this. It scans the repo's authored CSS for literal values that have a
+ * canonical token and WARNS (the blocking gate is `make validate-ds-tokens`, exit 2), so a stray
+ * `translateY(-4px)` or an off-brand font is caught at edit time.
+ *
+ * DESIGN BIAS: false positives are worse than misses here (a noisy guard gets ignored). So the RULES
+ * below only flag literals whose token is UNAMBIGUOUS regardless of surrounding context:
+ *   - the exact hover-lift transforms (--lift-card / --lift-subtle)
+ *   - the exact quiet two-step shadow literals + the known ad-hoc changelog shadow (--ifm-global-shadow-*)
+ *   - the arch drop-shadow (--shadow-arch)
+ *   - the brand-green hexes used as a value (--brand-green / --ifm-color-primary)
+ *   - a tea-party pastel used as a `color:` (a DISCIPLINE violation — pastels are fills only)
+ *   - off-brand font families (anything that isn't Fraunces / Geist / Geist Mono / a generic fallback)
+ * Context-dependent literals (a bare `8px` radius, a `0.2s` that might be a non-card transition, a
+ * `1rem` that's usually font-size) are deliberately NOT flagged — those are handled by the skill +
+ * human judgment, not a regex, to keep the signal clean.
+ *
+ * Usage:  node scripts/validate-ds-tokens.js [file1 file2 ...]   (no args = scan the whole CSS tree)
+ * Exit:   2 if any rule matches (a re-drift); else 0.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const JSON_OUT = process.argv.includes('--json');
+
+// Directories whose CSS is authored brand surface. We skip build output, deps, generated, and the
+// token DEFINITION file itself (custom.css legitimately holds the literals as the source of truth).
+const SCAN_DIRS = [
+  path.join(ROOT, 'src'),
+  path.join(ROOT, '..', 'packages', 'blog-ui', 'src'),
+];
+const SKIP_RE = /(node_modules|build|\.docusaurus|static\/storybook|dist)\//;
+// custom.css DEFINES the tokens (and documents the values in comments) — never flag it.
+const SKIP_FILES = new Set([path.join(ROOT, 'src', 'css', 'custom.css')]);
+
+// ── The RULES manifest: the literal->token map. Each rule: a regex that matches the LITERAL in a
+// value position, the token to suggest, and a human note. Kept conservative (see header). ──────────
+const RULES = [
+  {
+    id: 'lift-card',
+    // transform: ... translateY(-4px) ...  (the card hover lift)
+    re: /transform\s*:[^;]*\btranslateY\(\s*-4px\s*\)/g,
+    token: 'var(--lift-card)',
+    note: 'card hover lift',
+  },
+  {
+    id: 'lift-subtle',
+    re: /transform\s*:[^;]*\btranslateY\(\s*-2px\s*\)/g,
+    token: 'var(--lift-subtle)',
+    note: 'list/article hover lift',
+  },
+  {
+    id: 'shadow-lw',
+    re: /box-shadow\s*:[^;]*0\s+1px\s+3px\s+rgba\(\s*20\s*,\s*32\s*,\s*26\s*,\s*0?\.08\s*\)/g,
+    token: 'var(--ifm-global-shadow-lw)',
+    note: 'the quiet resting shadow step',
+  },
+  {
+    id: 'shadow-md',
+    re: /box-shadow\s*:[^;]*0\s+6px\s+20px\s+rgba\(\s*20\s*,\s*32\s*,\s*26\s*,\s*0?\.1\s*\)/g,
+    token: 'var(--ifm-global-shadow-md)',
+    note: 'the medium hover shadow step',
+  },
+  {
+    id: 'shadow-adhoc-changelog',
+    // the known ad-hoc card shadow the audit converged: 0 4px 12px rgba(0,0,0,.1)
+    re: /box-shadow\s*:[^;]*0\s+4px\s+12px\s+rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0?\.1\s*\)/g,
+    token: 'var(--ifm-global-shadow-md)',
+    note: 'an ad-hoc card shadow — use the brand medium step',
+  },
+  {
+    id: 'shadow-arch',
+    re: /drop-shadow\(\s*0\s+6px\s+16px\s+rgba\(\s*26\s*,\s*26\s*,\s*26\s*,\s*0?\.18\s*\)\s*\)/g,
+    token: 'var(--shadow-arch)',
+    note: 'the cathedral-arch illustration shadow',
+  },
+  {
+    id: 'brand-green-hex',
+    // the brand green hexes used anywhere as a value (not in a comment — comments are stripped first)
+    re: /#448061\b|#3c7256\b/gi,
+    token: 'var(--brand-green) or var(--ifm-color-primary)',
+    note: 'brand green — use the token (--ifm-color-primary is the AA-safe text green)',
+  },
+  {
+    id: 'pastel-as-text',
+    // a tea pastel used as a `color:` (DISCIPLINE: pastels are accent FILLS only, never text).
+    // The [^a-z-] guard avoids matching `background-color:` / `border-color:`; --tea-ink is allowed.
+    re: /(?:^|[^a-z-])color\s*:\s*(?:var\(\s*--tea-(?:pink|mint|green)\s*\)|#ffc5d3|#adfff5|#d2ffc4)/gi,
+    token: '--tea-ink (the only ink allowed on a pastel)',
+    note: 'a pastel used as TEXT — pastels are accent fills only; ride --tea-ink on them instead',
+  },
+  {
+    id: 'off-brand-font',
+    // font-family / font shorthand naming a family that isn't a brand family or a known generic.
+    // We match the declaration, then check it mentions none of the allowed families.
+    re: /\bfont(?:-family)?\s*:\s*[^;]*\b(Raleway|Nunito|Roboto|Lato|Montserrat|Open Sans|Poppins|Inter|Helvetica Neue|Arial)\b[^;]*/gi,
+    token: "var(--ifm-font-family-base) / -heading / -monospace (Geist / Fraunces / Geist Mono)",
+    note: 'off-brand typeface — use a brand font token',
+    // allow the family if the declaration ALSO references a brand token/family (e.g. fallback chains
+    // inside the token definitions, which live in custom.css and are skipped anyway).
+    allowIf: /var\(--(?:ifm-)?font|Fraunces|Geist/i,
+  },
+];
+
+// Strip /* ... */ comments and `// ...` so documented values in comments don't trip the rules.
+function stripComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+function lineOf(text, idx) {
+  return text.slice(0, idx).split('\n').length;
+}
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, {withFileTypes: true});
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (SKIP_RE.test(full + '/')) continue;
+    if (e.isDirectory()) walk(full, out);
+    else if (/\.(css|scss)$/.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+function filesToScan() {
+  if (args.length) return args.map((a) => path.resolve(a)).filter((f) => /\.(css|scss)$/.test(f));
+  const out = [];
+  for (const d of SCAN_DIRS) walk(d, out);
+  return out;
+}
+
+function scanFile(file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  if (SKIP_FILES.has(path.resolve(file))) return [];
+  const css = stripComments(raw);
+  const findings = [];
+  for (const rule of RULES) {
+    rule.re.lastIndex = 0;
+    let m;
+    while ((m = rule.re.exec(css))) {
+      const hit = m[0];
+      if (rule.allowIf && rule.allowIf.test(hit)) continue;
+      findings.push({
+        file: path.relative(ROOT, file),
+        line: lineOf(css, m.index),
+        rule: rule.id,
+        token: rule.token,
+        note: rule.note,
+        snippet: hit.trim().slice(0, 80),
+      });
+    }
+  }
+  return findings;
+}
+
+function main() {
+  const files = filesToScan();
+  const all = [];
+  for (const f of files) all.push(...scanFile(f));
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({findings: all, scanned: files.length}, null, 2));
+    process.exit(all.length ? 2 : 0);
+  }
+
+  if (!all.length) {
+    console.log(`✅ ds-tokens: no hardcoded values with a canonical token (${files.length} files).`);
+    process.exit(0);
+  }
+
+  console.log(`⚠️  ds-tokens: ${all.length} hardcoded value(s) that should reference a token:\n`);
+  for (const f of all) {
+    console.log(`  • ${f.file}:${f.line}  [${f.rule}] ${f.note}`);
+    console.log(`      ${f.snippet}`);
+    console.log(`      → use ${f.token}\n`);
+  }
+  console.log('  Reach for the token (see the implement-with-design-system skill). Values match, so');
+  console.log('  the swap is non-breaking. custom.css is the single source of truth.');
+  process.exit(2);
+}
+
+main();

--- a/bytesofpurpose-blog/src/theme/NavbarItem/navbarSummary.module.css
+++ b/bytesofpurpose-blog/src/theme/NavbarItem/navbarSummary.module.css
@@ -11,7 +11,7 @@
   position: absolute;
   top: calc(100% + 0.4rem);
   left: 50%;
-  transform: translateX(-50%) translateY(-4px);
+  transform: translateX(-50%) var(--lift-card);
   z-index: var(--ifm-z-index-fixed, 200);
 
   width: max-content;


### PR DESCRIPTION
## What & why

You asked whether we **enforce DS adherence (right variables) via a hook**. We didn't — the reconciliation + audits were one-time; nothing stopped re-drift. This is the **enforcement counterpart** to the `implement-with-design-system` skill (#121): the skill says *which token to use*, this *catches you* when you don't.

## What it adds
- **`scripts/validate-ds-tokens.js`** — scans authored CSS (`src/` + `packages/blog-ui/src/`, **not** `custom.css`, which defines the tokens) for literals that have a canonical token. **Conservative by design** (a noisy guard gets ignored): flags only context-unambiguous cases —
  - the exact hover-lift transforms → `--lift-card` / `--lift-subtle`
  - the quiet/medium + the known ad-hoc card shadows → `--ifm-global-shadow-lw/-md`
  - the arch drop-shadow → `--shadow-arch`
  - brand-green hexes → `--brand-green` / `--ifm-color-primary`
  - **a pastel used as `color:`** → discipline violation (pastels are fills only; `--tea-ink` is the only ink on them)
  - off-brand font families → the brand font tokens
  - *Deliberately NOT flagged:* bare `8px` / `0.2s` / `1rem` (context-dependent — left to the skill + judgment).
- **`.claude/hooks/validate-ds-tokens-hook.sh`** — warn-tier PostToolUse `Write|Edit` hook (file-scoped, never blocks), registered in `.claude/settings.json`.
- **`make validate-ds-tokens`** — the blocking gate (exit 2).
- **CLAUDE.md** — the "reach for a token, not a literal" operating-convention section.
- Migrated the one literal the guard caught: navbarSummary's `translateX(-50%) translateY(-4px)` → `translateX(-50%) var(--lift-card)`.

## Proven (fail-closed tenet)
- **Planted-leak test:** a scratch file with all 5 violation categories → caught all 5, exit 2; the valid token-usage lines in the same file → passed.
- **Real tree clean:** 56 files, 0 findings.
- **Hook:** end-to-end test warns and **exits 0** (never blocks).

## Pairing
Depends conceptually on `implement-with-design-system` (#121) — the skill is the playbook, this is the guard. Both reference each other. Independent of the other open PRs at the code level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)