### PR TITLE
chore(designs): publish the pitch-deck post

### DIFF
--- a/bytesofpurpose-blog/designs/2026-07-01-blog-pitch-deck.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-01-blog-pitch-deck.mdx
@@ -5,10 +5,8 @@ title: The Blog, Pitched as a Deck
 sidebar_label: Pitch Deck
 kind: frontend-design
 description: >-
-  A seven-slide pitch deck for this blog, built as a reveal.js deck embedded in
-  the post and themed entirely from the site's own design-system tokens. The
-  write-up covers the SlideDeck component: how reveal.js is lazy-loaded in the
-  browser only, and how the deck reads as the same brand as the page around it.
+  A seven-slide pitch deck for this blog, built as a live reveal.js deck embedded
+  in the post and themed entirely from the site's own design-system tokens.
 authors:
   - oeid
 tags:
@@ -16,7 +14,7 @@ tags:
   - design-system
   - docusaurus
 image: /img/social-card.png
-draft: true
+draft: false
 ---
 
 I built a pitch deck for this blog inside a design system, then brought it home as a real,


### PR DESCRIPTION
Publishes the reveal.js pitch-deck post (from #137) by flipping `draft: true` → `draft: false`, and shortens the description to fit the SEO limit.

## Changes
- `draft: false` — `/designs/blog-pitch-deck` now ships in the production build (previously dev-only).
- Description shortened 307 → 153 chars (the 307-char version tripped `validate-seo`'s `description-length` warning and would truncate in search/social cards).

## Verified
- ✅ Renders on current `master` in the dev server — the deck picked up the new **Space Grotesk** display font (#140) automatically via `var(--font-serif-display)`, proving the token-driven theming.
- ✅ `validate-seo` / `validate-links` / `validate-redirects` clean.
- ✅ Sidebar shows "Pitch Deck" with no draft badge.

Note: had to `yarn install` in this checkout — concurrent branch activity had left `node_modules` without `reveal.js` (it's in `package.json`/`yarn.lock` on master via #137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)