### PR TITLE
fix(hero,navbar): empty studio door + clipped hover popups + clear active-item indicator

### DIFF
--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -253,6 +253,29 @@ h6 {
 }
 
 /* ==========================================================================
+   Active navbar item: the SELECTED destination gets the brand-green text PLUS a
+   2px green underline accent (the --border-accent language, matching the hero's
+   scene-active highlight). Docusaurus' route-active state ships with almost no
+   visual weight (faint color only), so the current section was hard to spot.
+   Scoped to the top navbar (not the mobile drawer, which shows its own active row).
+   ========================================================================== */
+.navbar__link--active {
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  position: relative;
+}
+.navbar__link--active::after {
+  content: '';
+  position: absolute;
+  left: 0.6rem;
+  right: 0.6rem;
+  bottom: -0.15rem;
+  height: 2px;
+  background: var(--ifm-color-primary);
+  border-radius: 2px;
+}
+
+/* ==========================================================================
    Navbar "Buy Me a Coffee?" button (replaces the old alt-less <img> link)
    ========================================================================== */
 .navbar-coffee {

--- a/bytesofpurpose-blog/src/pages/index.module.css
+++ b/bytesofpurpose-blog/src/pages/index.module.css
@@ -285,7 +285,7 @@
      so it's dropped to keep the arch on the normal paint path. */
   transition: opacity 0.4s ease, transform 0.25s ease;
 }
-.flashArchImgActive {
+.flashArchImg.flashArchImgActive {
   opacity: 1;
 }
 
@@ -512,7 +512,7 @@
   opacity: 0;
   transition: opacity 0.6s ease;
 }
-.boutiquePeekImgActive {
+.boutiquePeekImg.boutiquePeekImgActive {
   opacity: 1;
 }
 /* Side windows read as displays you glance at: slightly dimmer + warmer than the door. */
@@ -869,7 +869,13 @@
   opacity: 0;
   transition: opacity 0.45s ease;
 }
-.studioLayerOn {
+/* The "on" layer must WIN over the base `opacity: 0` above. Both are single-class selectors (equal
+   specificity), so in the DEV CSS the later `.studioLayerOn` wins, but the PRODUCTION CSS-Modules
+   bundle can concatenate the base rule AFTER this one, flipping the cascade so the door/scene stay
+   invisible (a live bug: the centre arch rendered as empty wall). Bump specificity by scoping to the
+   layer classes so `.studioLayerOn` wins no matter the source order. */
+.studioDoorLayer.studioLayerOn,
+.studioDoorScene.studioLayerOn {
   opacity: 1;
 }
 /* the SCENE container is clipped to the arch interior (white-interior mask), like the side peek. */
@@ -1091,7 +1097,9 @@
   opacity: 0;
   transition: opacity 0.5s ease;
 }
-.studioPeekImgActive {
+/* Two-class so it wins over `.studioPeekImg { opacity: 0 }` regardless of prod CSS order (same
+   cascade race as .studioLayerOn above). */
+.studioPeekImg.studioPeekImgActive {
   opacity: 1;
 }
 

--- a/bytesofpurpose-blog/src/theme/Navbar/Content/styles.module.css
+++ b/bytesofpurpose-blog/src/theme/Navbar/Content/styles.module.css
@@ -26,7 +26,11 @@
   align-items: center;
   flex-wrap: nowrap; /* never wrap to a 2nd line; fold into More instead */
   min-width: 0;
-  overflow: hidden; /* clip rather than push the right group while JS folds */
+  /* NO `overflow: hidden` here. It clips BOTH axes, and the per-item hover-summary popups drop BELOW
+     the navbar (position:absolute; top:100%), so hiding overflow swallowed them (a regression). The
+     JS measure-and-fold already keeps the row within its budget, so clipping was only defensive;
+     dropping it lets the popups escape. If a pre-JS flash of a too-wide row is ever an issue, clip on
+     a PARENT that doesn't contain the popups, not here. */
 }
 
 /* The off-screen measurement copy of the FULL item list. It renders every item at

--- a/bytesofpurpose-blog/test/e2e/navbar-overflow.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/navbar-overflow.spec.ts
@@ -44,6 +44,30 @@ test.describe('Navbar priority+ overflow', () => {
     expect(h).toBeLessThan(60);
   });
 
+  test('WIDE: hovering an inline item shows its summary popup (not clipped by the overflow row)', async ({
+    page,
+  }) => {
+    // Regression guard: the overflow row must NOT clip the per-item hover-summary popups (they drop
+    // BELOW the navbar via position:absolute). An earlier `overflow:hidden` on the row swallowed them.
+    await page.setViewportSize({width: 1600, height: 800});
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle');
+
+    const craft = page.locator('.navbar__inner a.navbar__link', {hasText: 'Craft'}).first();
+    await craft.hover();
+    const popup = page.locator('.navbar__inner [class*="summaryPopup"]').first();
+    // It becomes visible AND is not zero-height-clipped (its box extends below the navbar).
+    await expect(popup).toBeVisible({timeout: 4000});
+    const box = await popup.boundingBox();
+    expect(box, 'popup should have a rendered box').toBeTruthy();
+    expect(box!.height).toBeGreaterThan(10);
+    // Its top edge sits BELOW the navbar (it dropped down, not clipped to the row).
+    const navBottom = await page
+      .locator('.navbar__inner')
+      .evaluate((el) => el.getBoundingClientRect().bottom);
+    expect(box!.y).toBeGreaterThanOrEqual(navBottom - 8);
+  });
+
   test('MEDIUM (1100px): folds the rightmost into "More", keeps leftmost inline, single line', async ({
     page,
   }) => {


### PR DESCRIPTION
## Two production-only rendering bugs

Both are equal-specificity / overflow issues that only bite in the **built** (minified/concatenated) CSS, not the dev server — which is why dev looked fine while prod broke.

### 1. Empty centre door (studio house hero) — your screenshot
The door + scene cross-fade layers use `.studioDoorLayer { opacity: 0 }` + `.studioLayerOn { opacity: 1 }` to reveal the active one. Both are **single-class (equal specificity)**, so the cascade is source-order dependent. The prod CSS bundle emitted the base `opacity: 0` **after** `.studioLayerOn`, so the door stayed invisible — live DOM showed `doorOpacity: 0` **with** the `studioLayerOn` class present, rendering the centre arch as empty green wall while the side windows showed.

**Fix:** scope the "on" rule to two classes (`.studioDoorLayer.studioLayerOn`, `.studioDoorScene.studioLayerOn`) so it wins regardless of order. Applied the same fix to the **three sibling pairs** with the identical latent race: `studioPeekImg`, `flashArchImg`, `boutiquePeekImg`.

### 2. Clipped hover-summary popups — regression from #128
The navbar overflow row had `overflow: hidden` (I added it to clip the folding row), but the per-item hover popups drop **below** the navbar (`position: absolute; top: 100%`), so hidden-overflow **swallowed them** — the popups went invisible. **Fix:** remove the clip; the JS measure-and-fold already bounds the row width, so the clip was only defensive.

## Tests (answering "why didn't tests catch it")
Added a **navbar hover-popup regression test**: hover an item → the summary popup is visible AND its box sits below the navbar (not clipped). All **5** navbar-overflow tests pass. The door fix was verified in a **prod build** (`doorOpacity: 1`, was `0` on live).

`validate-hero-anchors` 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)