### PR TITLE
fix(navbar): vertically center the mobile hamburger toggle

### DIFF
--- a/bytesofpurpose-blog/src/css/custom.css
+++ b/bytesofpurpose-blog/src/css/custom.css
@@ -620,6 +620,11 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   .navbar [class*='toggle'] button {
     min-width: 44px;
     min-height: 44px;
+    /* Center the glyph within the 44px hit area — without this the min-height leaves the icon
+       top-aligned, so the hamburger sat high vs the logo + Sign-in pill in the navbar row. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
   /* The custom auth control (sign-in pill / avatar) — give the tappable element room. */
   .navbarAuthItem a,


### PR DESCRIPTION
## What & why

Nit you spotted: in mobile mode the hamburger (☰) sat slightly high, not vertically centered with the logo text + Sign-in pill.

## Cause
The ≤996px touch-target rule gave `.navbar__toggle` `min-height: 44px` (WCAG target) but **no flex centering**, so the glyph stayed top-aligned inside the taller hit area.

## Fix
Add `display: inline-flex; align-items: center; justify-content: center` to the toggle so the icon centers within its 44px target.

## Verified
At 390px, the toggle / logo / Sign-in / navbar now share the same vertical center (all `y=30`); screenshot confirms the ☰ aligned with the rest of the row. contrast + em-dash guards clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)