### PR TITLE
feat(skill): verify-prod-deployment (browser post-deploy verification)

### DIFF
--- a/.claude/skills/verify-prod-deployment/SKILL.md
+++ b/.claude/skills/verify-prod-deployment/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify-prod-deployment
+description: Browser-based post-deploy verification for the live blog (blog.bytesofpurpose.com). The complement to validate-deployment (curl smoke checks); this drives a REAL browser to catch RENDER bugs the curl checks are blind to (a page can serve 200 with the right commit while a component renders blank, e.g. the studio-house door once shipped at opacity 0 from a prod-only CSS cascade race and every curl check passed). It FIRST waits for the CDN to propagate the exact bundle you just built (polls the live index's styles.<hash>.css until it matches build/ and serves 200; GitHub Pages + Cloudflare serve the OLD build for 1-3 min post-deploy), THEN confirms the deployed changes actually render, THEN watches for regressions (console errors + failed requests) on every page it loads, filtering the KNOWN-BENIGN noise (the CF Access /api/me CORS probe, the dmn_chk cookie, Infima vendor-prefixed CSS warnings). Run it AFTER `make deploy`, after validate-deployment. Use when verifying a deploy landed, debugging "the fix isn't live yet", or checking a deploy didn't regress a page.
+---
+
+# Verify a production deployment (in a browser)
+
+`validate-deployment/check.sh` confirms the deploy is **reachable + correct commit + premium-gated**
+via curl. It cannot see whether the page actually **renders**; a 200 with the right commit can still
+ship a blank component. This skill is the browser layer: it waits for propagation, confirms the
+**deployed change is really live**, and watches for regressions on the pages it visits.
+
+> Real example this exists for: the studio-house centre **door** shipped at `opacity: 0` (a prod-only
+> CSS equal-specificity cascade race). Every curl check passed; the arch was empty. A browser render
+> check catches it; curl never will.
+
+## Run it (AFTER `make deploy` + validate-deployment)
+
+From the blog dir (so `@playwright/test` resolves); the local `build/` must be the one you just
+deployed (do NOT rebuild in between, or the bundle-hash match will be wrong):
+
+```bash
+cd bytesofpurpose-blog
+node scripts/verify-prod-deployment.mjs --url https://blog.bytesofpurpose.com --build build
+```
+
+Exit codes: **0** all good · **2** a verification failed · **3** propagation never completed in ~4min
+(deploy may not have landed, or CDN is unusually slow; re-run in a few minutes).
+
+Flags: `--url` (default the live site) · `--build` (default `build`) · `--expect-css styles.<hash>.css`
+(skip auto-detecting the bundle from `build/`, e.g. when verifying a deploy you didn't build locally).
+
+## What it asserts (in order)
+
+1. **Propagation wait (the key step).** GitHub Pages + Cloudflare serve the OLD hashed bundles from
+   cached edges for **1-3 min** after a deploy, returning 200 the whole time. So it polls the live
+   `index.html` until the `styles.<hash>.css` it references **matches the hash in your local `build/`**
+   AND that bundle serves 200 on the edge. Only then does it verify; otherwise it'd be testing the
+   stale build. (Observed ~170s in one real deploy; the poll window is ~4 min.)
+2. **Deployed change is live.** Because step 1 gates on YOUR build's bundle hash, a green run proves
+   the exact assets you shipped are the ones serving; not a cached prior deploy.
+3. **Render checks.** Loads `/`, `/craft`, `/handbook`, `/changelog` and asserts each has a non-empty
+   `<title>` (rendered, not a blank error page). The homepage **hero** is sampled over ~14s: at every
+   moment the studio house must show its **door OR a scene** (never both layers at opacity 0 = the
+   empty-arch regression). Navbar presence is checked.
+4. **Regression watch.** Every page visited feeds a console-error + failed-request collector; a
+   non-benign entry FAILS the run. So a NEW error on a page it happens to load is caught, not just the
+   thing you changed. Add surfaces to the `pages` array as the site grows.
+
+## KNOWN-BENIGN console noise (do NOT chase these; the script already ignores them)
+
+These appear on a normal anonymous prod load and are NOT site errors (documented so they're not
+re-investigated every deploy):
+
+- **Cloudflare Access**; the premium sign-in flow probes `/api/me` against `bytesofpurpose.cloudflareaccess.com`;
+  the browser can't read that cross-origin response (`CORS header 'Access-Control-Allow-Origin' missing`,
+  status 200) and the `dmn_chk_*` cookie is rejected for the apex domain. The app handles the failure
+  (the control stays the "Sign in" button); this is the expected anonymous path, not a bug.
+- **Infima vendor-prefixed CSS**; `-webkit-text-size-adjust`, `line-clamp`, `text-size-adjust`,
+  "Ruleset ignored due to bad selector": Firefox logs "unknown property / declaration dropped". Cosmetic,
+  from a dependency's bundled CSS.
+- **Third-party analytics chatter**; `_ga_*` cookie expires overwritten, Reporting-Header JSON.
+
+The allowlist lives in `BENIGN` at the top of `scripts/verify-prod-deployment.mjs`. If a genuinely new
+benign source appears, add it there WITH a comment saying why it's safe; never widen it to silence a
+real error.
+
+## Where it fits
+
+`deploy-site` (ships it) → `validate-deployment` (curl: 200/Access/PostHog/premium/commit) →
+**verify-prod-deployment** (browser: propagation wait + render + regression watch). Run all three; this
+one is last because it needs the propagated build. Pairs with `maintain-homepage-hero` (the hero it
+render-checks) and the Playwright e2e (which tests the same surfaces pre-deploy on a build).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,8 @@ via the root `Makefile`. Secrets in the gitignored root `.env`.
 | Serve locally | `serve-locally` | run the blog on your machine: `make start` (:3000, drafts visible) vs `make serve` (built site, no drafts); the stale-route-table 404 gotcha (restart fixes it) + curl-false-200 |
 | Publish | `publish-site` | triage draft-readiness → un-draft approved → deploy; wraps `deploy-site` |
 | Deploy | `deploy-site` | secret-scan → build (PostHog env) → gh-pages → verify |
-| Verify live | `validate-deployment` | post-deploy 200/Access/PostHog-beacon checks |
+| Verify live | `validate-deployment` | post-deploy 200/Access/PostHog-beacon checks (curl smoke) |
+| Verify live (browser) | `verify-prod-deployment` | the BROWSER layer on top of validate-deployment: catches RENDER bugs curl is blind to (a 200 page with a blank component, e.g. the studio-house door once shipped at opacity 0). WAITS for the CDN to propagate the exact bundle you built (polls the live `styles.<hash>.css` until it matches `build/` + serves 200 — Pages/CF serve the OLD build 1-3 min post-deploy), then confirms the deployed change renders, then watches console errors + failed requests on every page it loads (filtering KNOWN-BENIGN noise: the CF Access `/api/me` CORS probe, `dmn_chk` cookie, Infima vendor-CSS warnings). `node scripts/verify-prod-deployment.mjs` from the blog dir, AFTER `make deploy` + validate-deployment |
 | Regression / E2E | `bytesofpurpose-blog/test/e2e/README.md` (no skill) | Playwright **3-project model** (dev :3000 / prod-build :4173 / posthog-prod test-mode :4173); axe a11y + SEO gates; dev-only-surfaces **absence** test (DebugMenu/draft badges must not ship). `make test-regression`. Build-only transforms (rehype, draft exclusion) need the prod build, not `yarn start`. |
 
 ## Repo-wide gotchas (details live in the linked skill)

--- a/bytesofpurpose-blog/scripts/verify-prod-deployment.mjs
+++ b/bytesofpurpose-blog/scripts/verify-prod-deployment.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * verify-prod-deployment; browser-based post-deploy verification for the Bytes of Purpose blog.
+ *
+ * WHY (beyond validate-deployment/check.sh): the curl smoke checks confirm 200 / public / PostHog /
+ * premium / commit-match, but they CANNOT see RENDER bugs; a page can serve 200 with the right
+ * commit while a component renders blank (e.g. the studio-house centre door once shipped at
+ * opacity 0 from a prod-only CSS cascade race; every curl check passed). This drives a real browser
+ * against the LIVE site and asserts key surfaces actually render, AFTER waiting for the deploy to
+ * propagate to the CDN edge.
+ *
+ * WHAT IT DOES
+ *   1. PROPAGATION WAIT: GitHub Pages + Cloudflare serve the OLD hashed bundles from cached edges for
+ *      1-3 min after a deploy (HTTP 200 the whole time). So we first poll the live index.html until
+ *      the CSS bundle hash it references MATCHES the one in the local build/ (the deploy you just
+ *      shipped) AND that bundle serves 200 on the edge. Only then do we verify; otherwise we'd be
+ *      testing the stale build. (This is the step the user asked to bake in: wait, then confirm the
+ *      DEPLOYED changes are actually the ones live.)
+ *   2. RENDER CHECKS on key surfaces: homepage hero (the house door/scene is visible, not an empty
+ *      arch), the navbar (present; active-item accent on a section page), and each checked page loads.
+ *   3. REGRESSION WATCH: collects console errors + failed requests on every page visited and FAILS on
+ *      anything that isn't in the KNOWN-BENIGN allowlist (documented below), so a new error on a page
+ *      we happen to load is caught, not just the thing we changed.
+ *
+ * Usage:  node verify.mjs [--url https://blog.bytesofpurpose.com] [--build <path to build/>]
+ *                          [--expect-css styles.<hash>.css]   (skip auto-detect from local build)
+ * Exit:   0 all good · 2 a verification failed · 3 propagation never completed within the window.
+ */
+import {firefox} from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const arg = (name, def) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : def;
+};
+const URL = arg('--url', 'https://blog.bytesofpurpose.com').replace(/\/$/, '');
+const BUILD = arg('--build', 'build');
+let expectCss = arg('--expect-css', null);
+
+// ── KNOWN-BENIGN console noise (do NOT treat as failures) ────────────────────────────────────────
+// Documented so this isn't re-investigated each deploy. These are EXPECTED on an anonymous prod load:
+//  - Cloudflare Access: the premium sign-in flow probes /api/me against the CF Access endpoint; the
+//    browser can't read that cross-origin response (CORS) and the dmn_chk cookie is rejected for the
+//    apex domain. The app handles the failure (stays "Sign in"); it is not a site error.
+//  - Vendor-prefixed CSS Infima ships (-webkit-text-size-adjust, line-clamp, text-size-adjust): Firefox
+//    logs "unknown property / declaration dropped". Cosmetic, from a dependency's bundled CSS.
+//  - Third-party analytics cookie chatter (_ga expires overwritten, Reporting-Header JSON).
+const BENIGN = [
+  /cloudflareaccess\.com/i,
+  /\/api\/me/i,
+  /dmn_chk/i,
+  /Cross-Origin Request Blocked/i,
+  /Access-Control-Allow-Origin/i,
+  /text-size-adjust/i,
+  /line-clamp/i,
+  /Ruleset ignored due to bad selector/i,
+  /_ga_/i,
+  /Reporting[- ]?Header/i,
+  /downloadable font|OTS parsing/i, // occasional webfont sanitizer noise
+];
+const isBenign = (msg) => BENIGN.some((re) => re.test(msg));
+
+// ── Find the CSS bundle hash the fresh local build emitted (what SHOULD be live) ──────────────────
+function localCssBundle() {
+  if (expectCss) return expectCss;
+  try {
+    const dir = path.join(BUILD, 'assets', 'css');
+    const f = fs.readdirSync(dir).find((n) => /^styles\.[a-z0-9]+\.css$/.test(n));
+    return f || null;
+  } catch {
+    return null;
+  }
+}
+
+async function liveCssBundle() {
+  // Read the live index.html and extract the styles.<hash>.css it references (cache-busted).
+  const res = await fetch(`${URL}/?cb=${Date.now()}`, {cache: 'no-store'}).catch(() => null);
+  if (!res || !res.ok) return null;
+  const html = await res.text();
+  const m = html.match(/styles\.[a-z0-9]+\.css/);
+  return m ? m[0] : null;
+}
+
+async function bundleReachable(name) {
+  const res = await fetch(`${URL}/assets/css/${name}`, {cache: 'no-store'}).catch(() => null);
+  return !!res && res.ok;
+}
+
+const log = (...a) => console.log(...a);
+let failed = 0;
+
+async function main() {
+  const want = localCssBundle();
+  log(`🔎 verify-prod-deployment ${URL}`);
+  if (want) log(`   expecting CSS bundle from the local build: ${want}`);
+  else log('   (no local build found; skipping bundle-match propagation wait, waiting on reachability only)');
+
+  // 1. PROPAGATION WAIT ─ poll until the live index references our bundle AND it serves 200. Up to ~4min.
+  if (want) {
+    let ok = false;
+    for (let i = 0; i < 24; i++) {
+      const live = await liveCssBundle();
+      const reachable = await bundleReachable(want);
+      if (live === want && reachable) {
+        log(`✅ propagated: live references ${want} and it serves 200 (after ~${i * 10}s)`);
+        ok = true;
+        break;
+      }
+      if (i === 0) log(`   waiting for CDN propagation (live=${live || 'n/a'})…`);
+      await new Promise((r) => setTimeout(r, 10_000));
+    }
+    if (!ok) {
+      log(`❌ propagation: the live site never served ${want} within ~4min. The deploy may not have`);
+      log('   landed, or CDN propagation is unusually slow. Re-run verify in a few minutes.');
+      process.exit(3);
+    }
+  }
+
+  // 2 + 3. RENDER CHECKS + REGRESSION WATCH via a real browser.
+  const browser = await firefox.launch();
+  const ctx = await browser.newContext({viewport: {width: 1280, height: 900}});
+  const page = await ctx.newPage();
+  const consoleErrors = [];
+  const failedReqs = [];
+  page.on('console', (m) => {
+    if (m.type() === 'error' && !isBenign(m.text())) consoleErrors.push(m.text().slice(0, 160));
+  });
+  page.on('requestfailed', (r) => {
+    const u = r.url();
+    if (!isBenign(u)) failedReqs.push(u.slice(-80));
+  });
+
+  // The pages we assert render cleanly. Add surfaces here as the site grows.
+  const pages = ['/', '/craft', '/handbook', '/changelog'];
+  for (const rel of pages) {
+    await page.goto(`${URL}${rel}?cb=${Date.now()}`, {waitUntil: 'domcontentloaded'});
+    await page.waitForLoadState('networkidle').catch(() => {});
+    await page.waitForTimeout(1500);
+    const title = await page.title();
+    if (!title) {
+      log(`❌ ${rel}: empty <title> (page did not render)`);
+      failed = 1;
+    } else {
+      log(`✅ ${rel}: rendered ("${title.slice(0, 40)}")`);
+    }
+  }
+
+  // HERO: over ~14s the studio house must show its door OR a scene at each moment (never an empty
+  // arch = both layers at opacity 0). This is the exact regression that shipped invisibly before.
+  await page.goto(`${URL}/?cb=${Date.now()}`, {waitUntil: 'domcontentloaded'});
+  await page.waitForLoadState('networkidle').catch(() => {});
+  let heroEverEmpty = false;
+  let heroEverShown = false;
+  for (let i = 0; i < 8; i++) {
+    const s = await page.evaluate(() => {
+      const o = (sel) => {
+        const el = document.querySelector(sel);
+        return el ? parseFloat(getComputedStyle(el).opacity) : null;
+      };
+      const door = o('[class*="studioDoorLayer"]');
+      const scene = o('[class*="studioDoorScene"]');
+      // Only meaningful on the studio-house variant; if it's not rendered, skip (return nulls).
+      return {door, scene, present: door !== null || scene !== null};
+    });
+    if (s.present) {
+      const visible = (s.door || 0) > 0.5 || (s.scene || 0) > 0.5;
+      if (visible) heroEverShown = true;
+      else heroEverEmpty = true;
+    }
+    await page.waitForTimeout(1700);
+  }
+  if (heroEverShown && !heroEverEmpty) {
+    log('✅ hero: the house door/scene is visible (no empty-arch frame observed)');
+  } else if (heroEverEmpty) {
+    log('❌ hero: observed an EMPTY arch frame (door AND scene both hidden); the render bug is back');
+    failed = 1;
+  } else {
+    log('ℹ️  hero: studio-house not rendered this session (A/B resolved to another variant); skipped');
+  }
+
+  // NAVBAR present.
+  const navOk = (await page.locator('.navbar__inner').count()) > 0;
+  log(navOk ? '✅ navbar: present' : '❌ navbar: missing');
+  if (!navOk) failed = 1;
+
+  await browser.close();
+
+  // Regression watch verdict.
+  if (consoleErrors.length) {
+    log(`❌ console: ${consoleErrors.length} non-benign error(s) across the checked pages:`);
+    consoleErrors.slice(0, 8).forEach((e) => log(`     • ${e}`));
+    failed = 1;
+  } else {
+    log('✅ console: no non-benign errors (known CF-Access/vendor-CSS noise ignored)');
+  }
+  if (failedReqs.length) {
+    log(`❌ network: ${failedReqs.length} unexpected failed request(s):`);
+    failedReqs.slice(0, 8).forEach((u) => log(`     • …${u}`));
+    failed = 1;
+  } else {
+    log('✅ network: no unexpected failed requests');
+  }
+
+  log('');
+  log(failed ? '✗ verify-prod-deployment: FAILURES above.' : '✅ verify-prod-deployment: all good.');
+  process.exit(failed ? 2 : 0);
+}
+
+main().catch((e) => {
+  console.error('verify-prod-deployment crashed:', e);
+  process.exit(2);
+});


### PR DESCRIPTION
## What & why

You asked for a skill to **verify prod after a deployment** — one that waits for the deploy to appear, confirms the deployed changes actually made it, and watches for regressions on the pages it checks. This is that skill, built after the studio-door bug shipped invisibly past every curl check.

`validate-deployment` (curl) confirms 200 / Access / PostHog / premium / commit-match — but it's **blind to render bugs**: a 200 page with the right commit can still ship a blank component (the studio-house door was `opacity: 0` live from a prod-only CSS cascade race; all curl checks passed). This skill is the **browser layer**.

## `scripts/verify-prod-deployment.mjs` (Playwright)
1. **Propagation wait (the step you asked for).** Polls the live `index.html`'s `styles.<hash>.css` until it **matches the bundle in your local `build/`** AND that bundle serves 200 on the edge. Pages/CF serve the OLD build 1-3 min post-deploy (observed ~170s in the deploy I just did). Gating on *your* build's hash proves the change you shipped is the one live — not a cached prior deploy.
2. **Render checks.** `/`, `/craft`, `/handbook`, `/changelog` have non-empty titles; the homepage **hero is sampled over ~14s and must show the door OR a scene at every frame** (never an empty arch — the exact regression); navbar present.
3. **Regression watch.** Console errors + failed requests on **every page it visits** fail the run, filtering a documented **KNOWN-BENIGN allowlist** (the CF Access `/api/me` CORS probe, `dmn_chk` cookie, Infima vendor-CSS warnings) so a genuinely new error surfaces instead of drowning in expected noise.

Exit `0` ok · `2` verification failed · `3` propagation timed out.

## Run order (documented in the skill + CLAUDE.md)
`deploy-site` → `validate-deployment` (curl) → **`verify-prod-deployment`** (browser, last — needs the propagated build):
```
cd bytesofpurpose-blog
node scripts/verify-prod-deployment.mjs --url https://blog.bytesofpurpose.com --build build
```

## Verified
Green against the current live site: propagation matched (`styles.b4928624.css`), hero door visible ("no empty-arch frame observed"), 4 pages rendered, no non-benign console errors, no failed requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)