### PR TITLE
feat(designs): kind-signaling sidebar labels for the Designs blog

### DIFF
--- a/bytesofpurpose-blog/designs/2025-02-06-genai-agent-design.mdx
+++ b/bytesofpurpose-blog/designs/2025-02-06-genai-agent-design.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-genai-agent
+sidebar_label: GenAI Agent
+kind: agent-design
 sidebar_position: 1
 title: GenAI Agent Design
 ---

--- a/bytesofpurpose-blog/designs/2025-12-31-Framework.mdx
+++ b/bytesofpurpose-blog/designs/2025-12-31-Framework.mdx
@@ -1,5 +1,7 @@
 ---
 slug: blog-post-eval-framework
+kind: tooling-cli-design
+sidebar_label: Blog Post Eval Framework
 title: 'Blog Post Eval Framework'
 description: 'Is my new content doc worthy, blog post worthy, or neither?'
 authors: [oeid]

--- a/bytesofpurpose-blog/designs/2025-12-31-blog-design.md
+++ b/bytesofpurpose-blog/designs/2025-12-31-blog-design.md
@@ -1,5 +1,7 @@
 ---
 slug: design-blog
+sidebar_label: Blog Design
+kind: frontend-design
 sidebar_position: 2
 title: Blog Design
 draft: true

--- a/bytesofpurpose-blog/designs/2026-02-27-autonomous-build-agents.mdx
+++ b/bytesofpurpose-blog/designs/2026-02-27-autonomous-build-agents.mdx
@@ -1,5 +1,6 @@
 ---
 slug: design-autonomous-build-agents
+sidebar_label: Autonomous Build Agents
 sidebar_position: 9
 title: Autonomous Build Agents
 description: >-
@@ -12,7 +13,7 @@ tags:
   - architecture
   - ai-agents
   - saas-delivery
-kind: system-design
+kind: agent-design
 draft: false
 source:
   repo: work-git

--- a/bytesofpurpose-blog/designs/2026-05-31-ab-testing-framework.mdx
+++ b/bytesofpurpose-blog/designs/2026-05-31-ab-testing-framework.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-ab-testing
+sidebar_label: A/B Testing Framework
+kind: backend-design
 sidebar_position: 3
 title: A/B Testing Framework
 draft: true

--- a/bytesofpurpose-blog/designs/2026-06-01-draft-aware-sidebar.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-01-draft-aware-sidebar.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-draft-aware-sidebar
+sidebar_label: Draft-Aware Sidebar
+kind: frontend-design
 sidebar_position: 4
 title: Draft-Aware Sidebar (dev-only)
 draft: true

--- a/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-premium-gating
+sidebar_label: Premium Content Gating
+kind: backend-design
 sidebar_position: 5
 title: Premium Content Gating
 description: How a static GitHub-Pages blog hard-gates premium content with build-time encryption + a Cloudflare Worker that vends the key only to LinkedIn-signed-in readers.

--- a/bytesofpurpose-blog/designs/2026-06-03-sidebar-emoji-system.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-03-sidebar-emoji-system.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-sidebar-emoji-system
+sidebar_label: Sidebar Emoji System
+kind: tooling-cli-design
 sidebar_position: 6
 title: Sidebar Emoji System (self-maintaining)
 draft: true

--- a/bytesofpurpose-blog/designs/2026-06-04-binary-pyramid-logo.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-04-binary-pyramid-logo.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-binary-pyramid-logo
+sidebar_label: Binary Pyramid Logo
+kind: tooling-cli-design
 sidebar_position: 7
 title: Designing the Binary Pyramid Logo
 description: 'A UI design log: turning 1s and 0s into a pyramid of Greek columns, what we tried, what worked, and what did not.'

--- a/bytesofpurpose-blog/designs/2026-06-09-rosette-of-zeros.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-09-rosette-of-zeros.mdx
@@ -1,5 +1,7 @@
 ---
 slug: design-rosette-of-zeros
+sidebar_label: Rosette of Zeros
+kind: tooling-cli-design
 sidebar_position: 8
 title: A Rosette of Zeros, Drawn by Two CLIs
 description: 'A design log: bending the binary-pyramid column of 0s into an 8-fold rosette using the bikar DSL, then asking qiyas what it saw.'

--- a/bytesofpurpose-blog/designs/2026-06-21-ecommerce-site-scanner-and-lead-generation-engine.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-21-ecommerce-site-scanner-and-lead-generation-engine.mdx
@@ -1,5 +1,6 @@
 ---
 slug: design-ecommerce-site-scanner-and-lead-generation-engine
+sidebar_label: 'Ecommerce Scanner & Lead-Gen'
 sidebar_position: 10
 title: Ecommerce Site Scanner & Lead Generation Engine
 description: >-
@@ -13,7 +14,7 @@ tags:
   - architecture
   - ecommerce
   - lead-generation
-kind: system-design
+kind: backend-design
 draft: false
 source:
   repo: work-git

--- a/bytesofpurpose-blog/designs/2026-06-22-aide.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-aide.mdx
@@ -1,5 +1,6 @@
 ---
 slug: design-aide
+sidebar_label: Aide
 sidebar_position: 13
 title: Aide
 description: >-
@@ -13,7 +14,7 @@ tags:
   - architecture
   - ai-agents
   - saas-delivery
-kind: system-design
+kind: agent-design
 draft: true
 source:
   repo: work-git

--- a/bytesofpurpose-blog/designs/2026-06-22-markdown-review-studio.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-markdown-review-studio.mdx
@@ -1,5 +1,6 @@
 ---
 slug: design-markdown-review-studio
+sidebar_label: Markdown Review Studio
 sidebar_position: 11
 title: Markdown Review Studio
 description: >-
@@ -13,7 +14,7 @@ tags:
   - architecture
   - claude-code
   - developer-tools
-kind: system-design
+kind: tooling-cli-design
 draft: false
 source:
   repo: work-git

--- a/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
@@ -1,5 +1,6 @@
 ---
 slug: design-self-healing-storefront
+sidebar_label: Self-Healing Storefront
 sidebar_position: 12
 title: Self-Healing Storefront
 description: >-
@@ -13,7 +14,7 @@ tags:
   - ai-agents
   - ab-testing
   - cro
-kind: system-design
+kind: backend-design
 draft: false
 source:
   repo: work-git

--- a/bytesofpurpose-blog/designs/2026-06-23-actions-pages-deploy.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-23-actions-pages-deploy.mdx
@@ -1,5 +1,6 @@
 ---
 slug: design-actions-pages-deploy
+sidebar_label: Pages Deploy Pipeline
 sidebar_position: 14
 title: Building a Pages Deploy That Consumes a Private Package
 description: >-
@@ -14,7 +15,7 @@ tags:
   - github-actions
   - github-pages
   - devops
-kind: system-design
+kind: backend-design
 draft: false
 ---
 

--- a/bytesofpurpose-blog/designs/2026-06-25-build-system.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-25-build-system.mdx
@@ -3,7 +3,7 @@ slug: design-build-system
 sidebar_position: 15
 title: The Build System Behind This Blog
 sidebar_label: Build System
-kind: reference
+kind: tooling-cli-design
 description: >-
   How this Docusaurus site builds itself from content: the folder layout, the
   one generate-assets step that turns frontmatter into data, what each generator

--- a/bytesofpurpose-blog/designs/2026-06-26-vestaboard-flash-hero.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-26-vestaboard-flash-hero.mdx
@@ -2,8 +2,8 @@
 slug: design-vestaboard-flash-hero
 sidebar_position: 16
 title: 'The Departure-Board Hero: a Vestaboard split-flap + camera flash'
-sidebar_label: 'Vestaboard hero'
-kind: design-story
+sidebar_label: Vestaboard Hero
+kind: frontend-design
 description: >-
   The story behind the homepage camera-flash hero: an arched portal whose scene
   cross-fades behind a flash of light, captioned by a Vestaboard split-flap board

--- a/bytesofpurpose-blog/designs/2026-06-27-building-masks-with-claude.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-27-building-masks-with-claude.mdx
@@ -2,7 +2,7 @@
 slug: design-building-masks-with-claude
 sidebar_position: 17
 title: 'Building Masks with Claude: a drag-to-URL tuning loop'
-sidebar_label: 'Building masks with Claude'
+sidebar_label: Building Masks
 description: >-
   How a slow edit-restart-screenshot loop for pinning an arched image mask
   became a fast one: a dev-only panel whose drag handles write to the URL, a
@@ -15,7 +15,7 @@ tags:
   - frontend
   - tooling
   - workflow
-kind: design-story
+kind: frontend-design
 date: 2026-06-27
 draft: true
 ---

--- a/bytesofpurpose-blog/designs/2026-06-28-lebanese-house-hero.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-28-lebanese-house-hero.mdx
@@ -2,8 +2,8 @@
 slug: design-lebanese-house-hero
 sidebar_position: 18
 title: 'The House Hero: a Lebanese home you scroll through'
-sidebar_label: 'House hero'
-kind: design-story
+sidebar_label: House Hero
+kind: frontend-design
 description: >-
   How the departure-board hero became a traditional Lebanese central-hall home,
   and the pivot to a scroll-driven parallax journey through the scenes.

--- a/bytesofpurpose-blog/scripts/lib/blog-kinds.json
+++ b/bytesofpurpose-blog/scripts/lib/blog-kinds.json
@@ -121,6 +121,41 @@
         {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
       ]
     },
+    "frontend-design": {
+      "emoji": "🎨",
+      "description": "A FRONTEND/experience design (a /designs post): UI, interaction, components, visual systems — heroes, the sidebar, mockup-driven surfaces. Structurally a client/render concern (layout, motion, state, a11y), distinct from a service architecture.",
+      "outline": [
+        {"id": "mockup", "label": "a UX mockup or visual (a <Mockup>/<Gif> in the body, or a `mockups:` frontmatter sidecar link)"},
+        {"id": "decisions", "label": "a Decisions section (a heading like \"Key Decisions\" / \"Decisions\" / \"Trade-offs\")"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "backend-design": {
+      "emoji": "⚙️",
+      "description": "A BACKEND/systems design (a /designs post): services, pipelines, data, infra, deploy — the server-side architecture. Structurally a service/data concern (components, flows, storage, failure modes), distinct from a UI design.",
+      "outline": [
+        {"id": "architecture", "label": "an architecture view (a diagram, a <DiagramWithFootnotes>, or a components/flow breakdown)"},
+        {"id": "decisions", "label": "a Decisions section (a heading like \"Key Decisions\" / \"Decisions\" / \"Trade-offs\")"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "agent-design": {
+      "emoji": "🤖",
+      "description": "An AI/AGENT design (a /designs post): an autonomous or LLM-driven system — the agent loop, tools, prompts, guardrails. Structurally an agent concern (capabilities, control flow, evaluation), distinct from a plain backend service.",
+      "outline": [
+        {"id": "agent-loop", "label": "the agent's loop/capabilities (the control flow, tools, or responsibilities it has)"},
+        {"id": "decisions", "label": "a Decisions section (a heading like \"Key Decisions\" / \"Decisions\" / \"Trade-offs\")"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
+    "tooling-cli-design": {
+      "emoji": "🛠️",
+      "description": "A TOOLING/CLI/script design (a /designs post): a CLI, generator, build step, or dev tool — often a small drawing/checking/build recipe. Structurally a tool concern (inputs, the transform, the output it produces), distinct from a running service or a UI.",
+      "outline": [
+        {"id": "tool-io", "label": "the tool's inputs->output (what it consumes, the transform/recipe, and what it produces)"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
     "tutorial": {
       "emoji": "🧪",
       "description": "A hands-on, learn-by-doing walkthrough ('A Hands-On Way to', 'Teaching X', 'Running X Locally').",

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -67,8 +67,13 @@ function outlineExpectations(kind) {
 
 // Sidebar-label length budget. The kind emoji is added automatically, so these bound the
 // TEXT only. ~3 words / ~32 chars keeps a Posts-sidebar entry to a single tidy line.
+// /designs entries get a LOOSER budget (5 content words / 44 chars): a design needs room to
+// name BOTH the artifact and signal its kind (e.g. "Self-Healing Storefront Backend"), and the
+// designs sidebar is a reference index, not a dense post stream.
 const MAX_LABEL_WORDS = 3;
 const MAX_LABEL_CHARS = 32;
+const MAX_LABEL_WORDS_DESIGNS = 5;
+const MAX_LABEL_CHARS_DESIGNS = 44;
 
 // Drop a leading emoji (+ trailing space) so the length check measures the words a human
 // reads, not the auto-prepended kind glyph.
@@ -127,6 +132,19 @@ const CHECKS = {
   mockup: (fm, body) => Boolean(fm.mockups) || /<Mockup[\s>]/.test(body),
   decisions: (fm, body) =>
     /^#{1,4}\s+.*\b(key decisions?|decisions?|trade[-\s]?offs?)\b/im.test(body),
+  // backend-design: an architecture view (a diagram component, a mermaid fence, or a flow/components heading)
+  architecture: (fm, body) =>
+    /<DiagramWithFootnotes[\s>]/.test(body) ||
+    /```mermaid/.test(body) ||
+    /^#{1,4}\s+.*\b(architecture|components?|data ?flow|flow|pipeline|system)\b/im.test(body),
+  // agent-design: the agent's loop / capabilities / tools
+  'agent-loop': (fm, body) =>
+    /^#{1,4}\s+.*\b(agent|loop|tools?|capabilit|control ?flow|prompts?|guardrails?|responsibilit)\b/im.test(body) ||
+    /\*\*(tools?|capabilit|the loop)\b/im.test(body),
+  // tooling-cli-design: the tool's inputs -> output (the transform / recipe it runs)
+  'tool-io': (fm, body) =>
+    /^#{1,4}\s+.*\b(input|output|usage|how it works|the recipe|the transform|cli|command|pipeline)\b/im.test(body) ||
+    /```(bash|sh|console|shell|js|ts|python|json)?\n/.test(body),
   // design-story
   'links-to-design': (fm, body) =>
     /\]\(\/designs\/[^)\s]+\)/.test(body) || /\/designs\b/.test(body),
@@ -282,14 +300,18 @@ function checkFile(file) {
       (usingLabel ? fm.sidebar_label : fm.title || '').toString().trim(),
     );
     const words = contentWordCount(labelText); // particles (the/of/and/is…) don't count
-    if (labelText && (words > MAX_LABEL_WORDS || labelText.length > MAX_LABEL_CHARS)) {
+    // /designs gets the looser budget (a design names both the artifact + its kind).
+    const isDesigns = /\/designs\//.test(file);
+    const maxWords = isDesigns ? MAX_LABEL_WORDS_DESIGNS : MAX_LABEL_WORDS;
+    const maxChars = isDesigns ? MAX_LABEL_CHARS_DESIGNS : MAX_LABEL_CHARS;
+    if (labelText && (words > maxWords || labelText.length > maxChars)) {
       findings.push({
         file: path.relative(ROOT, file),
         kind,
         id: 'long-sidebar-label',
         detail: usingLabel
-          ? `sidebar_label "${labelText}" is long (${words} content words / ${labelText.length} chars). Aim for <= ${MAX_LABEL_WORDS} content words.`
-          : `no \`sidebar_label:\` and the title is long (${words} content words / ${labelText.length} chars) for the sidebar. Add a short \`sidebar_label:\` (<= ${MAX_LABEL_WORDS} content words); the full title stays on the page.`,
+          ? `sidebar_label "${labelText}" is long (${words} content words / ${labelText.length} chars). Aim for <= ${maxWords} content words.`
+          : `no \`sidebar_label:\` and the title is long (${words} content words / ${labelText.length} chars) for the sidebar. Add a short \`sidebar_label:\` (<= ${maxWords} content words); the full title stays on the page.`,
       });
     }
   }


### PR DESCRIPTION
## What & why

The `/designs` sidebar showed **long full titles** with no signal of *what* each design is (an agent? a system? a UI? a CLI?), and several posts had no `kind:` (so no type emoji). Example you flagged: `/designs/design-rosette-of-zeros` rendered as the long title "A Rosette of Zeros, Drawn by Two CLIs" with nothing telling a reader it's a tooling/CLI design.

Per your direction: the short sidebar label should **signal the artifact's KIND, organized by structural nature**, in **≤5 non-particle words**. **Slugs/URLs are untouched** (no redirects, zero SEO risk — the `design-` echo lives only in the slug, separate from the label).

## Changes
1. **4 new structural design kinds** in `blog-kinds.json` (the source of truth; the draft-docs plugin auto-derives the sidebar emoji from `kind:`):
   - `frontend-design` 🎨 — UI/experience/components (heroes, sidebar, masks)
   - `backend-design` ⚙️ — services/pipelines/infra (scanner, storefront, deploy, gating)
   - `agent-design` 🤖 — AI/agent systems (GenAI agent, build agents, Aide)
   - `tooling-cli-design` 🛠️ — CLIs/generators/build tools (rosette, logo, build system)

   Each has a description of what makes it *structurally* distinct + an outline.
2. **Lockstep:** added the matching outline tests to `validate-post-outline.js` CHECKS (`architecture` / `agent-loop` / `tool-io`) so the new outline ids are covered (no "no test in CHECKS" slip).
3. **Looser label budget for `/designs`:** 5 content words / 44 chars (`MAX_LABEL_WORDS_DESIGNS`) — a design names both the artifact and its kind; other instances keep the 3-word budget.
4. **All 19 `/designs` posts** get `kind:` + a short `sidebar_label:`. The sidebar now reads e.g. **"🛠️ Rosette of Zeros"**, **"⚙️ Self-Healing Storefront"**, **"🤖 Autonomous Build Agents"**, **"🎨 House Hero"** — scannable by type. Full titles stay as the page H1 / SEO.

## Verification
- `validate-post-outline` clean of **error-tier** (no `unknown-kind` / `long-sidebar-label` / lockstep-slip), exits warn-only.
- The remaining advisories are legitimate per-post outline nudges (a design missing its kind's recommended section, e.g. a backend-design without an architecture diagram) — the intended advisory behavior, not regressions.
- Dev server compiles; `/designs` + the posts serve 200.

## Deferred (per your "labels not slugs" choice)
The `design-` slug echo (`/designs/design-rosette-of-zeros`) is left as-is — renaming would need a `{from,to}` redirect per post. Easy follow-up if you later want clean URLs too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)