### PR TITLE
feat(navbar): priority+ overflow menu (no more hamburger collapse)

### DIFF
--- a/bytesofpurpose-blog/playwright.config.ts
+++ b/bytesofpurpose-blog/playwright.config.ts
@@ -77,7 +77,7 @@ export default defineConfig({
       // graph-* specs + the DebugMenu spec. The DebugMenu renders ONLY on the
       // dev server (localhost + non-prod build) — it's stripped from prod — so it
       // must run here against :3000, not the build-backed projects.
-      testMatch: /(graph-.*|debug-menu|draft-sidebar|blog-draft-badge|craft-self-split|navbar-auth|reconstruction-posts|co-design-imports|showcase-components|homepage|hero-loading)\.spec\.ts$/,
+      testMatch: /(graph-.*|debug-menu|draft-sidebar|blog-draft-badge|craft-self-split|navbar-auth|navbar-overflow|reconstruction-posts|co-design-imports|showcase-components|homepage|hero-loading)\.spec\.ts$/,
       use: { ...devices['Desktop Firefox'], baseURL: DEV_BASE },
     },
     {

--- a/bytesofpurpose-blog/src/theme/Navbar/Content/NavbarItemsOverflow.tsx
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/NavbarItemsOverflow.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {ErrorCauseBoundary} from '@docusaurus/theme-common';
 import NavbarItem from '@theme/NavbarItem';
+import {computeVisibleCount} from './overflowFit';
 import styles from './styles.module.css';
 
 // Priority+ navbar: keep the left items on ONE line, and when they don't all fit, fold the
@@ -15,34 +16,9 @@ import styles from './styles.module.css';
 
 type Item = {label?: string; [k: string]: unknown};
 
-/**
- * Pure priority+ fit: given each item's measured width, the available row width, and the width to
- * reserve for the "More" trigger, return how many LEADING items stay inline. Exported so it can be
- * unit-tested without a DOM.
- *
- * - Everything fits (sum <= available) → all items inline (no More trigger, so no reserve needed).
- * - Otherwise greedily fit leading items within (available - reserve); the rest overflow.
- * - Always keep at least 1 item inline (never a lonely "More" on a wide-ish bar).
- */
-export function computeVisibleCount(
-  widths: number[],
-  available: number,
-  reserve: number,
-): number {
-  const total = widths.reduce((a, b) => a + b, 0);
-  if (total <= available) return widths.length;
-  let used = 0;
-  let count = 0;
-  for (let i = 0; i < widths.length; i++) {
-    if (used + widths[i] <= available - reserve) {
-      used += widths[i];
-      count++;
-    } else {
-      break;
-    }
-  }
-  return Math.max(1, count);
-}
+// The pure greedy fit (computeVisibleCount) lives in ./overflowFit so it can be unit-tested without
+// loading React / the Docusaurus theme. Re-export for anything importing it from here historically.
+export {computeVisibleCount} from './overflowFit';
 
 // One item wrapped in the upstream error boundary (a bad item can't crash the whole nav).
 function SafeItem({item, isDropdownItem}: {item: Item; isDropdownItem?: boolean}) {

--- a/bytesofpurpose-blog/src/theme/Navbar/Content/NavbarItemsOverflow.tsx
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/NavbarItemsOverflow.tsx
@@ -1,0 +1,184 @@
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {ErrorCauseBoundary} from '@docusaurus/theme-common';
+import NavbarItem from '@theme/NavbarItem';
+import styles from './styles.module.css';
+
+// Priority+ navbar: keep the left items on ONE line, and when they don't all fit, fold the
+// RIGHTMOST ones into a "More ▾" dropdown. Order is preserved (leftmost = highest priority,
+// stays inline longest), so a user still sees the primary destinations and reaches the rest in
+// one click; instead of the whole nav collapsing to the mobile hamburger the moment it's tight.
+//
+// SSR-SAFE: the FIRST render (server + hydration) renders EVERY item inline, identical to
+// upstream, so there's no hydration mismatch and the nav works with JS off. Only AFTER mount do
+// we measure widths and fold; a client-only enhancement. A ResizeObserver re-folds on width
+// changes (resize, zoom, font/emoji reflow).
+
+type Item = {label?: string; [k: string]: unknown};
+
+/**
+ * Pure priority+ fit: given each item's measured width, the available row width, and the width to
+ * reserve for the "More" trigger, return how many LEADING items stay inline. Exported so it can be
+ * unit-tested without a DOM.
+ *
+ * - Everything fits (sum <= available) → all items inline (no More trigger, so no reserve needed).
+ * - Otherwise greedily fit leading items within (available - reserve); the rest overflow.
+ * - Always keep at least 1 item inline (never a lonely "More" on a wide-ish bar).
+ */
+export function computeVisibleCount(
+  widths: number[],
+  available: number,
+  reserve: number,
+): number {
+  const total = widths.reduce((a, b) => a + b, 0);
+  if (total <= available) return widths.length;
+  let used = 0;
+  let count = 0;
+  for (let i = 0; i < widths.length; i++) {
+    if (used + widths[i] <= available - reserve) {
+      used += widths[i];
+      count++;
+    } else {
+      break;
+    }
+  }
+  return Math.max(1, count);
+}
+
+// One item wrapped in the upstream error boundary (a bad item can't crash the whole nav).
+function SafeItem({item, isDropdownItem}: {item: Item; isDropdownItem?: boolean}) {
+  return (
+    <ErrorCauseBoundary
+      onError={(error) =>
+        new Error(
+          `A theme navbar item failed to render.\n${JSON.stringify(item, null, 2)}`,
+          {cause: error},
+        )
+      }>
+      <NavbarItem {...(item as any)} {...(isDropdownItem ? {isDropdownItem: true} : {})} />
+    </ErrorCauseBoundary>
+  );
+}
+
+export default function NavbarItemsOverflow({items}: {items: Item[]}): React.JSX.Element {
+  // How many leading items render inline; the rest fold into "More". Start with ALL inline (=
+  // items.length) so SSR + first client render match upstream exactly.
+  const [visibleCount, setVisibleCount] = useState(items.length);
+  const [mounted, setMounted] = useState(false);
+
+  // Refs to the live containers we measure against.
+  const rowRef = useRef<HTMLDivElement | null>(null); // the visible inline row (available width)
+  const measureRef = useRef<HTMLDivElement | null>(null); // the hidden full-width copy
+  const moreWidthRef = useRef<number>(0); // measured width of the "More" trigger (reserve it)
+
+  // Measure each item's natural width from the hidden copy, then greedily fit as many as possible
+  // into the AVAILABLE width and fold the rest. The available width is the space the left group
+  // has WITHOUT pushing the right group off; i.e. the navbar inner width minus the logo/toggle
+  // that precede us and minus the right group. (We can't use the overflow row's own clientWidth:
+  // it's a content-sized flex child that grows to fit, so it would always report "everything
+  // fits". We compute the real budget from navbar geometry instead.)
+  const compute = useCallback(() => {
+    const row = rowRef.current;
+    const measure = measureRef.current;
+    if (!row || !measure) return;
+
+    // Below the mobile breakpoint the inline items are display:none (Infima); don't fold.
+    if (typeof window !== 'undefined' && window.matchMedia('(max-width: 996px)').matches) {
+      setVisibleCount(items.length);
+      return;
+    }
+
+    const inner = row.closest('.navbar__inner') as HTMLElement | null;
+    const leftContainer = row.closest('.navbar__items') as HTMLElement | null;
+    const rightContainer = inner?.querySelector('.navbar__items--right') as HTMLElement | null;
+    if (!inner || !leftContainer) return;
+
+    // Space already spent by things in the LEFT container that are NOT our overflow row (the logo
+    // and the mobile-sidebar toggle sit before us). EXCLUDE our own overflow row AND the hidden
+    // measurement copy (it's absolutely-positioned but still reports a full-width rect, so counting
+    // it would blow up the budget). Only IN-FLOW siblings count.
+    let leftSiblings = 0;
+    for (const child of Array.from(leftContainer.children)) {
+      if (child === row || child === measure) continue;
+      const el = child as HTMLElement;
+      // skip absolutely-positioned / out-of-flow nodes (they don't consume row width)
+      if (getComputedStyle(el).position === 'absolute') continue;
+      leftSiblings += el.getBoundingClientRect().width;
+    }
+    const rightW = rightContainer ? rightContainer.getBoundingClientRect().width : 0;
+    const GAP = 24; // breathing room so items never butt against the right group
+
+    const avail = inner.clientWidth - leftSiblings - rightW - GAP;
+    const widths = Array.from(measure.children).map(
+      (c) => (c as HTMLElement).getBoundingClientRect().width,
+    );
+    const reserve = moreWidthRef.current || 90; // More-trigger width (fallback until measured)
+    setVisibleCount(computeVisibleCount(widths, Math.max(0, avail), reserve));
+  }, [items.length]);
+
+  // Client-only enhancement: after the component mounts (the measure ruler + real navbar geometry
+  // now exist), fold once and re-fold on every width change. One effect, runs on mount + whenever
+  // `compute` changes (item set). No `mounted` gate needed: effects only run on the client, so the
+  // SSR/first-hydration render already showed all items inline before this fires.
+  useEffect(() => {
+    setMounted(true);
+    let raf = 0;
+    const schedule = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(compute);
+    };
+    // Fold IMMEDIATELY (synchronously in the effect), not only via rAF: in React StrictMode the
+    // effect mounts, cleans up (cancelling the scheduled rAF), then re-mounts, so a fold that lived
+    // only in the rAF could be cancelled and never fire. The immediate call guarantees the first
+    // fold; the rAF then coalesces subsequent width-change recomputes.
+    compute();
+    schedule();
+    const ro = new ResizeObserver(schedule);
+    const inner = rowRef.current?.closest('.navbar__inner');
+    if (inner) ro.observe(inner);
+    else if (rowRef.current) ro.observe(rowRef.current);
+    window.addEventListener('resize', schedule);
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      window.removeEventListener('resize', schedule);
+    };
+  }, [compute]);
+
+  const visible = items.slice(0, visibleCount);
+  const overflow = items.slice(visibleCount);
+
+  // The "More ▾" trigger is a synthetic dropdown navbar item, rendered through the SAME
+  // @theme/NavbarItem so it inherits the site's dropdown styling + click-outside + keyboard.
+  const moreItem: Item = {
+    type: 'dropdown',
+    label: 'More',
+    items: overflow.map((it) => ({...it})),
+  };
+
+  return (
+    <>
+      {/* The visible inline row (measured for available width). */}
+      <div ref={rowRef} className={styles.overflowRow}>
+        {visible.map((item, i) => (
+          <SafeItem key={i} item={item} />
+        ))}
+        {mounted && overflow.length > 0 && (
+          <div ref={(el) => { moreWidthRef.current = el?.getBoundingClientRect().width || moreWidthRef.current; }}
+               className={styles.moreDropdown}>
+            <SafeItem item={moreItem} />
+          </div>
+        )}
+      </div>
+
+      {/* Hidden full-width copy: the ruler we measure every item against. Rendered ALWAYS (it's
+          visibility:hidden + position:absolute, so it's inert and out-of-flow in SSR and client
+          alike) so real item widths are available on the very first post-mount measure (no race
+          waiting for a second render). */}
+      <div ref={measureRef} className={styles.measure} aria-hidden="true">
+        {items.map((item, i) => (
+          <SafeItem key={i} item={item} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/bytesofpurpose-blog/src/theme/Navbar/Content/index.tsx
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/index.tsx
@@ -1,0 +1,111 @@
+/**
+ * Swizzled from @docusaurus/theme-classic Navbar/Content.
+ * The ONLY change from upstream: the LEFT navbar items render through
+ * <NavbarItemsOverflow> (priority+; fold the rightmost into a "More ▾" dropdown
+ * when they don't fit one line) instead of the plain inline list. The right group,
+ * logo, mobile toggle, color-mode toggle, and search are byte-for-byte upstream, so
+ * the `.navbar__items--right` ordering contract + the navbar-auth e2e keep working.
+ */
+import React from 'react';
+import clsx from 'clsx';
+import {
+  useThemeConfig,
+  ErrorCauseBoundary,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {
+  splitNavbarItems,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
+import NavbarItem from '@theme/NavbarItem';
+import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
+import SearchBar from '@theme/SearchBar';
+import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
+import NavbarLogo from '@theme/Navbar/Logo';
+import NavbarSearch from '@theme/Navbar/Search';
+import NavbarItemsOverflow from './NavbarItemsOverflow';
+import styles from './styles.module.css';
+
+function useNavbarItems() {
+  // TODO temporary casting until ThemeConfig type is improved
+  return useThemeConfig().navbar.items as any[];
+}
+
+// Upstream inline list; kept for the RIGHT group (never overflowed).
+function NavbarItems({items}: {items: any[]}): React.JSX.Element {
+  return (
+    <>
+      {items.map((item, i) => (
+        <ErrorCauseBoundary
+          key={i}
+          onError={(error) =>
+            new Error(
+              `A theme navbar item failed to render.
+Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:
+${JSON.stringify(item, null, 2)}`,
+              {cause: error},
+            )
+          }>
+          <NavbarItem {...item} />
+        </ErrorCauseBoundary>
+      ))}
+    </>
+  );
+}
+
+function NavbarContentLayout({
+  left,
+  right,
+}: {
+  left: React.ReactNode;
+  right: React.ReactNode;
+}) {
+  return (
+    <div className="navbar__inner">
+      <div
+        className={clsx(
+          ThemeClassNames.layout.navbar.containerLeft,
+          'navbar__items',
+        )}>
+        {left}
+      </div>
+      <div
+        className={clsx(
+          ThemeClassNames.layout.navbar.containerRight,
+          'navbar__items navbar__items--right',
+        )}>
+        {right}
+      </div>
+    </div>
+  );
+}
+
+export default function NavbarContent(): React.JSX.Element {
+  const mobileSidebar = useNavbarMobileSidebar();
+  const items = useNavbarItems();
+  const [leftItems, rightItems] = splitNavbarItems(items);
+  const searchBarItem = items.find((item) => item.type === 'search');
+  return (
+    <NavbarContentLayout
+      left={
+        <>
+          {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
+          <NavbarLogo />
+          {/* CHANGED vs upstream: priority+ overflow instead of a plain inline list. */}
+          <NavbarItemsOverflow items={leftItems} />
+        </>
+      }
+      right={
+        <>
+          <NavbarItems items={rightItems} />
+          <NavbarColorModeToggle className={styles.colorModeToggle} />
+          {!searchBarItem && (
+            <NavbarSearch>
+              <SearchBar />
+            </NavbarSearch>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/bytesofpurpose-blog/src/theme/Navbar/Content/overflowFit.ts
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/overflowFit.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure priority+ fit for the navbar overflow menu. Zero React / theme imports, so it can be
+ * unit-tested in isolation (no Docusaurus theme deps to resolve).
+ *
+ * Given each left item's measured width, the available row width, and the width to reserve for the
+ * "More" trigger, return how many LEADING items stay inline. The rest fold into "More".
+ *
+ * - Everything fits (sum <= available) → all items inline (no More trigger, so no reserve needed).
+ * - Otherwise greedily fit leading items within (available - reserve); the rest overflow.
+ * - Always keep at least 1 item inline when there IS at least one (never a lonely "More").
+ */
+export function computeVisibleCount(
+  widths: number[],
+  available: number,
+  reserve: number,
+): number {
+  const total = widths.reduce((a, b) => a + b, 0);
+  if (total <= available) return widths.length;
+  let used = 0;
+  let count = 0;
+  for (let i = 0; i < widths.length; i++) {
+    if (used + widths[i] <= available - reserve) {
+      used += widths[i];
+      count++;
+    } else {
+      break;
+    }
+  }
+  return Math.max(1, count);
+}

--- a/bytesofpurpose-blog/src/theme/Navbar/Content/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/styles.module.css
@@ -1,0 +1,54 @@
+/* Swizzled from @docusaurus/theme-classic Navbar/Content/styles.module.css.
+   The upstream rules are preserved verbatim; the overflow-menu rules are added below. */
+
+/* Hide color mode toggle in small viewports (upstream). */
+@media (max-width: 996px) {
+  .colorModeToggle {
+    display: none;
+  }
+}
+
+/* Restore some Infima style that broke with CSS Cascade Layers (upstream).
+   See https://github.com/facebook/docusaurus/pull/11142 */
+:global(.navbar__items--right) > :last-child {
+  padding-right: 0;
+}
+
+/* ── Priority+ overflow menu ────────────────────────────────────────────────
+   The left navbar items stay on ONE line; when they don't all fit, the rightmost
+   fold into a "More ▾" dropdown (measured at runtime). These styles cover the
+   hidden measurement row + keeping the inline row from wrapping before JS runs. */
+
+/* The left items container must never wrap to a second line; if the row is too
+   wide, the overflow JS folds items into the More menu instead of wrapping. */
+.overflowRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap; /* never wrap to a 2nd line; fold into More instead */
+  min-width: 0;
+  overflow: hidden; /* clip rather than push the right group while JS folds */
+}
+
+/* The off-screen measurement copy of the FULL item list. It renders every item at
+   natural width so we can read each item's width, without being visible or
+   interactive and without affecting layout. */
+.measure {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+/* The whole overflow apparatus (inline row + More trigger) is desktop-only; below
+   the mobile breakpoint the default hamburger sidebar takes over and Infima hides
+   .navbar__item, so there is nothing to measure or fold. */
+@media (max-width: 996px) {
+  .measure,
+  .moreDropdown {
+    display: none;
+  }
+}

--- a/bytesofpurpose-blog/test/e2e/navbar-overflow.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/navbar-overflow.spec.ts
@@ -1,0 +1,95 @@
+import {test, expect, type Page} from '@playwright/test';
+
+/**
+ * Navbar priority+ overflow (dev project, :3000).
+ *
+ * The left navbar items stay on ONE line; when they don't all fit, the RIGHTMOST fold into a
+ * "More ▾" dropdown (src/theme/Navbar/Content + NavbarItemsOverflow). Leftmost items keep their
+ * inline priority. Below the mobile breakpoint (<=996px) the default hamburger takes over and the
+ * overflow apparatus is inert. This spec locks that contract across viewport widths.
+ *
+ * The fold is a CLIENT enhancement (measure-on-mount + ResizeObserver), so we set the viewport,
+ * load, and poll until the layout settles.
+ */
+
+const OVERFLOW_ROW = '[class*="overflowRow"]';
+
+// The inline (non-"More") left links currently rendered on one line.
+async function inlineLabels(page: Page): Promise<string[]> {
+  return page.$$eval(`${OVERFLOW_ROW} .navbar__link`, (els) =>
+    els
+      .map((e) => (e.textContent || '').trim())
+      .filter((t) => t && !t.startsWith('More')),
+  );
+}
+
+// The "More" trigger (a dropdown navbar link labelled "More"), or null.
+function moreTrigger(page: Page) {
+  return page.locator(`${OVERFLOW_ROW} .navbar__link`, {hasText: /^More/}).first();
+}
+
+test.describe('Navbar priority+ overflow', () => {
+  test('WIDE (1600px): everything fits inline, no "More" trigger', async ({page}) => {
+    await page.setViewportSize({width: 1600, height: 800});
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    // All primary destinations are inline; no overflow menu.
+    await expect(moreTrigger(page)).toHaveCount(0);
+    const inline = await inlineLabels(page);
+    expect(inline).toContain('💻 Craft');
+    expect(inline).toContain('❤️ Support'); // the rightmost item is inline when there's room
+    // Single line: the row is one item tall (not wrapped).
+    const h = await page.locator(OVERFLOW_ROW).evaluate((el) => el.getBoundingClientRect().height);
+    expect(h).toBeLessThan(60);
+  });
+
+  test('MEDIUM (1100px): folds the rightmost into "More", keeps leftmost inline, single line', async ({
+    page,
+  }) => {
+    await page.setViewportSize({width: 1100, height: 800});
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    // The overflow trigger appears...
+    await expect(moreTrigger(page)).toBeVisible({timeout: 10000});
+
+    // ...the LEFTMOST item stays inline...
+    const inline = await inlineLabels(page);
+    expect(inline).toContain('💻 Craft');
+
+    // ...and a RIGHTMOST item (Support) is NOT inline; it lives in the More menu (in order).
+    expect(inline).not.toContain('❤️ Support');
+    const menuItems = await moreTrigger(page)
+      .locator('xpath=ancestor::*[contains(@class,"dropdown")]')
+      .locator('.dropdown__menu a')
+      .allTextContents();
+    const menu = menuItems.map((t) => t.trim());
+    expect(menu).toContain('❤️ Support');
+    // Overflow order is preserved: Support comes after Vote/Todos in the menu.
+    expect(menu.indexOf('❤️ Support')).toBeGreaterThan(menu.indexOf('🗳️ Vote'));
+
+    // The bar stays on ONE line (the whole point: no wrap, no hamburger).
+    const h = await page.locator(OVERFLOW_ROW).evaluate((el) => el.getBoundingClientRect().height);
+    expect(h).toBeLessThan(60);
+
+    // Nothing overflows the viewport horizontally.
+    const overflowsX = await page.evaluate(() => {
+      const inner = document.querySelector('.navbar__inner') as HTMLElement | null;
+      return inner ? inner.scrollWidth - inner.clientWidth : 0;
+    });
+    expect(overflowsX).toBeLessThanOrEqual(1);
+  });
+
+  test('MOBILE (390px): the hamburger takes over, no "More" overflow trigger', async ({page}) => {
+    await page.setViewportSize({width: 390, height: 800});
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    // Below 996px the default mobile sidebar toggle (hamburger) is shown...
+    await expect(page.locator('.navbar__toggle')).toBeVisible();
+    // ...and the priority+ overflow apparatus does NOT add a "More" trigger (the inline items are
+    // display:none here; the mobile sidebar holds the nav instead).
+    await expect(moreTrigger(page)).toHaveCount(0);
+  });
+});

--- a/bytesofpurpose-blog/test/unit/navbarOverflow.test.ts
+++ b/bytesofpurpose-blog/test/unit/navbarOverflow.test.ts
@@ -1,0 +1,44 @@
+import {computeVisibleCount} from '../../src/theme/Navbar/Content/overflowFit';
+
+/**
+ * Unit test for the pure priority+ fit used by the navbar overflow menu. Given each item's measured
+ * width, the available row width, and the width reserved for the "More" trigger, computeVisibleCount
+ * returns how many LEADING items stay inline (the rest fold into "More"). No DOM needed.
+ */
+describe('computeVisibleCount (navbar priority+ fit)', () => {
+  test('everything fits → all items inline, no reserve consumed', () => {
+    const widths = [100, 100, 100]; // sum 300
+    expect(computeVisibleCount(widths, 400, 90)).toBe(3);
+  });
+
+  test('exact fit (sum === available) still shows all', () => {
+    expect(computeVisibleCount([100, 100, 100], 300, 90)).toBe(3);
+  });
+
+  test("doesn't fit → greedily fits leading items within (available - reserve)", () => {
+    // 5 items @100 = 500 > 420 available. Reserve 90 for More → budget 330 → 3 items (300) fit, 4th
+    // (400) would exceed. So 3 inline, 2 overflow.
+    expect(computeVisibleCount([100, 100, 100, 100, 100], 420, 90)).toBe(3);
+  });
+
+  test('reserve is respected (a larger More trigger folds one more item)', () => {
+    // Same widths/available as above but a wider reserve (150) → budget 270 → 2 items fit.
+    expect(computeVisibleCount([100, 100, 100, 100, 100], 420, 150)).toBe(2);
+  });
+
+  test('variable widths fold at the right boundary', () => {
+    // widths sum 1137 (the real navbar), available 849, reserve 90 → budget 759.
+    // 82+105+116+114+105+120 = 642 (6 items) fit; +121 = 763 > 759 → stop. Expect 6.
+    const widths = [82, 105, 116, 114, 105, 120, 121, 104, 79, 88, 104];
+    expect(computeVisibleCount(widths, 849, 90)).toBe(6);
+  });
+
+  test('always keeps at least ONE item inline (never a lonely More)', () => {
+    // Even absurdly tight: the first item alone exceeds the budget → floor of 1.
+    expect(computeVisibleCount([500, 100, 100], 200, 90)).toBe(1);
+  });
+
+  test('empty list → zero visible', () => {
+    expect(computeVisibleCount([], 400, 90)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What & why

From your prod screenshots: when the navbar's 11 items don't all fit, it **wrapped to two lines / overflowed**, and below 996px it **collapsed to the mobile hamburger hiding everything**. Now the left items stay on **one line** and the rightmost fold into a **"More ▾" dropdown** when they don't fit; primary destinations stay visible, the rest are one click away. (Classic *priority+* navigation.)

## How
- **Swizzle `@theme/Navbar/Content`** — byte-for-byte upstream except the LEFT group renders through `<NavbarItemsOverflow>`. The right group / logo / mobile toggle / color-mode / search are untouched, so the `.navbar__items--right` ordering contract + the `navbar-auth` e2e keep working.
- **`NavbarItemsOverflow`** — SSR renders **all** items inline (identical to upstream → no hydration mismatch, works with JS off). After mount it measures each item's width against the available budget (navbar inner width − logo − right group) and greedily folds the overflow into a "More ▾" dropdown, re-folding via a `ResizeObserver`. Reuses the site's own dropdown (through `@theme/NavbarItem`) so the menu inherits its styling + click-outside + keyboard, and each folded item keeps its leading emoji. The **mobile hamburger (≤996px) is preserved**.
- The greedy fit is a **pure exported `computeVisibleCount(widths, available, reserve)`** so it's unit-testable without a DOM (Jest test to follow — task tracked).

## The bug I hit (documented in the code)
The first fold is called **synchronously** in the mount effect, not only via `requestAnimationFrame`. Under React StrictMode the effect mounts → cleans up (cancelling the scheduled rAF) → re-mounts, so an rAF-only fold got cancelled and never fired (the nav stayed unwrapped). The immediate call guarantees the first fold; the rAF only coalesces later resize recomputes.

## Verification
- Prod `yarn build` **SSRs + hydrates clean**.
- **At 1100px:** single-line bar, **6 items inline** (Craft→Questions) + **5 in the More menu** (Handbook, Designs, Vote, Todos, Support) **in order**, no viewport overflow.
- ds-tokens + em-dash guards clean.

Follow-ups (tracked): a Jest unit test for `computeVisibleCount` + a Playwright `navbar-overflow.spec.ts` for the 1100/1500/375px breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)