### PR TITLE
fix(designs): arrow keys navigate the slide deck

### DIFF
--- a/bytesofpurpose-blog/src/components/SlideDeck/index.tsx
+++ b/bytesofpurpose-blog/src/components/SlideDeck/index.tsx
@@ -229,12 +229,24 @@ function SlideDeckImpl({children, width = 1280, height = 720}: SlideDeckProps): 
 
   return (
     <div className={styles.deckFrame}>
-      <div className={clsx('reveal', styles.reveal)} ref={deckRef} tabIndex={-1}>
+      {/* tabIndex=0 makes the deck keyboard-focusable AND focusable-on-click, and
+          onMouseDown focuses it so the very first click (not just a Tab) arms the
+          arrow keys. Paired with reveal's keyboardCondition:'focused', arrows drive
+          the deck only while it holds focus and never hijack page scroll for a reader
+          skimming past it. role/aria-label name it for assistive tech. */}
+      <div
+        className={clsx('reveal', styles.reveal)}
+        ref={deckRef}
+        tabIndex={0}
+        role="group"
+        aria-label="Slide deck. Use arrow keys to navigate, Escape for the slide grid."
+        onMouseDown={() => deckRef.current?.focus()}
+      >
         <div className="slides">{children}</div>
       </div>
       <p className={styles.hint}>
-        Use ← / → to move, <kbd>F</kbd> for fullscreen, <kbd>S</kbd> for speaker notes, <kbd>Esc</kbd>{' '}
-        for the slide grid.
+        Click the deck, then use ← / → to move, <kbd>F</kbd> for fullscreen, <kbd>S</kbd> for speaker
+        notes, <kbd>Esc</kbd> for the slide grid.
       </p>
     </div>
   );

--- a/bytesofpurpose-blog/src/components/SlideDeck/styles.module.css
+++ b/bytesofpurpose-blog/src/components/SlideDeck/styles.module.css
@@ -22,6 +22,14 @@
   overflow: hidden;
   background: var(--surface-page);
   box-shadow: var(--ifm-global-shadow-lw);
+  outline: none;
+}
+/* The deck is keyboard-focusable (tabIndex=0); show a brand focus ring when it holds
+   focus so the reader knows the arrow keys are armed. :focus-visible keeps it off for
+   plain mouse clicks. */
+.reveal:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
 }
 
 /* reveal sets font on .reveal; pin ours so nothing leaks Infima's stack. */


### PR DESCRIPTION
The published pitch deck (`/designs/blog-pitch-deck`) didn't respond to ← / → — the keys scrolled the page instead of moving slides.

## Cause
reveal.js was configured with `keyboardCondition: 'focused'` (so it wouldn't hijack page scroll globally), but the `.reveal` element was `tabIndex={-1}` and nothing ever focused it — so it never held focus, and the arrows fell through to the page.

## Fix
- `tabIndex={0}` — the deck is now keyboard-focusable and click-focusable.
- `onMouseDown` focuses the deck so the **first click arms the arrows** (no Tab needed).
- `role="group"` + `aria-label` name it for assistive tech.
- `:focus-visible` brand focus ring so the reader sees the deck is armed.
- Hint updated to "Click the deck, then use ← / →".
- Kept `keyboardCondition: 'focused'` so a reader skimming past the deck still scrolls the page normally.

## Verified
- ✅ Clicked the deck, ← / → move between slides (cover ⇄ premise), in-browser.
- ✅ Zero console errors on the current build.
- ✅ `validate-ds-tokens` clean on the CSS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)