### PR TITLE
feat(handbook): animate the logo mockups (split-flap roll, bit cursor, blink)

### DIFF
--- a/bytesofpurpose-blog/docs/handbook/design-system/logos.mdx
+++ b/bytesofpurpose-blog/docs/handbook/design-system/logos.mdx
@@ -63,14 +63,13 @@ split-flap, the faith frame around a mechanically rolling bit.
 
 <OptionGrid columns={210}>
   <OptionTile name="Arch + Flap Tile" chosen note="The green cathedral arch IS the housing for a Vestaboard flap that rolls B → 0 → 1 → blank. The brand's actual split-flap, set into the faith frame.">
-    <span style={{width: 60, height: 70, background: 'var(--ifm-color-primary)', borderRadius: '30px 30px 6px 6px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', boxShadow: 'var(--shadow-sm)'}}>
-      <span style={{fontFamily: 'var(--font-mono)', fontWeight: 600, fontSize: '2rem', color: '#f4f1ea'}}>B</span>
-    </span>
+    <SplitFlapMark />
   </OptionTile>
   <OptionTile name="Arch + Flap (outline)" note="Same pairing as a hairline arch over a tinted interior; the dark flap pops. Lighter weight for favicons and dark surfaces.">
-    <span style={{width: 60, height: 70, border: '2.5px solid var(--ifm-color-primary)', borderRadius: '30px 30px 6px 6px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', background: 'var(--accent-tint)'}}>
-      <span style={{fontFamily: 'var(--font-mono)', fontWeight: 600, fontSize: '1.9rem', color: 'var(--text-heading)'}}>0</span>
-    </span>
+    <SplitFlapMark outline />
+  </OptionTile>
+  <OptionTile name="Arch + Bit Cursor" note="A mono cursor inside the arch flashing 1 → 0 → empty. The byte, lit inside the faith frame, and it is alive.">
+    <BitCursor />
   </OptionTile>
   <OptionTile name="Arched Flap Sign · BoP" note="'BoP' on a three-tile flap board hung under a green arch crown: the homepage departure-board sign, distilled into a mark.">
     <span style={{display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 6}}>
@@ -123,7 +122,7 @@ favicons, avatars, or motion accents.
     </span>
   </OptionTile>
   <OptionTile name="Terminal Cursor" note="Lowercase mono 'bop' with a blinking caret. Pure engineer energy; animates natively.">
-    <span style={{fontFamily: 'var(--font-mono)', fontSize: '1.8rem', fontWeight: 500, color: 'var(--text-heading)'}}>bop<span style={{color: 'var(--ifm-color-primary)', fontWeight: 700}}>_</span></span>
+    <span style={{fontFamily: 'var(--font-mono)', fontSize: '1.8rem', fontWeight: 500, color: 'var(--text-heading)'}}>bop<BlinkCaret /></span>
   </OptionTile>
   <OptionTile name="The Semicolon" note="Code's quiet period of intention: a pause with purpose. Minimal, witty, scales tiny.">
     <span style={{fontFamily: 'var(--font-serif-display)', fontSize: '3.2rem', fontWeight: 600, color: 'var(--ifm-color-primary)', lineHeight: 1}}>;</span>
@@ -133,7 +132,7 @@ favicons, avatars, or motion accents.
       <span style={{display: 'flex', height: 16, background: 'var(--ifm-color-primary)', alignItems: 'center', gap: 4, padding: '0 6px'}}>
         {[0,1,2].map(i => <i key={i} style={{width: 5, height: 5, borderRadius: '50%', background: 'rgba(255,255,255,0.55)'}} />)}
       </span>
-      <span style={{display: 'block', background: 'var(--surface-card)', padding: '10px 8px', fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--text-heading)'}}>bop_</span>
+      <span style={{display: 'block', background: 'var(--surface-card)', padding: '10px 8px', fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--text-heading)'}}>bop<BlinkCaret /></span>
     </span>
   </OptionTile>
 </OptionGrid>

--- a/bytesofpurpose-blog/src/components/DesignSystem/AnimatedMarks.tsx
+++ b/bytesofpurpose-blog/src/components/DesignSystem/AnimatedMarks.tsx
@@ -1,0 +1,95 @@
+import React, {useEffect, useState} from 'react';
+import styles from './styles.module.css';
+
+/**
+ * AnimatedMarks — the logo mockups that were ALIVE in the design project, rebuilt faithfully:
+ *  - SplitFlapMark: the green cathedral arch housing a real Vestaboard flap that mechanically rolls
+ *    B → 0 → 1 → blank (the CHOSEN direction). The fold leaf is CSS; the glyph cycling is JS.
+ *  - BitCursor: a mono bit inside the arch flashing 1 → 0 → empty.
+ *  - BlinkCaret: a blinking terminal caret.
+ * All motion respects prefers-reduced-motion (discipline rule 6): the JS timers early-return when
+ * reduced motion is on (pinning the first frame), and the CSS fold/blink self-guard in the module.
+ */
+
+/** Local mirror of the repo's useReducedMotion (index.tsx) — reactive, SSR-safe. */
+function useReducedMotion(): boolean {
+  const [reduce, setReduce] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return undefined;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduce(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+  return reduce;
+}
+
+/** Cycle through `frames` every `intervalMs`, pausing on reduced motion (holds the first frame). */
+function useCycle(frames: string[], intervalMs: number): string {
+  const reduce = useReducedMotion();
+  const [i, setI] = useState(0);
+  useEffect(() => {
+    if (reduce) return undefined;
+    const id = setInterval(() => setI((n) => (n + 1) % frames.length), intervalMs);
+    return () => clearInterval(id);
+  }, [reduce, intervalMs, frames.length]);
+  return frames[reduce ? 0 : i];
+}
+
+/** One physical flap tile (dark housing, folding leaf) showing `glyph`. */
+function Flap({glyph}: {glyph: string}): React.JSX.Element {
+  return (
+    <span className={`${styles.flap} ${styles.flapSolo}`}>
+      <span className={styles.flapGlyph}>{glyph}</span>
+      <span className={styles.flapFold} aria-hidden="true" />
+    </span>
+  );
+}
+
+/**
+ * The chosen mark: the green arch as the flap's housing, the flap rolling B → 0 → 1 → blank.
+ * `outline` renders the hairline-arch variant.
+ */
+export function SplitFlapMark({outline = false}: {outline?: boolean}): React.JSX.Element {
+  const glyph = useCycle(['B', '0', '1', ' '], 1400);
+  return (
+    <span
+      className={outline ? styles.archFlapOutline : styles.archFlap}
+      role="img"
+      aria-label="Arch housing a Vestaboard flap rolling B, 0, 1, blank">
+      <Flap glyph={glyph} />
+    </span>
+  );
+}
+
+/** The arch with a mono bit flashing 1 → 0 → empty. `outline` renders the hairline variant. */
+export function BitCursor({outline = false}: {outline?: boolean}): React.JSX.Element {
+  const bit = useCycle(['1', '0', ' '], 800);
+  return (
+    <span
+      className={outline ? styles.archFlapOutline : styles.archFlap}
+      role="img"
+      aria-label="Arch with a bit cursor flashing one, zero, empty">
+      <span
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontWeight: 'var(--weight-bold)' as React.CSSProperties['fontWeight'],
+          fontSize: '1.9rem',
+          color: outline ? 'var(--ifm-color-primary)' : '#f4f1ea',
+          lineHeight: 1,
+        }}>
+        {bit}
+      </span>
+    </span>
+  );
+}
+
+/** A blinking terminal caret (used inline in the terminal marks). */
+export function BlinkCaret(): React.JSX.Element {
+  return (
+    <span className={styles.caret} aria-hidden="true">
+      _
+    </span>
+  );
+}

--- a/bytesofpurpose-blog/src/components/DesignSystem/index.ts
+++ b/bytesofpurpose-blog/src/components/DesignSystem/index.ts
@@ -10,6 +10,7 @@ export {RadiusSwatches, ElevationDemo} from './RadiusElevationDemo';
 export {default as TokenTable} from './TokenTable';
 export {BrandMarks, FeatureIcons, ArchIllustrations} from './BrandMarks';
 export {OptionGrid, OptionTile, DecisionNote} from './OptionGrid';
+export {SplitFlapMark, BitCursor, BlinkCaret} from './AnimatedMarks';
 export {
   ButtonRow,
   ChipRow,

--- a/bytesofpurpose-blog/src/components/DesignSystem/styles.module.css
+++ b/bytesofpurpose-blog/src/components/DesignSystem/styles.module.css
@@ -554,3 +554,126 @@
   line-height: var(--leading-body);
   margin-top: var(--space-1);
 }
+
+/* ---- Animated logo marks (faithful to the design project's live mockups) --- */
+
+/* A single physical Vestaboard flap tile: dark recessed housing, warm off-white mono glyph,
+   a center seam, and a top leaf that folds down each beat. The glyph cycling (B → 0 → 1 → blank)
+   is driven in JS so it is reliable; the fold is pure CSS. */
+.flap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.74em;
+  height: 1.12em;
+  font-family: var(--font-mono);
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+  border-radius: 0.1em;
+  overflow: hidden;
+  color: #f4f1ea;
+  background: linear-gradient(180deg, #2b2b2e 0%, #202023 49%, #161618 51%, #1d1d20 100%);
+  box-shadow: inset 0 0.04em 0.02em rgba(255, 255, 255, 0.08),
+    inset 0 -0.04em 0.04em rgba(0, 0, 0, 0.5), 0 0.03em 0.06em rgba(0, 0, 0, 0.28);
+}
+
+.flap::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 0.055em;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.55);
+  box-shadow: 0 0.04em 0.03em rgba(0, 0, 0, 0.4);
+  z-index: 4;
+  pointer-events: none;
+}
+
+.flapGlyph {
+  position: relative;
+  z-index: 5;
+}
+
+/* The folding top leaf sweeps down each beat as a translucent shadow (glyph stays legible above). */
+.flapFold {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 50%;
+  z-index: 3;
+  transform-origin: bottom center;
+  backface-visibility: hidden;
+  background: linear-gradient(180deg, rgba(8, 8, 9, 0.85), rgba(8, 8, 9, 0.15));
+  animation: flapfold 1.4s ease-in infinite;
+}
+
+@keyframes flapfold {
+  0% {
+    transform: rotateX(0deg);
+  }
+  26% {
+    transform: rotateX(-90deg);
+  }
+  99.9% {
+    transform: rotateX(-90deg);
+  }
+  100% {
+    transform: rotateX(0deg);
+  }
+}
+
+.flapSolo {
+  font-size: 40px;
+}
+
+/* A blinking terminal caret. */
+.caret {
+  color: var(--ifm-color-primary);
+  font-weight: var(--weight-bold);
+  animation: dsBlink 1.1s step-end infinite;
+}
+
+@keyframes dsBlink {
+  50% {
+    opacity: 0;
+  }
+}
+
+/* The green arch housing for the flap (solid + outline variants). */
+.archFlap {
+  width: 60px;
+  height: 70px;
+  background: var(--ifm-color-primary);
+  border-radius: 30px 30px 6px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+}
+
+.archFlapOutline {
+  width: 60px;
+  height: 70px;
+  border: 2.5px solid var(--ifm-color-primary);
+  border-radius: 30px 30px 6px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-tint);
+}
+
+/* Reduced motion: hold the fold and the caret still (discipline rule 6). The JS glyph cycling
+   also stops via useReducedMotion in the component; this pins the CSS pieces. */
+@media (prefers-reduced-motion: reduce) {
+  .flapFold {
+    animation: none;
+    transform: rotateX(0deg);
+  }
+  .caret {
+    animation: none;
+  }
+}

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -31,6 +31,9 @@ import {
   OptionGrid,
   OptionTile,
   DecisionNote,
+  SplitFlapMark,
+  BitCursor,
+  BlinkCaret,
   ButtonRow,
   ChipRow,
   DemoButton,
@@ -158,6 +161,11 @@ export default {
   OptionGrid,
   OptionTile,
   DecisionNote,
+  // Animated logo marks (faithful to the design project's live mockups): the chosen split-flap
+  // rolling B→0→1→blank, the arch bit cursor, the blinking caret. All reduced-motion guarded.
+  SplitFlapMark,
+  BitCursor,
+  BlinkCaret,
   // Live control specimens rendered from the repo's real Infima button classes + tokens
   // (Buttons + Core Components pages): buttons, pastel tags, badges, callouts.
   ButtonRow,


### PR DESCRIPTION
## What

The design-system Logos page rendered the logo directions **statically**, but several were **animated** in the source design project. This restores the motion, faithfully.

- **SplitFlapMark** — the chosen *green arch × Vestaboard* mark is now a real folding **split-flap** that mechanically rolls **B → 0 → 1 → blank** (fold leaf in CSS, glyph cycling in JS). Solid + outline variants.
- **BitCursor** — adds the *Arch + Bit Cursor* direction: the arch flashing **1 → 0 → empty**.
- **BlinkCaret** — the *Terminal Cursor* and *Terminal Window* marks now **blink**.

## How

- New `src/components/DesignSystem/AnimatedMarks.tsx` (SplitFlapMark / BitCursor / BlinkCaret), registered in `MDXComponents.tsx`, wired into the Logos `OptionTile`s.
- Keyframes (`flapfold`, `dsBlink`) + physical-flap styling added to the DesignSystem CSS module.
- **All motion respects `prefers-reduced-motion`** (discipline rule 6): the JS timers early-return via a local `useReducedMotion` (pinning the first frame); the CSS fold/blink self-guard in the module.

## Verification (local)

- Verified live: the flap glyph cycles **B → 0 → 1 → blank** over time (confirmed reading the DOM across beats); bit cursor + caret animate; **no console errors**.
- Reduced-motion guard confirmed present in the shipped CSS + the JS hook.
- Gates clean: structure, ds-tokens, contrast, links.

## Note

Builds on the design-system section from #136 (merged). Independent of the in-flight slide-deck branch; touches only the Logos page + the DesignSystem kit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)