### PR TITLE
feat(mindset): verified video for the watch-your-thoughts cascade

### DIFF
--- a/bytesofpurpose-blog/mindset/2026-06-25-quotes-that-moved-me.mdx
+++ b/bytesofpurpose-blog/mindset/2026-06-25-quotes-that-moved-me.mdx
@@ -48,7 +48,7 @@ If you want to go fast, <Focus>go alone</Focus>. If you want to go far, <Focus>g
 
 <SectionBanner why="The chain I come back to when I want a reminder that small inputs upstream decide who I become downstream." />
 
-<PosterQuote source="Frank Outlaw" cite="often misattributed to Lao Tzu; the line traces to a 1977 Frank Outlaw saying">
+<PosterQuote source="Frank Outlaw" cite="often misattributed to Lao Tzu; the line traces to a 1977 Frank Outlaw saying, and Meryl Streep delivers it as Thatcher in The Iron Lady" video="https://www.youtube.com/watch?v=GSXYHqs0KPo">
 <Beat lead="Watch your" big="THOUGHTS" />
 <Beat lead="they become your" big="WORDS" />
 <Beat lead="watch your words, they become your" big="ACTIONS" />


### PR DESCRIPTION
## What

Adds the `video=` link that was missing on the `<PosterQuote>` cascade in `quotes-that-moved-me.mdx`. When the poster feature first shipped, no video candidate cleared verification, so the cascade had no "watch" link. Ran `find-quote-video` and found a verified one.

## The video

[The Iron Lady (2011) — Clip #1 "What we think, we become"](https://www.youtube.com/watch?v=GSXYHqs0KPo) — Meryl Streep as Margaret Thatcher delivering the **exact** "watch your thoughts, they become words... it becomes your destiny" cascade. A real, recognizable performance of the words, not a faceless motivation remix.

## Verification (per the `find-quote-video` bar)

- **Public + exists**: the YouTube **oEmbed** endpoint returns valid data for `GSXYHqs0KPo` (a private/removed video returns 404 there — a competing candidate, `uZi0vLAhzgQ`, did 404 and was discarded).
- **Title/channel**: "The Iron Lady - Clip #1 What we think, we become" on "The Meryl Streep Forum".
- **On-topic**: the scene is corroborated by IMDb, clip.cafe, and Ranker as the exact cascade line from the film.
- **Clean URL**: canonical `watch?v=`, no tracking params (`validate-links` clean).
- **Attribution stays honest**: `source` remains Frank Outlaw (1977 origin); the `cite` notes the famous Streep delivery. No em-dashes; outline validator passes.

Honest limit: I can't watch/listen, so I can't certify the audio verbatim — but it's a documented film clip of the exact words from a coherent source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)