### PR TITLE
fix(navbar): mobile hamburger drawer lists items one-per-line

### DIFF
--- a/bytesofpurpose-blog/src/theme/Navbar/Content/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/styles.module.css
@@ -51,4 +51,13 @@
   .moreDropdown {
     display: none;
   }
+  /* CRITICAL: at mobile width the overflow wrapper must become transparent to layout so its
+     children behave as if they were DIRECT children of .navbar__items again. Infima's mobile rule
+     hides items with `.navbar__item { display: none }`, but our flex `.overflowRow` is a wrapper;
+     its own `display: flex` would otherwise keep laying the (still-visible) items out in a row.
+     `display: contents` removes the wrapper box entirely so Infima's per-item hide applies and the
+     desktop items disappear on mobile (the hamburger sidebar's own menu__list shows them instead). */
+  .overflowRow {
+    display: contents;
+  }
 }

--- a/bytesofpurpose-blog/src/theme/NavbarItem/index.tsx
+++ b/bytesofpurpose-blog/src/theme/NavbarItem/index.tsx
@@ -3,7 +3,7 @@ import ComponentTypes from '@theme/NavbarItem/ComponentTypes';
 import styles from './navbarSummary.module.css';
 
 // One-line summary per navbar item, keyed by its `label`. The source of truth for the hover
-// popups — keep in sync with the navbar items in docusaurus.config.js. An item with no entry
+// popups; keep in sync with the navbar items in docusaurus.config.js. An item with no entry
 // here renders normally (no popup).
 // Keyed by the navbar item's EXACT label (the lookup is SUMMARIES[label]). Every navbar item now
 // leads with a consistent emoji, so each key includes that emoji prefix (matching the label in
@@ -54,8 +54,11 @@ export default function NavbarItem({type, ...props}: {type?: string} & Record<st
   const summary = summaryName ? SUMMARIES[summaryName] : undefined;
 
   // Only desktop, left-positioned primary items get the popup (skip dropdowns + right-side
-  // utility controls, where a popover would be awkward).
-  if (!summary || componentType === 'dropdown' || props.position === 'right') {
+  // utility controls, where a popover would be awkward). Also skip the MOBILE drawer: the popup is
+  // a pointer-device affordance (CSS-suppressed on mobile), but the wrapper span is `inline-flex`,
+  // which would break the drawer's vertical `menu__list` (items would flow 2-per-row). On mobile,
+  // render the bare item so each sits on its own line.
+  if (!summary || props.mobile || componentType === 'dropdown' || props.position === 'right') {
     return item;
   }
 

--- a/bytesofpurpose-blog/test/e2e/navbar-overflow.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/navbar-overflow.spec.ts
@@ -91,5 +91,41 @@ test.describe('Navbar priority+ overflow', () => {
     // ...and the priority+ overflow apparatus does NOT add a "More" trigger (the inline items are
     // display:none here; the mobile sidebar holds the nav instead).
     await expect(moreTrigger(page)).toHaveCount(0);
+
+    // REGRESSION GUARD: the desktop inline items must be HIDDEN at mobile width (Infima's
+    // `.navbar__item{display:none}`). The overflow wrapper uses `display: contents` on mobile so it
+    // doesn't keep laying its (would-be-hidden) children out in a flex row across the top of the
+    // page. Assert none of the top-bar inline links are actually visible.
+    const inlineVisible = await page
+      .locator('.navbar__inner .navbar__link:visible')
+      .allTextContents();
+    expect(inlineVisible.filter((t) => t.trim() && !t.startsWith('More'))).toHaveLength(0);
+  });
+
+  test('MOBILE (390px): the opened hamburger drawer lists items VERTICALLY (one per line)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({width: 390, height: 800});
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    // Open the drawer.
+    await page.locator('.navbar__toggle').click();
+    const drawer = page.locator('.navbar-sidebar');
+    await expect(drawer).toBeVisible();
+
+    // The drawer renders the nav as a vertical menu list (one item per line), NOT a wrapped
+    // horizontal row. Assert the list items stack: each successive item sits BELOW the previous.
+    const links = drawer.locator('.menu__list .menu__link, .menu__list a');
+    const count = await links.count();
+    expect(count).toBeGreaterThanOrEqual(5);
+    const boxes = [];
+    for (let i = 0; i < Math.min(count, 6); i++) {
+      boxes.push(await links.nth(i).boundingBox());
+    }
+    // Each item's top is strictly greater than the previous item's top (stacked vertically).
+    for (let i = 1; i < boxes.length; i++) {
+      expect(boxes[i]!.y).toBeGreaterThan(boxes[i - 1]!.y);
+    }
   });
 });


### PR DESCRIPTION
## What & why

You spotted it: the opened mobile hamburger drawer laid its nav items out **2-per-row** instead of one per line (screenshot).

## Root cause
Pre-existing in the **hover-summary `NavbarItem` swizzle** (not the new overflow work): every item with a summary is wrapped in `<span class="navItemWrap">`, which is `display: inline-flex`. In the mobile drawer's block `menu__list`, that inline-flex wrapper made the items flow **horizontally**. The popup itself is a desktop pointer affordance (already CSS-suppressed on mobile), but the wrapper span still rendered and broke the vertical list.

## Fix
- **`NavbarItem`**: skip the wrapper entirely when `props.mobile` → return the bare item, so the drawer's vertical `menu__list` is untouched.
- **`Content/styles`**: at ≤996px give `.overflowRow` `display: contents` so the desktop overflow wrapper collapses on mobile (defensive; Infima already hides the items via `.navbar__item{display:none}`).
- **`navbar-overflow.spec`**: added a mobile test asserting the drawer stacks vertically (each item's top strictly below the previous) + that the top-bar inline items are hidden at mobile width.
- Drive-by: de-em-dashed a pre-existing comment in the same file (the em-dash gate flagged it once I touched the file).

## Verification
- Drawer now stacks: item tops at y = 68, 104, 140, 176, … (36px apart, one per line). Screenshot confirms Craft / Journey / Initiatives / … each on its own line.
- All **4** `navbar-overflow` tests pass (wide / medium-fold / mobile-hidden / mobile-drawer-vertical).

Small follow-up to #128 (the navbar overflow feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)