### PR TITLE
fix(hero): eager-load above-the-fold house images (no pop-in)

### DIFF
--- a/bytesofpurpose-blog/playwright.config.ts
+++ b/bytesofpurpose-blog/playwright.config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
       // graph-* specs + the DebugMenu spec. The DebugMenu renders ONLY on the
       // dev server (localhost + non-prod build) — it's stripped from prod — so it
       // must run here against :3000, not the build-backed projects.
-      testMatch: /(graph-.*|debug-menu|draft-sidebar|blog-draft-badge|craft-self-split|navbar-auth|reconstruction-posts|co-design-imports|showcase-components|homepage)\.spec\.ts$/,
+      testMatch: /(graph-.*|debug-menu|draft-sidebar|blog-draft-badge|craft-self-split|navbar-auth|reconstruction-posts|co-design-imports|showcase-components|homepage|hero-loading)\.spec\.ts$/,
       use: { ...devices['Desktop Firefox'], baseURL: DEV_BASE },
     },
     {

--- a/bytesofpurpose-blog/src/pages/index.tsx
+++ b/bytesofpurpose-blog/src/pages/index.tsx
@@ -784,7 +784,8 @@ function StudioFacade({
               src={useBaseUrl('/img/cards/window.png')}
               alt=""
               aria-hidden="true"
-              loading="lazy"
+              loading="eager"
+              decoding="async"
               width={400}
               height={400}
             />
@@ -825,7 +826,9 @@ function StudioFacade({
                 src={useBaseUrl('/img/cards/door.png')}
                 alt=""
                 aria-hidden="true"
-                loading="lazy"
+                loading="eager"
+                decoding="async"
+                fetchPriority="high"
                 width={400}
                 height={400}
               />
@@ -841,7 +844,11 @@ function StudioFacade({
                     className={clsx(styles.studioPeekImg, i === shown && styles.studioPeekImgActive)}
                     src={useBaseUrl(card.img)}
                     alt=""
-                    loading="lazy"
+                    // The FIRST scene is above-the-fold on load (the door opens onto it); eager-load it
+                    // so the arch isn't briefly empty. The other 6 scenes stay lazy (only the active one
+                    // is ever visible, swapped via opacity).
+                    loading={i === 0 ? 'eager' : 'lazy'}
+                    decoding="async"
                     width={400}
                     height={400}
                   />
@@ -861,7 +868,8 @@ function StudioFacade({
               src={useBaseUrl('/img/cards/window.png')}
               alt=""
               aria-hidden="true"
-              loading="lazy"
+              loading="eager"
+              decoding="async"
               width={400}
               height={400}
             />

--- a/bytesofpurpose-blog/test/e2e/hero-loading.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/hero-loading.spec.ts
@@ -1,0 +1,63 @@
+import {test, expect} from '@playwright/test';
+
+/**
+ * Hero image loading (dev project, :3000).
+ *
+ * The house hero sits ABOVE the fold, so its always-visible images must load EAGERLY (not lazy, or
+ * the arches/windows/door pop in after paint). This asserts the shipped attributes on the studio
+ * (variant_c) house: the two window arches + the centre door + the first scene are loading="eager"
+ * (the door also fetchpriority=high), while the non-initial scene layers stay lazy. Guards against a
+ * regression back to loading="lazy" on the focal hero art.
+ */
+
+test.describe('Hero image loading', () => {
+  test('house hero: above-the-fold arch images are eager (door high priority)', async ({page}) => {
+    await page.goto('/?ab-homepage-hero-anim=variant_c', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    // The always-visible arch images (2 windows + door) + the first scene.
+    const archImgs = page.locator('[class*="studioArchImg"], [class*="studioPeekImgActive"]');
+    await expect(archImgs.first()).toBeVisible({timeout: 15000});
+
+    const imgs = await archImgs.evaluateAll((els) =>
+      els.map((e) => {
+        const img = e as HTMLImageElement;
+        return {
+          src: (img.getAttribute('src') || '').split('/').pop(),
+          loading: img.loading,
+          fetchPriority: img.getAttribute('fetchpriority') || (img as any).fetchPriority,
+          complete: img.complete,
+          naturalWidth: img.naturalWidth,
+        };
+      }),
+    );
+
+    // Every above-the-fold arch image is eager AND actually decoded (no empty slot on first paint).
+    expect(imgs.length).toBeGreaterThanOrEqual(3);
+    for (const img of imgs) {
+      expect(img.loading, `${img.src} should be eager`).toBe('eager');
+      expect(img.complete, `${img.src} should be decoded`).toBe(true);
+      expect(img.naturalWidth, `${img.src} should have loaded`).toBeGreaterThan(0);
+    }
+
+    // The centre door is the focal image → high fetch priority.
+    const door = imgs.find((i) => i.src === 'door.png');
+    expect(door, 'the door image should be present').toBeTruthy();
+    expect(door!.fetchPriority).toBe('high');
+  });
+
+  test('non-initial scene layers stay lazy (only the focal art is eager)', async ({page}) => {
+    await page.goto('/?ab-homepage-hero-anim=variant_c', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    // Across all hero <img>s there is at least one lazy image (the deferred scenes / pan backdrop),
+    // proving we eager-loaded selectively rather than making everything eager.
+    const anyLazy = await page
+      .locator('header img[loading="lazy"], .navbar ~ * img[loading="lazy"]')
+      .count()
+      .catch(() => 0);
+    const lazyOnPage = await page.locator('img[loading="lazy"]').count();
+    expect(lazyOnPage).toBeGreaterThan(0);
+    void anyLazy;
+  });
+});


### PR DESCRIPTION
## What & why

Prod observation: the house hero's arches/windows/door **popped in** only once their images decoded. The cause: the hero `<img>`s used `loading="lazy"` — which is actively wrong for **above-the-fold** content (the hero is tuned to sit above the fold, per the `maintain-homepage-hero` gotchas). `lazy` told the browser to *defer* the most-important images, leaving empty arch slots on first paint.

## Fix
Make the always-visible house images eager (load-priority only — no visual/structural change):
- **Side-window arches (`window.png` ×2)** and the **centre door (`door.png`)**: `loading="eager"` + `decoding="async"`. The door also gets `fetchPriority="high"` (React 19 camelCase) as the focal image.
- **First scene (`i === 0`)**: eager (the door opens onto it). Scenes 2–7 stay lazy — only the active one is ever visible, swapped via opacity.

Still lazy (correctly): the rotating scene layers, the boutique/flash-variant peeks, and the parallax depth-backdrop pan images (off-screen / non-initial).

**No masks, gradients, transforms, or filters touched** — so none of the hero's DPR-seam gotchas are in play.

## Verification
- `validate-hero-anchors` → 40/40 green.
- Live DOM (variant_c): all 4 above-the-fold arch images show `loading="eager"`, `complete: true`, decoded (`naturalWidth 1024`); door `fetchPriority: high`.
- Dev compiles; home serves 200.

Note: this is the pragmatic fix for the reported pop-in. A fuller arch-shaped CSS placeholder behind each slot was considered but deferred — the door arch is a seam-sensitive multi-layer GPU stack (gotcha #15), and eager-loading resolves the perceptible pop-in without touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)