### PR TITLE
docs(changelog): archive the reorg + hub-system task batches

### DIFF
--- a/bytesofpurpose-blog/changelog/CLAUDE-CHANGELOG.md
+++ b/bytesofpurpose-blog/changelog/CLAUDE-CHANGELOG.md
@@ -21,6 +21,32 @@
   component=Claude. Date drives the card's execution/inception date.
 -->
 
+## [2026-07-02] The durable-hub system: kinds, unified area, and three hubs
+<!-- meta: type=feature category=development priority=high component=Site -->
+Turned the ad-hoc Projects hub from the first batch into a real, enforced SYSTEM. A "hub" is now a durable `/craft` index page (a new `kind: hub`) that catalogs the dated `/initiatives` logs of one activity, grouped by area, via a generated `<Catalog>` component. Established that `/craft` docs can carry a `kind:` (they could not surface an emoji before; the `draft-docs` plugin now derives a docs kind emoji the same way it does for blog posts). Introduced two new activity kinds (project, tinkering) plus a single unified `area:` field (backend, frontend, script, plugin) so the model scales to many hubs without a field per hub. Generalized the one-off ProjectsCatalog into a manifest-driven generator plus a generic `<Catalog kind="...">` component, and migrated the existing project posts onto it. Moved 34 more dated logs (project, tinkering, research) out of `/craft` into `/initiatives`, retired the emptied folders, and stood up Tinkering and Research hubs (research logs also flow onto the existing Research board by stage, so the hub is the by-area view and the board the by-progress view). Made the whole thing self-sustaining: a `make validate-hubs` gate plus a warn hook that catch a hub rendering no catalog or a post missing its area, a CLAUDE.md operating convention, and a `manage-hubs` skill that owns the registry and the add-a-hub checklist.
+
+- Should the flagged /craft project-log docs move to /initiatives, and which ones?
+- Where should the durable Projects hub live under Software Development, and what should it link?
+- Should backend and plugins project logs also move to /initiatives and the Projects hub?
+- Should there be a Tinkering hub, and should the tinkering logs move to /initiatives?
+- Should the research logs get a Research hub, given the existing Research board?
+- Should there be a dedicated hub post kind, and can /craft docs carry a kind at all?
+- Auto-link initiatives into their hub by frontmatter tag (confirmed the generated design)
+- Document the durable hubs as a CLAUDE.md operating convention
+- Do we need a manage-hubs skill that owns the hub registry and the powering kinds?
+- Build the kind system, docs kind emoji, generic Catalog, and migrate the Projects hub
+- Move 34 project, tinkering, and research logs and stand up the Tinkering and Research hubs
+- Formalize the hubs with a validate-hubs gate, the convention, and the manage-hubs skill
+
+## [2026-07-02] Reorganize project logs into initiatives, plus two tag-driven catalogs
+<!-- meta: type=feature category=development priority=high component=Site -->
+A durable-versus-temporal cleanup under Software Development, prompted by dated project logs sitting in `/craft` as if they were lasting knowledge. Moved 25 project logs (the frontend and scripting `projects/` folders plus a few automation, analytics, and Home Assistant logs) onto the `/initiatives` blog, pairing each published move with a redirect and correctly leaving drafts without one (a redirect to a draft target fails the build gate). Built the first durable Projects hub: a generated index that groups the moved logs by area and links to each. Consolidated the scattered bookmark and setup-machine command dumps into one task-grouped cheatsheet. Turned the flat Tools page into a tag-driven Repos of Interest catalog (each repo tagged tool, relevant, GenAI, testing) with a generator that fails closed on a bad URL or an em-dash in a blurb. Added a conditional dev-server restart reminder: a Stop hook that nudges only when a server is actually running and the session changed a route-shaping file, so it never cries wolf.
+
+- Should the flagged /craft project-log docs move to /initiatives?
+- Consolidate the bookmark and setup-machine command dumps into one sectioned post
+- Should the Tools page become a tag-driven reference catalog of repos of interest?
+- Add a conditional dev-server restart reminder Stop hook
+
 ## [2026-07-01] Homepage UX fixes + a browser-based deploy verifier
 <!-- meta: type=feature category=development priority=high component=Site -->
 A batch of homepage and navbar fixes surfaced by looking at the live site, each shipped with a test and a proper deploy verification. The navbar now stays on one line and folds its rightmost items into a "More" dropdown (priority+ overflow) instead of collapsing to the mobile hamburger; the mobile drawer lists items one per line (a stray inline-flex wrapper from the hover-summary swizzle was breaking it); the hamburger glyph is vertically centered. The house hero stopped popping in (its above-the-fold arches load eagerly) and stopped rendering an EMPTY centre door on production (a prod-only CSS equal-specificity race left both door and scene at opacity 0; fixed by scoping the "on" rule to two classes, across all four layer pairs). The selected navbar item now has a clear brand-green underline accent instead of faint text. Zero broken links across the whole build. Closed the loop with a new `verify-prod-deployment` skill: a browser check that WAITS for the CDN to serve the exact bundle you built (Pages/Cloudflare hold the old build 1 to 3 min), confirms the deployed change actually renders, and watches every page it loads for real console errors and failed requests (filtering the known-benign Cloudflare Access probe noise).


### PR DESCRIPTION
Archives this session's completed tasks (16) into `CLAUDE-CHANGELOG.md` per the changelog convention (the task list crossed the 10-completed threshold).

## Two dated batches (2026-07-02)
1. **The durable-hub system** — the kind system (`project`/`tinkering`/`hub`), unified `area`, docs kind-emoji, the generic `<Catalog>`, moving 34 logs, the Tinkering + Research hubs, and the `validate-hubs` gate + `manage-hubs` skill (shipped as #149/#152/#153).
2. **Reorganize project logs into initiatives, plus two tag-driven catalogs** — the earlier reorg (25 logs → `/initiatives` + Projects hub), the bookmarks cheatsheet, the Repos of Interest catalog, and the dev-server restart hook (#145/#146/#147/#148).

## Verification
- Summaries de-em-dashed and every `<Catalog>` / `kind:` mention backtick-escaped (they render on `/changelog`, so a raw tag would break the build).
- Regenerated: **44 → 46 cards**; `make build` ✅ SUCCESS (summaries are MDX-safe).

The generated `changelog-data.json` is gitignored; only the `CLAUDE-CHANGELOG.md` source is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)