### PR TITLE
fix(brand): navbar logo headroom + hover no longer flips

### DIFF
--- a/bytesofpurpose-blog/src/components/DesignSystem/AnimatedMarks.tsx
+++ b/bytesofpurpose-blog/src/components/DesignSystem/AnimatedMarks.tsx
@@ -81,7 +81,8 @@ export function SplitFlapMark({
 }: SplitFlapMarkProps): React.JSX.Element {
   // One flip every 15s, cycling B → 0 → P → 1. `direct` makes each change a SINGLE fold straight to
   // the target (no rolling through the deck), so the mark rests on the glyph the rest of the beat.
-  const [glyph, kick] = useGlyphCycle(BYTE_FRAMES, {intervalMs: 15000});
+  // The flip is auto-timed only; hovering does nothing (no per-hover flip).
+  const [glyph] = useGlyphCycle(BYTE_FRAMES, {intervalMs: 15000});
   const archClass = `${outline ? styles.archFlapOutline : styles.archFlap} ${
     compact ? styles.archFlapNavbar : ''
   }`;
@@ -89,8 +90,7 @@ export function SplitFlapMark({
     <span
       className={archClass}
       role="img"
-      aria-label="Arch housing a Vestaboard flap flipping B, 0, P, 1"
-      onMouseEnter={kick}>
+      aria-label="Arch housing a Vestaboard flap flipping B, 0, P, 1">
       {/* SplitFlap tiles are em-sized, so font-size on this wrapper scales the flap. */}
       <span style={{fontSize: size, display: 'inline-flex'}}>
         <SplitFlap text={glyph} settleMs={520} direct />
@@ -135,7 +135,7 @@ export function BlinkCaret(): React.JSX.Element {
  * motion fallback for the navbar logo, so the header never looks broken before hydration. Sized to
  * the navbar via the `size` font-size.
  */
-export function ArchStatic({size = '16px'}: {size?: string}): React.JSX.Element {
+export function ArchStatic({size = '14px'}: {size?: string}): React.JSX.Element {
   return (
     <span
       className={`${styles.archFlap} ${styles.archFlapNavbar}`}
@@ -152,7 +152,7 @@ export function ArchStatic({size = '16px'}: {size?: string}): React.JSX.Element 
  * on hover); the design-system page uses it 'continuous'. Navbar-sized by default.
  */
 export function ArchFlapLogo({
-  size = '16px',
+  size = '14px',
   cadence = 'occasional',
 }: {
   size?: string;

--- a/bytesofpurpose-blog/src/components/DesignSystem/styles.module.css
+++ b/bytesofpurpose-blog/src/components/DesignSystem/styles.module.css
@@ -583,9 +583,11 @@
 }
 
 /* Navbar variant: a compact arch that fits the header line (tight padding + smaller corner) so the
-   mark aligns with the wordmark and never overflows the navbar height. */
+   mark aligns with the wordmark and never overflows the navbar height. Top padding gives the domed
+   top breathing room above the letter card; a slightly larger bottom keeps the tile nudged UP from
+   the arch base (not sitting on the floor). */
 .archFlapNavbar {
-  padding: 3px 5px 4px;
+  padding: 7px 6px 5px;
   border-radius: 16px 16px 4px 4px;
 }
 


### PR DESCRIPTION
Two navbar-logo refinements from live feedback (follow-ups to #139):

- **Headroom / sizing:** the flap tile hugged the arch dome. Shrunk the navbar flap (16px → 14px) and gave the compact arch more top headroom (`padding: 7px 6px 5px`), so the domed top has breathing room above the letter card and the tile sits a touch higher off the base.
- **Cadence:** the flap already auto-flips every 15s (B→0→P→1, verified in the browser). **Removed the per-hover flip** so hovering does nothing — the motion is auto-timed only.

## Verification
- Hover no longer changes the glyph (5 rapid hovers → stayed "B").
- Auto-flip still fires on the 15s timer (observed P→1→B unattended).
- Sizing looks balanced (headroom under the dome), light + dark.
- typecheck + ds-tokens clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)