### PR TITLE
fix(links): repoint stale links to current IA (zero broken links/anchors)

### DIFF
--- a/bytesofpurpose-blog/changelog/development/2025-01-15-component-creation-svg-kanban.md
+++ b/bytesofpurpose-blog/changelog/development/2025-01-15-component-creation-svg-kanban.md
@@ -108,7 +108,7 @@ import KanbanExample from '@site/static/img/kanban-example.svg';
 ## Related Links
 
 - [Kanban Board Customization Blog Post](/craft/productivity/prompts/kanban-board-customization)
-- [Kanban Customization Documentation](/craft/blogging/embed-diagrams/diagrams-kanban-customization)
+- [Kanban Customization Documentation](/handbook/components/diagrams/diagrams-kanban-customization)
 - [Customization Prompt](https://github.com/omars-lab/omars-lab.github.io/blob/master/prompts/draw/customize-kanban-board.md)
 - [Base SVG Template](/img/kanban-structure.svg)
 

--- a/bytesofpurpose-blog/docs/craft/premium-gating-demo.mdx
+++ b/bytesofpurpose-blog/docs/craft/premium-gating-demo.mdx
@@ -5,6 +5,10 @@ description: A live demo of premium content. The rest of this page unlocks when 
 premium: true
 premium_teaser: This is premium content. Sign in with LinkedIn to read the rest.
 draft: false
+# The only heading ("The gated body") lives inside the premium body, which is encrypted
+# away at build. So the auto-TOC's link to #the-gated-body resolves to a heading that
+# isn't in the shipped HTML (a broken anchor). Hide the TOC: there's nothing ungated to list.
+hide_table_of_contents: true
 ---
 
 ## The gated body

--- a/bytesofpurpose-blog/docs/craft/product-management/ideas/README.mdx
+++ b/bytesofpurpose-blog/docs/craft/product-management/ideas/README.mdx
@@ -26,7 +26,7 @@ The dividing line is whether I have **acted on** the idea, not whether it is fin
 This page is the **durable** half: the board that indexes the unactioned ideas and the framework
 for maturing them. The idea **posts themselves** are temporal, so they live on the
 [Thoughts & Ideas](/thoughts) blog. It is exactly the same split the
-[Experiments](/product-management/experiments) page uses, where the durable board lives here in
+[Experiments](/craft/product-management/experiments) page uses, where the durable board lives here in
 Craft and the dated experiment posts live on a blog.
 
 ## The Ideas board

--- a/bytesofpurpose-blog/docs/craft/product-management/research/README.md
+++ b/bytesofpurpose-blog/docs/craft/product-management/research/README.md
@@ -31,7 +31,7 @@ post's frontmatter, so the board can never drift from the posts it indexes. Clic
 This page is the **durable** half: the board that indexes the research and the framework for how I
 run an investigation. The research **posts themselves** are temporal, so they live on the
 [Thoughts](/thoughts) blog (each a card above), exactly the same split the
-[Experiments](/product-management/experiments) and [Ideas](/product-management/ideas) boards use.
+[Experiments](/craft/product-management/experiments) and [Ideas](/craft/product-management/ideas) boards use.
 A research that concludes in a lasting lesson distills up into the relevant Craft topic; one that
 leads to building something graduates into an Initiative.
 

--- a/bytesofpurpose-blog/docs/handbook/components/README.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/README.mdx
@@ -15,12 +15,12 @@ demonstrates the technique, and in time links to the posts that actually leverag
 
 The components are grouped by what they embed:
 
-- **🏗️ [Structural Components](/components/structural):** the building blocks: cards, details,
+- **🏗️ [Structural Components](/handbook/components/structural):** the building blocks: cards, details,
   buttons, headers, footers, graphs, highlights, timelines, tables of contents, and more.
-- **🖼️ [Diagrams](/components/diagrams):** mermaid, PlantUML sequences, flow charts, Figma,
+- **🖼️ [Diagrams](/handbook/components/diagrams):** mermaid, PlantUML sequences, flow charts, Figma,
   Google Drawings, Kanban customization.
-- **💻 [Code](/components/code):** code cells, GitHub gists, Jupyter notebooks.
-- **🔗 [External Components](/components/external):** embedding HTML, React elements, images,
+- **💻 [Code](/handbook/components/code):** code cells, GitHub gists, Jupyter notebooks.
+- **🔗 [External Components](/handbook/components/external):** embedding HTML, React elements, images,
   SVGs, and YouTube videos.
 
 This reference lives under the [Legend](/handbook) because it is part of how the site works: the

--- a/bytesofpurpose-blog/docs/handbook/components/code/README.md
+++ b/bytesofpurpose-blog/docs/handbook/components/code/README.md
@@ -32,7 +32,7 @@ Code embedding techniques are **methods for adding code to content**:
 
 ## Key Documents
 
-- [Code Cells](/craft/blogging/embed-code/code-cells) - Creating and embedding interactive code cells
-- [Code Gists](/craft/blogging/embed-code/code-gists) - GitHub Gist integration and embedding
-- [Jupyter Notebooks](/craft/blogging/embed-code/code-jupyter-notebooks) - Embedding Jupyter notebooks in blog posts
+- [Code Cells](/handbook/components/code/code-cells) - Creating and embedding interactive code cells
+- [Code Gists](/handbook/components/code/code-gists) - GitHub Gist integration and embedding
+- [Jupyter Notebooks](/handbook/components/code/code-jupyter-notebooks) - Embedding Jupyter notebooks in blog posts
 

--- a/bytesofpurpose-blog/docs/handbook/components/diagrams/README.md
+++ b/bytesofpurpose-blog/docs/handbook/components/diagrams/README.md
@@ -43,11 +43,11 @@ Blogging diagram embedding emphasizes visual presentation, while documentation t
 
 ## Key Documents
 
-- [Figma Diagrams](/craft/blogging/embed-diagrams/diagrams-figma) - Embedding Figma designs and prototypes
-- [Flow Charts](/craft/blogging/embed-diagrams/diagrams-flow-charts) - Creating and embedding flow charts
-- [Google Drawing](/craft/blogging/embed-diagrams/diagrams-google-drawing) - Using Google Drawings for diagrams
-- [Kanban Customization](/craft/blogging/embed-diagrams/diagrams-kanban-customization) - Customizing and embedding Kanban boards
-- [Mermaid Diagrams](/craft/blogging/embed-diagrams/diagrams-mermaid) - Mermaid diagram integration and syntax
-<!-- - [MindNode](/craft/blogging/embed-diagrams/diagrams-mindnode) - Mind mapping with MindNode -->
-- [PlantUML Sequence Diagrams](/craft/blogging/embed-diagrams/diagrams-puml-sequence) - Creating sequence diagrams with PlantUML
+- [Figma Diagrams](/handbook/components/diagrams/diagrams-figma) - Embedding Figma designs and prototypes
+- [Flow Charts](/handbook/components/diagrams/diagrams-flow-charts) - Creating and embedding flow charts
+- [Google Drawing](/handbook/components/diagrams/diagrams-google-drawing) - Using Google Drawings for diagrams
+- [Kanban Customization](/handbook/components/diagrams/diagrams-kanban-customization) - Customizing and embedding Kanban boards
+- [Mermaid Diagrams](/handbook/components/diagrams/diagrams-mermaid) - Mermaid diagram integration and syntax
+<!-- - [MindNode](/handbook/components/diagrams/diagrams-mindnode) - Mind mapping with MindNode -->
+- [PlantUML Sequence Diagrams](/handbook/components/diagrams/diagrams-puml-sequence) - Creating sequence diagrams with PlantUML
 

--- a/bytesofpurpose-blog/docs/handbook/components/external/README.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/external/README.mdx
@@ -42,9 +42,9 @@ External components focus on media and custom elements, while structural compone
 
 ## Key Documents
 
-<!-- - [HTML Elements](/craft/blogging/embed-external-components/html) - Embedding custom HTML elements -->
-- [HTML React Elements](/craft/blogging/embed-external-components/html-react-elements) - Embedding React components
-<!-- - [Images - PNGs](/craft/blogging/embed-external-components/images-pngs) - PNG image embedding and optimization -->
-- [Images - SVGs](/craft/blogging/embed-external-components/images-svgs) - SVG implementation and embedding
-- [Videos - YouTube](/craft/blogging/embed-external-components/videos-youtube) - YouTube video embedding
-- [Tips](/craft/blogging/embed-external-components/tips) - Tips and best practices for embedding external components
+<!-- - [HTML Elements](/handbook/components/external/html) - Embedding custom HTML elements -->
+- [HTML React Elements](/handbook/components/external/html-react-elements) - Embedding React components
+<!-- - [Images - PNGs](/handbook/components/external/images-pngs) - PNG image embedding and optimization -->
+- [Images - SVGs](/handbook/components/external/images-svgs) - SVG implementation and embedding
+- [Videos - YouTube](/handbook/components/external/videos-youtube) - YouTube video embedding
+- [Tips](/handbook/components/external/tips) - Tips and best practices for embedding external components

--- a/bytesofpurpose-blog/docs/handbook/components/structural/README.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/README.mdx
@@ -15,18 +15,18 @@ A collection of reusable structural components for blog posts and documentation.
 
 ## Components
 
-<!-- - [Frontmatter](/craft/blogging/embed-structural-components/adding-frontmatter) - Frontmatter configuration -->
-- [Card](/craft/blogging/embed-structural-components/card) - Card component
-- [Details](/craft/blogging/embed-structural-components/details) - Details component
-- [Fancy Button](/craft/blogging/embed-structural-components/fancy-button) - Fancy Button component
-- [Footer](/craft/blogging/embed-structural-components/footer) - Footer component
-- [Graph Renderer Component](/craft/blogging/embed-structural-components/graph) - Graph Renderer Component
-- [Header](/craft/blogging/embed-structural-components/header) - Header component
-- [Highlight](/craft/blogging/embed-structural-components/highlight) - Highlight component
-- [Linking Posts](/craft/blogging/embed-structural-components/links) - Linking Posts
-- [Table of Contents](/craft/blogging/embed-structural-components/table-of-content) - Table of Contents
-- [Timeline](/craft/blogging/embed-structural-components/timeline) - Timeline component
-- [Truncating](/craft/blogging/embed-structural-components/adding-truncate-sections) - Truncating sections
+<!-- - [Frontmatter](/handbook/components/structural/adding-frontmatter) - Frontmatter configuration -->
+- [Card](/handbook/components/structural/card) - Card component
+- [Details](/handbook/components/structural/details) - Details component
+- [Fancy Button](/handbook/components/structural/fancy-button) - Fancy Button component
+- [Footer](/handbook/components/structural/footer) - Footer component
+- [Graph Renderer Component](/handbook/components/structural/graph) - Graph Renderer Component
+- [Header](/handbook/components/structural/header) - Header component
+- [Highlight](/handbook/components/structural/highlight) - Highlight component
+- [Linking Posts](/handbook/components/structural/links) - Linking Posts
+- [Table of Contents](/handbook/components/structural/table-of-content) - Table of Contents
+- [Timeline](/handbook/components/structural/timeline) - Timeline component
+- [Truncating](/handbook/components/structural/adding-truncate-sections) - Truncating sections
 
 ---
 

--- a/bytesofpurpose-blog/docs/handbook/components/structural/links.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/links.mdx
@@ -20,7 +20,7 @@ All point to the same file ...
         * ❌⛓️‍💥: /2-mechanics/docusaurus-mechanics/start-here.mdx
         * ❌⛓️‍💥: start-here.mdx
     * using final url path / slug ...
-        * [✅🔗](../embed-external-components/tips) `[](../embed-external-components/tips)`
+        * [✅🔗](../external/tips) `[](../external/tips)`
         * [✅🔗](./README.mdx) `[](./README.mdx)`
 * Don't work
     * ❌⛓️‍💥: ./start-here

--- a/bytesofpurpose-blog/docs/journey/self-reflection/README.mdx
+++ b/bytesofpurpose-blog/docs/journey/self-reflection/README.mdx
@@ -29,7 +29,7 @@ power icons on each question mean:
 The individual question sets are temporal, so they live as posts on the Initiatives blog,
 collected under one tag. Browse them all here:
 
-- **[All "ask myself" question sets](/initiatives/tags/ask-myself)**: the full collection,
+- **[All "ask myself" question sets](/questions/tags/ask-myself)**: the full collection,
   from finding your purpose to reflecting on your worth.
 
 Pick the one whose title stings a little. That is usually the one to start with.


### PR DESCRIPTION
## What & why

The production deploy build logged broken-link + broken-anchor **warnings** (non-blocking, pre-existing). All were stale links pointing at an **old blogging-docs IA**, plus one premium-gating anchor artifact. This clears them so the build reports **zero broken links / anchors**.

## Fixes
- **`/craft/blogging/embed-{structural,external,diagrams,code}-components/*` → `/handbook/components/{structural,external,diagrams,code}/*`** — the handbook component reference pages moved instances; the READMEs (+ the `structural/links` demo `../external/tips` + a changelog entry) still pointed at the old paths.
- **`/components/*` → `/handbook/components/*`** — the components index linked without the `/handbook` prefix.
- **`/product-management/*` → `/craft/product-management/*`** — ideas/research README links missing the `/craft` prefix.
- **`/initiatives/tags/ask-myself` → `/questions/tags/ask-myself`** — the `ask-myself` tag lives on the Questions instance, not Initiatives.
- **`premium-gating-demo` `#the-gated-body` anchor** — the page's only heading is inside the encrypted `premium: true` body, so the auto-TOC linked to a heading absent from the shipped HTML. `hide_table_of_contents: true` (nothing ungated to list).

## Verification
Full production build (`yarn build`) now reports **ZERO broken links and ZERO broken anchors** (was ~30 broken links + 1 anchor). No content moved — link targets only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)