### PR TITLE
feat(genai): fan out References[GenAI] → reading-list / watches / tools / tips

### DIFF
--- a/.claude/skills/import-noteplan/SKILL.md
+++ b/.claude/skills/import-noteplan/SKILL.md
@@ -44,15 +44,27 @@ where it belongs, its kind) stays with you. It never edits blog content.
 | `--inventory <file>` | Parse a NotePlan file → JSON of every link (markdown + bare URL), its enclosing section-path (`A › B › C`), its annotation, `[ ]`/`[x]` task-state, line number, and whether it's already in the migration table. This feeds the classify step. |
 | `--snapshot <folder> --out <manifest.json>` | Tally every link + non-blank content line of every `.md` in the folder (above the marker) into a baseline manifest. Run ONCE at the start of a migration session. |
 | `--audit <folder> --baseline <manifest.json>` | Re-tally and assert nothing in the baseline is missing now (content may only grow). Exit 2 + a per-item report if any link/line was dropped. |
-| `--append-migration <file> --records <json>` | Append (create if absent) the `## 🔗 Migrated to Blog` table with the given rows. Pure append; dedups by source URL AND blog URL (idempotent); self-guards non-destructive. Use `--dry-run` to preview. |
+| `--append-migration <file> --records <json>` | Append (create if absent) the `## 🔗 Migrated to Blog` table with the given rows. Pure append; dedups by source URL / content (idempotent); self-guards non-destructive. Use `--dry-run` to preview. |
+| `--rebuild-migration <file> --records <json>` | REPLACE the whole managed table from a fresh record list — use it to REPOINT rows when destinations change (a link now fans out to a different doc/section). Still non-destructive: only the block below the sentinel is rewritten; the body above it stays byte-exact. |
 | `--verify <file> --baseline <pre-migration-copy>` | Assert the body above the marker is byte-identical to a pre-migration copy of the same file. Exit 0 safe / 1 destructive. |
 
-A migration record is `{link, url, blogUrl, kind, date}` (`url` = the source link, omit for a
-whole-section row; `blogUrl` = the destination). Records go via `--records '<json-array>'` or
-`--records-file <path>`.
+A migration record is `{link, url, content, blogUrl, section, kind, date}`:
+- **`url` + `link`** — a LINK migration: the source URL + its label. Rendered as `[link](url)` in the
+  source cell.
+- **`content`** (no `url`) — a NON-LINK migration (a tip, a note, a structured block): the moved TEXT
+  itself, rendered as a **code span** in the source cell instead of a link. This is how prose/structure
+  (e.g. the "what belongs in a CLAUDE.md" note) records WHAT was moved, not just that something was.
+- **`blogUrl`** — the destination DOC.
+- **`section`** (optional) — the destination doc's HEADING; the row deep-links to `blogUrl#anchor`
+  (anchor derived from the heading, matching Docusaurus's slug), so the row points at the EXACT section
+  the content became.
+
+Dedup is by **source URL** (a link migrated once is never re-migrated, even to a new section) or by
+**content key** for non-link rows (whitespace/case-insensitive). Records go via `--records '<json>'`
+or `--records-file <path>`.
 
 Run the bundled assertions any time you touch the transformer:
-`node .claude/skills/import-noteplan/import-noteplan.test.js` (8 assertions, exits non-zero on failure).
+`node .claude/skills/import-noteplan/import-noteplan.test.js` (16 assertions, exits non-zero on failure).
 
 ## The migration URL: record the true FINAL blog URL, at draft time
 
@@ -62,6 +74,41 @@ you decide its slug. So the table records the **real** `https://blog.bytesofpurp
 soon as the post is drafted — even before it's deployed. The URL is a fact, not a promise; the post
 just carries `draft: true` until the user approves and runs the normal `publish-site` / `deploy-site`
 flow. Never write a placeholder or a "TBD" URL into the NotePlan table.
+
+The table records the destination as a **deep link to the exact section** (`…/reading-list#llm-architecture`),
+not just the doc, via the record's `section` field. So a half-migrated file shows precisely what landed
+where.
+
+## Fan-out: one source file → MANY destination docs (by nature)
+
+A single NotePlan file is rarely one thing. `References[GenAI]` held reference articles AND conference
+talks AND creative tools AND a "what belongs in a CLAUDE.md" tip. **Do not force a whole file into one
+doc.** Route each item to the doc that fits its NATURE, and record the true destination per row:
+
+- **articles / papers / blog posts** → a **`reading-list`** doc (🔖).
+- **talks / long videos** (YouTube, conference recordings) → a **"Good Watches"** `reading-list` doc —
+  a reader picks a watch by mood + time, which is a different job from a reading list.
+- **tools / apps / libraries** → a **tools** `reading-list` doc (or `docs/craft/productivity/tool-usage`).
+- **tips / rules of thumb** (the CLAUDE.md note) → a **`tips`** doc (📌) at the right topic level (e.g.
+  `docs/craft/software-development/tips.mdx`).
+
+The migration table is the ledger that makes fan-out honest: every source item gets a row pointing at
+its OWN destination doc + section, so nothing is silently lumped or lost. When you discover a file fans
+out, propose the full destination map (which cluster → which doc) and confirm before drafting.
+
+## Enrich, don't dump: quote cards + non-link content
+
+Migrating is an UPGRADE, not a copy (same spirit as `import-co-design`). Two enrichments matter:
+
+- **Quote-worthy blockquotes → cards.** When a source link carries a genuine editorial insight (a `>`
+  blockquote with real commentary — "the takeaway most people miss is…"), render it as an
+  **`<EditorialQuote>`** card inside a `<QuoteSet>` (globally registered, works in docs too): the pull
+  line in the body, the insight as `reflection=`, the author as `source=`. Put the source LINK as a
+  plain markdown line after the card — **`cite=` renders as plain text**, so a link inside it is NOT
+  clickable (a real bug that bit; see Troubleshooting).
+- **Non-link content → a content-cell row.** Some migrated items are not links at all (a tip, a
+  structured note). Those become a `content` record (no `url`) — the table shows the moved text as a
+  **code span** in the source cell, so the note still records exactly WHAT was taken.
 
 ## Allow / deny — which Lists files are blog-eligible
 
@@ -97,20 +144,23 @@ touching a file, `TaskCreate` a task like *"Migrate NotePlan `References[GenAI]`
    `NOTEPLAN_BASELINE` to that path so the no-drop hook audits against it. (If you skip this, the hook
    self-baselines on the first edit — but an explicit snapshot is the honest starting line.)
 1. **Inventory the file.** `--inventory "<file>"` → the link/section JSON.
-2. **Classify each cluster.** Walk `organize-post`'s decision tree (durable vs temporal → acted-on vs
-   not → which kind). A section of curated links is usually durable `/craft`/`reference`; an
-   `# Idea:` heading is a `/thoughts` idea; a quote block is `quote-set`; a question block is
-   `question-set`. SPLIT a mixed file into one post per coherent kind — never force.
+2. **Classify each cluster + plan the FAN-OUT.** Walk `organize-post`'s decision tree (durable vs
+   temporal → acted-on vs → which kind), and route each cluster to the doc that fits its NATURE (see
+   "Fan-out" above): articles → a `reading-list`, talks → a Good Watches doc, tools → a tools doc,
+   tips → a `tips` doc, ideas → `/thoughts`, quotes → `quote-set`. SPLIT a mixed file across docs —
+   never force it into one.
 3. **Propose the destination MAP and CONFIRM with the user.** Show, per link/section: its destination
-   post (title + absolute slug), its `kind:`, and the final blog URL. Do NOT write anything —
-   NotePlan or blog — until the user confirms the map. (This is the "propose → confirm per batch"
-   contract.)
-4. **Draft the post(s).** Create the blog post(s) as `draft: true` with the confirmed absolute slug,
-   via `author-blog-post` (frontmatter + MDX pitfalls). Thin idea clusters → `mature-content` first;
-   a board-ready idea → `groom-initiatives`; link a defined term once → `link-glossary-terms`; then
-   `validate-links` on the new post.
-5. **Append the migration table.** `--append-migration "<file>" --records '<rows>'` with the real
-   final blog URLs. (`--dry-run` first if you want to eyeball the table.)
+   doc (title + absolute slug), its `kind:`, the section it lands in, and the final deep-link URL. Do
+   NOT write anything — NotePlan or blog — until the user confirms the map. (The "propose → confirm per
+   batch" contract.)
+4. **Draft the post(s), enriching as you go.** Create each doc as `draft: true` with its absolute slug,
+   via `author-blog-post`. Turn quote-worthy blockquotes into `<EditorialQuote>` cards (see "Enrich");
+   thin idea clusters → `mature-content` first; a board-ready idea → `groom-initiatives`;
+   `link-glossary-terms` + `validate-links` on the new post.
+5. **Append (or rebuild) the migration table.** `--append-migration "<file>" --records-file <path>`
+   with the real deep-link destinations (`blogUrl` + `section`) and any non-link `content` rows. Use
+   `--rebuild-migration` instead when repointing rows whose destination changed (e.g. a link now fans
+   out elsewhere). `--dry-run` first to eyeball it.
 6. **Verify non-destructive.** Copy the pre-migration file aside first (or use the git backup at
    `$NOTEPLAN_GIT_DIR`), then `--verify "<file>" --baseline <copy>` → must exit 0. Also re-run
    `--audit` against the session baseline → exit 0.
@@ -152,6 +202,9 @@ redirect on the blog per the CLAUDE.md redirect convention.
 | The `description:` frontmatter is gibberish | It's NotePlan's auto-summary. Ignore it; read the body. Do not copy it into the blog post's `description`. |
 | `--inventory` misses a link | It's likely a NotePlan `noteplan://` / `vscode://` / `x-callback` link, not an `http(s)` URL. Those are app-local and usually NOT migrated (they don't resolve for a reader); if one should be, record it as a section row (no `url`). |
 | Audit reports a "line" drop that's just reflow | The guard tallies trimmed non-blank lines; genuinely re-wrapping a line changes it. If the content is truly preserved (just reformatted), re-snapshot the baseline deliberately — but confirm nothing was actually lost first. |
+| A quote card's source link shows as literal `[text](url)` | `<EditorialQuote cite=…>` renders `cite` as PLAIN TEXT, not markdown. Put the source link as a plain markdown line AFTER the card, and use `cite` only for prose attribution ("via Ryan Holiday"). |
+| Adding a new kind (reading-list / tips / …) fails `validate-post-outline` | Add the kind to `blog-kinds.json` (unique emoji — check for collisions), a matching CHECKS entry in `validate-post-outline.js` if it has a NEW outline id, AND a row in the `docs/handbook/README.mdx` legend table (the legend-drift check enforces it). |
+| A migrated link needs to move to a different doc later | Rebuild, don't re-append: `--rebuild-migration` with the corrected records replaces the whole table (repointing the row) while keeping the body above the sentinel byte-exact. |
 
 ## Files
 

--- a/.claude/skills/import-noteplan/import-noteplan.js
+++ b/.claude/skills/import-noteplan/import-noteplan.js
@@ -102,6 +102,29 @@ function migratedUrlsFromBlock(block) {
   return urls;
 }
 
+/** A stable idempotency key for a moved NON-LINK content blob (whitespace-collapsed). */
+function contentKey(content) {
+  return String(content).replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Extract the moved NON-LINK content already recorded (code-span source cells) for idempotency. */
+function migratedContentFromBlock(block) {
+  if (!block) return new Set();
+  const keys = new Set();
+  for (const line of block.split('\n')) {
+    const cells = line.split('|').map((c) => c.trim());
+    if (cells.length < 5) continue;
+    // A non-link source cell is a code span: `…content…` (no markdown link).
+    const cm = cells[1] && cells[1].match(/^`(.+)`$/);
+    if (cm && !/\]\(/.test(cells[1])) {
+      // Undo the newline placeholder + backtick escaping we render with.
+      const restored = cm[1].replace(/ ⏎ /g, ' ').replace(/ˋ/g, '`');
+      keys.add(contentKey(restored));
+    }
+  }
+  return keys;
+}
+
 // ---------------------------------------------------------------------------
 // --inventory
 // ---------------------------------------------------------------------------
@@ -207,29 +230,74 @@ function cell(value) {
 }
 
 /**
- * Render a single table row. A record is { link, url, blogUrl, kind, date }.
- *  - link/url describe the SOURCE (either a label + url, or just a section name).
- *  - blogUrl is the destination on the blog.
+ * Derive a Docusaurus heading anchor from a section heading's TEXT — the slug it
+ * generates for `## Some Heading` (lower-case, spaces→hyphens, punctuation
+ * dropped). So `section: "LLM architecture"` → `#llm-architecture`, letting a
+ * migration row deep-link to the exact section the content landed in.
+ */
+function anchorSlug(heading) {
+  return String(heading)
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '') // drop punctuation (keep word chars, spaces, hyphens)
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/** The destination cell value: blogUrl, deep-linked to #section-anchor when a section is given. */
+function destination(rec) {
+  if (!rec.blogUrl) return '';
+  if (rec.section && !rec.blogUrl.includes('#')) {
+    return `${rec.blogUrl}#${anchorSlug(rec.section)}`;
+  }
+  return rec.blogUrl;
+}
+
+/**
+ * Render the SOURCE cell (the first column) of a migration row.
+ *  - A LINK migration → `[text](url)` (or a bare `<url>`).
+ *  - A NON-LINK migration (a tip, a note, a structured block — no `url`) → the
+ *    moved content itself as an inline code span, so the note records WHAT was
+ *    moved, not just that something was. Newlines in the content become ` ⏎ ` so
+ *    it stays one table cell; the code span keeps it visually distinct.
+ */
+function sourceCell(rec) {
+  if (rec.url && rec.link) return `[${cell(rec.link)}](${rec.url})`;
+  if (rec.url) return `<${rec.url}>`;
+  if (rec.content) {
+    const oneLine = String(rec.content).replace(/\r?\n/g, ' ⏎ ').replace(/`/g, 'ˋ').trim();
+    return '`' + cell(oneLine) + '`';
+  }
+  return cell(rec.link || rec.section || '(section)');
+}
+
+/**
+ * Render a single table row. A record is { link, url, content, blogUrl, section, kind, date }.
+ *  - link/url describe a LINK source; `content` is a NON-LINK source (rendered as
+ *    a code span in the source cell instead of a link).
+ *  - blogUrl is the destination doc; `section` (optional) is the destination
+ *    doc's HEADING, rendered as a `#anchor` deep link so the row points at the
+ *    exact section the content became.
  */
 function renderRow(rec) {
-  const label =
-    rec.url && rec.link
-      ? `[${cell(rec.link)}](${rec.url})`
-      : rec.url
-        ? `<${rec.url}>`
-        : cell(rec.link || rec.section || '(section)');
-  return `| ${label} | ${cell(rec.blogUrl)} | ${cell(rec.kind)} | ${cell(rec.date)} |`;
+  return `| ${sourceCell(rec)} | ${cell(destination(rec))} | ${cell(rec.kind)} | ${cell(rec.date)} |`;
 }
 
 function appendMigration(file, records) {
   const original = readFileUtf8(file);
   const { body, block } = splitAtMarker(original);
 
-  // Idempotency: skip records whose source url OR blogUrl is already recorded.
+  // Idempotency: the SOURCE url is the primary key — a link migrated once is not
+  // migrated again (even if it now points at a different section). Fall back to the
+  // full rendered destination (blogUrl#anchor) for section-only rows that have no
+  // source url.
   const existing = migratedUrlsFromBlock(block);
+  const existingContent = migratedContentFromBlock(block);
   const fresh = records.filter((r) => {
     if (r.url && existing.has(r.url)) return false;
-    if (r.blogUrl && existing.has(r.blogUrl)) return false;
+    if (!r.url && r.content && existingContent.has(contentKey(r.content))) return false;
+    if (!r.url && !r.content && existing.has(destination(r))) return false;
     return true;
   });
 
@@ -240,25 +308,44 @@ function appendMigration(file, records) {
   if (block === null) {
     // Create the block. The body is preserved byte-exact; the block owns its
     // leading `\n\n` separator so verify sees the body unchanged.
-    const newBlock =
-      '\n\n' +
-      SENTINEL +
-      '\n' +
-      MARKER +
-      '\n\n' +
-      TABLE_HEADER +
-      '\n' +
-      TABLE_DIVIDER +
-      '\n' +
-      fresh.map(renderRow).join('\n') +
-      '\n';
-    return { changed: true, added: fresh.length, content: body + newBlock };
+    return { changed: true, added: fresh.length, content: body + buildBlock(fresh) };
   }
 
   // Extend the existing block: append rows after the last table row.
   const trimmed = block.replace(/\s+$/, '');
   const newBlock = trimmed + '\n' + fresh.map(renderRow).join('\n') + '\n';
   return { changed: true, added: fresh.length, content: body + newBlock };
+}
+
+/** Build the full managed block (separator + sentinel + table) from a record list. */
+function buildBlock(records) {
+  return (
+    '\n\n' +
+    SENTINEL +
+    '\n' +
+    MARKER +
+    '\n\n' +
+    TABLE_HEADER +
+    '\n' +
+    TABLE_DIVIDER +
+    '\n' +
+    records.map(renderRow).join('\n') +
+    '\n'
+  );
+}
+
+/**
+ * REBUILD the entire managed table from a fresh record list. Unlike append (which
+ * only adds), this REPLACES every row below the sentinel — use it to REPOINT rows
+ * when destinations change (e.g. a link now fans out to a different doc/section).
+ * Still fully non-destructive: only the block below the sentinel is rewritten; the
+ * user's body above it is preserved byte-for-byte (assertNonDestructive proves it).
+ */
+function rebuildMigration(file, records) {
+  const original = readFileUtf8(file);
+  const { body } = splitAtMarker(original);
+  const content = body + buildBlock(records);
+  return { changed: true, added: records.length, content };
 }
 
 /**
@@ -420,8 +507,10 @@ function main() {
   }
 
   const appendFile = getFlag(argv, '--append-migration');
-  if (appendFile) {
-    const abs = path.resolve(appendFile);
+  const rebuildFile = getFlag(argv, '--rebuild-migration');
+  if (appendFile || rebuildFile) {
+    const isRebuild = Boolean(rebuildFile);
+    const abs = path.resolve(appendFile || rebuildFile);
     const recordsArg = getFlag(argv, '--records');
     const recordsFile = getFlag(argv, '--records-file');
     let records;
@@ -430,16 +519,18 @@ function main() {
     } else if (recordsArg) {
       records = JSON.parse(recordsArg);
     } else {
-      console.error('--append-migration requires --records <json> or --records-file <path>');
+      console.error(
+        `${isRebuild ? '--rebuild-migration' : '--append-migration'} requires --records <json> or --records-file <path>`
+      );
       process.exit(2);
     }
     if (!Array.isArray(records)) records = [records];
-    const result = appendMigration(abs, records);
+    const result = isRebuild ? rebuildMigration(abs, records) : appendMigration(abs, records);
     const dryRun = argv.includes('--dry-run');
     if (dryRun) {
       process.stdout.write(result.content);
       console.error(
-        `\n[dry-run] would ${result.changed ? `add ${result.added} row(s)` : 'make NO change'}.`
+        `\n[dry-run] would ${isRebuild ? `rebuild the table with ${result.added} row(s)` : result.changed ? `add ${result.added} row(s)` : 'make NO change'}.`
       );
       return;
     }
@@ -447,7 +538,9 @@ function main() {
       // Fail-closed: never write unless the original body is preserved byte-exact.
       assertNonDestructive(readFileUtf8(abs), result.content);
       fs.writeFileSync(abs, result.content);
-      console.error(`Appended ${result.added} migration row(s) to ${path.basename(abs)}.`);
+      console.error(
+        `${isRebuild ? 'Rebuilt' : 'Appended'} ${result.added} migration row(s) ${isRebuild ? 'in' : 'to'} ${path.basename(abs)}.`
+      );
     } else {
       console.error('No new rows to append (all records already migrated).');
     }
@@ -522,6 +615,7 @@ function main() {
       '  node import-noteplan.js --inventory <file>',
       '  node import-noteplan.js --append-migration <file> --records <json> [--dry-run]',
       '  node import-noteplan.js --append-migration <file> --records-file <path> [--dry-run]',
+      '  node import-noteplan.js --rebuild-migration <file> --records-file <path> [--dry-run]',
       '  node import-noteplan.js --verify <file> --baseline <pre-migration-copy>',
       '  node import-noteplan.js --snapshot <folder> --out <manifest.json>',
       '  node import-noteplan.js --audit <folder> --baseline <manifest.json>',
@@ -541,6 +635,12 @@ module.exports = {
   snapshot,
   audit,
   tallyFile,
+  rebuildMigration,
+  anchorSlug,
+  destination,
+  sourceCell,
+  renderRow,
+  contentKey,
   MARKER,
   SENTINEL,
 };

--- a/.claude/skills/import-noteplan/import-noteplan.test.js
+++ b/.claude/skills/import-noteplan/import-noteplan.test.js
@@ -88,12 +88,14 @@ test('idempotent: re-append same record adds nothing', () => {
   assert.strictEqual(second.changed, false, 'no change on re-run');
   assert.strictEqual(second.added, 0);
 });
-test('dedup by blogUrl too', () => {
+test('two DIFFERENT source links to the same doc both migrate (source url is the key)', () => {
   const { p } = tmp(SAMPLE);
   const first = M.appendMigration(p, [{ link: 'A', url: 'https://a', blogUrl: 'https://blog.x/same', kind: 'k', date: 'd' }]);
   fs.writeFileSync(p, first.content);
+  // A different source link landing on the same doc is NOT a dup — two articles
+  // can share a section. Dedup is by SOURCE url, not destination.
   const second = M.appendMigration(p, [{ link: 'B', url: 'https://b', blogUrl: 'https://blog.x/same', kind: 'k', date: 'd' }]);
-  assert.strictEqual(second.added, 0, 'same blogUrl is a dup');
+  assert.strictEqual(second.added, 1, 'distinct source url → fresh, even to the same doc');
 });
 
 console.log('verify');
@@ -122,6 +124,81 @@ test('assertNonDestructive throws when body would change', () => {
       `orig=${JSON.stringify(orig)} should preserve body`
     );
   }
+});
+
+console.log('section anchors (deep-link destinations)');
+test('anchorSlug matches Docusaurus heading slugs', () => {
+  assert.strictEqual(M.anchorSlug('LLM architecture'), 'llm-architecture');
+  assert.strictEqual(M.anchorSlug('AWS and cloud AI: Amazon Q'), 'aws-and-cloud-ai-amazon-q');
+  assert.strictEqual(M.anchorSlug('Good watches'), 'good-watches');
+});
+test('destination deep-links to #section when given', () => {
+  assert.strictEqual(
+    M.destination({ blogUrl: 'https://b/x', section: 'LLM architecture' }),
+    'https://b/x#llm-architecture'
+  );
+  // no section → plain doc url
+  assert.strictEqual(M.destination({ blogUrl: 'https://b/x' }), 'https://b/x');
+  // already-anchored blogUrl is left as-is
+  assert.strictEqual(
+    M.destination({ blogUrl: 'https://b/x#already', section: 'Ignore' }),
+    'https://b/x#already'
+  );
+});
+test('renderRow puts the deep link in the destination cell', () => {
+  const row = M.renderRow({ link: 'Raschka', url: 'https://u', blogUrl: 'https://b/rl', section: 'LLM architecture', kind: 'reading-list', date: 'd' });
+  assert.ok(row.includes('https://b/rl#llm-architecture'), row);
+});
+test('fan-out: same file, different docs, source-url dedup holds', () => {
+  const { p } = tmp(SAMPLE);
+  // First link → reading list; second → good-watches. Both fresh.
+  const r1 = M.appendMigration(p, [{ link: 'A Talk', url: 'https://youtu.be/abc', blogUrl: 'https://b/watches', section: 'Talks', kind: 'reading-list', date: 'd' }]);
+  fs.writeFileSync(p, r1.content);
+  const r2 = M.appendMigration(p, [{ link: 'Repo', url: 'https://github.com/o/r', blogUrl: 'https://b/reading', section: 'Tools', kind: 'reading-list', date: 'd' }]);
+  fs.writeFileSync(p, r2.content);
+  assert.strictEqual(r2.added, 1, 'a different source link to a different doc is fresh');
+  // Re-adding the first source url (even to a new doc) is a dup — migrated once.
+  const r3 = M.appendMigration(p, [{ link: 'A Talk', url: 'https://youtu.be/abc', blogUrl: 'https://b/OTHER', kind: 'reading-list', date: 'd' }]);
+  assert.strictEqual(r3.added, 0, 'source url already migrated → skipped');
+});
+
+console.log('non-link content migrations (code-span cells)');
+test('a non-link record renders content as a code span, not a link', () => {
+  const row = M.renderRow({ content: '# Claude.md\n* Mental models\n* Tenets', blogUrl: 'https://b/tips', section: 'What belongs in a CLAUDE.md', kind: 'tips', date: 'd' });
+  assert.ok(/\|\s*`[^|]*Mental models[^|]*`\s*\|/.test(row), 'source cell is a code span: ' + row);
+  assert.ok(!/\]\(/.test(row.split('|')[1]), 'no markdown link in the source cell');
+  assert.ok(row.includes('https://b/tips#what-belongs-in-a-claudemd'), 'deep link destination: ' + row);
+});
+test('non-link content dedups by content key', () => {
+  const { p } = tmp(SAMPLE);
+  const rec = [{ content: 'a tip about caching', blogUrl: 'https://b/tips', kind: 'tips', date: 'd' }];
+  const first = M.appendMigration(p, rec);
+  fs.writeFileSync(p, first.content);
+  const second = M.appendMigration(p, [{ content: 'A TIP about   caching', blogUrl: 'https://b/tips', kind: 'tips', date: 'd' }]);
+  assert.strictEqual(second.added, 0, 'same content (whitespace/case-insensitive) is a dup');
+});
+test('non-link content preserves the non-destructive prefix', () => {
+  const { p } = tmp(SAMPLE);
+  const before = fs.readFileSync(p);
+  const res = M.appendMigration(p, [{ content: '# Claude.md tip', blogUrl: 'https://b/tips', kind: 'tips', date: 'd' }]);
+  assert.ok(Buffer.from(res.content, 'utf8').subarray(0, before.length).equals(before));
+});
+
+console.log('rebuild (repoint the whole table, non-destructive)');
+test('rebuild replaces all rows but preserves the body prefix', () => {
+  const { p } = tmp(SAMPLE);
+  const before = fs.readFileSync(p);
+  // seed with a row pointing at doc A
+  const seeded = M.appendMigration(p, [{ link: 'A Talk', url: 'https://youtu.be/abc', blogUrl: 'https://b/reading', kind: 'reading-list', date: 'd' }]);
+  fs.writeFileSync(p, seeded.content);
+  // rebuild: same link now points at doc B (watches) with a section anchor
+  const rebuilt = M.rebuildMigration(p, [{ link: 'A Talk', url: 'https://youtu.be/abc', blogUrl: 'https://b/watches', section: 'Talks', kind: 'reading-list', date: 'd' }]);
+  assert.ok(Buffer.from(rebuilt.content, 'utf8').subarray(0, before.length).equals(before), 'body prefix preserved');
+  assert.ok(rebuilt.content.includes('https://b/watches#talks'), 'repointed to new dest');
+  assert.ok(!rebuilt.content.includes('https://b/reading'), 'old dest is gone (replaced, not appended)');
+  // exactly one data row
+  const rows = rebuilt.content.split('\n').filter((l) => l.startsWith('|') && l.includes(']('));
+  assert.strictEqual(rows.length, 1, 'table fully rebuilt, not accumulated');
 });
 
 console.log('snapshot / audit (corpus no-drop)');

--- a/bytesofpurpose-blog/docs/craft/generative-ai/genai-good-watches.mdx
+++ b/bytesofpurpose-blog/docs/craft/generative-ai/genai-good-watches.mdx
@@ -1,0 +1,32 @@
+---
+slug: /generative-ai/good-watches
+title: '🔖 GenAI Good Watches'
+sidebar_label: '🔖 Good watches'
+kind: reading-list
+description: "Talks and long-form videos on generative AI worth the watch: Claude Code internals, agent patterns, AI engineering, and building at scale, with a note on each."
+authors: [oeid]
+tags: [generative-ai, genai, talks, videos, reading-list]
+draft: true
+---
+
+Talks and long-form videos on generative AI worth the watch, pulled out of my notes with the
+author, length, and a line on what each one covers so you can pick by your mood and the time you have.
+
+## Talks worth watching
+
+- [How Claude Code Works](https://youtu.be/RFKCzGlAU6Q) (Jared Zoneraich, PromptLayer, 1 hour) - Deep dive into Claude Code's architecture, arguing its success stems from a simplified "Master Loop" paired with capable models rather than complex frameworks. Covers internal tools (Bash, FileEdit, Grep), Todo planning, sandboxing, and system prompts.
+- [No Vibes Allowed: Solving Hard Problems in Complex Codebases](https://youtu.be/rmvDxxNubIg) (Dex Horthy, HumanLayer, 20 minutes) - Context engineering techniques for getting AI coding tools to handle 300k LOC Rust codebases effectively. Introduces "frequent intentional compaction" approach for managing context throughout development.
+- [Don't Build Agents, Build Skills Instead](https://youtu.be/CEvIs9y1uog) (Barry Zhang & Mahesh Murag, Anthropic, 16 minutes) - Argues that Skills are the solution for packaging procedural knowledge that agents can dynamically load. Covers minimal form factor for portable, composable expertise and network effects of skill-based agents.
+- [Identity for AI Agents](https://youtu.be/VSdV-AdSlis) (Patrick Riley & Carlos Galan, Auth0, 1 hour) - Implementing secure identity and access management for AI agents with Okta and Auth0
+- [OpenAI + Temporal: Building Durable, Production Ready Agents](https://youtu.be/k8cnVCMYmNc) (Cornelia Davis, Temporal, 1 hour) - Using Temporal's durable execution framework with OpenAI Agents SDK to handle flakey networks, rate limits, and long-running operations. OpenAI uses Temporal for production services like image gen and Codex.
+- [Your MCP Server is Bad (and you should feel bad)](https://youtu.be/96G7FLab8xc) (Jeremiah Lowin, Prefect, 54 minutes) - Framework for building agent-native MCP servers using FastMCP. Covers the three pillars of agent-native product design: Discovery, Iteration, and Context. Critiques REST wrapper approaches.
+- [Automating Large Scale Refactors with Parallel Agents](https://youtu.be/rcsliSIy_YU) (Robert Brennan, OpenHands, 1 hour) - Patterns for orchestrating large-scale code changes with swarms of agents and human-in-the-loop. Includes concrete example of migrating entire codebase from one React state management library to another.
+- [Building Intelligent Research Agents with Manus](https://youtu.be/xz0-brt56L8) (Ivan Leo, Manus AI (now Meta Superintelligence), 1 hour) - Introduction to Manus 1.5 and Manus API as a "general action engine" for executing workflows. Workshop on building bespoke research agents that connect to private data sources.
+- [DSPy: The End of Prompt Engineering](https://youtu.be/-cKUW6n8hBU) (Kevin Madura, AlixPartners, 1 hour) - Programming with LLMs using DSPy instead of manual prompt engineering. Covers Signatures, Modules, Adapters, and Optimizers (like MIPRO) for robust enterprise AI applications.
+- [Spec-Driven Development: Agentic Coding at FAANG Scale and Quality](https://youtu.be/HY_JyxAZsiE) (Al Harris, Amazon Kiro, 1 hour) - How the Kiro team uses Spec-Driven Development for reproducible and reliable delivery with AI coding tools at Amazon scale.
+- [How METR Measures Long Tasks and Experienced Dev Productivity](https://youtu.be/k1t2xyWMUdY) (Joel Becker, METR, 1 hour) - Reconciles lab vs field evidence on AI capabilities. Explores why impressive benchmark performance doesn't always translate to real-world developer productivity impact.
+- [Why 2026 Is the Year to Build a Second Brain (And Why You NEED One)](https://www.youtube.com/watch?v=0TpON5T-Sw4) (Nate B Jones, 30 minutes) - Building AI second brain systems with Slack, Notion, Zapier, and Claude/ChatGPT. Covers active vs passive systems, AI loops for classification and routing, and 8 building blocks for second brain systems.
+- [Dispatch from the Future: Building an AI-native Company](https://www.youtube.com/watch?v=MGzymaYBiss) (Dan Shipper, Every) - Insights on building companies with AI at the core
+- [How BlackRock Builds Custom Knowledge Apps at Scale](https://youtu.be/08mH36_NVos) (Vaibhav Page & Infant Vasanth, BlackRock, 18 minutes) - Modular, Kubernetes-native AI framework for scaling Knowledge Apps across enterprise. Covers document extraction, investment signals, and maintaining compliance in regulated industry.
+- [Amazon Q Demos in 6 minutes](https://www.youtube.com/watch?v=-6AH74XD5M4) (My experiences on the IT "Battlefield", 6 minutes) - Quick tour covering Q Business (chat, file interaction, data source connections) and Q Developer tools (code optimization, documentation for migration/modernization).
+- [Best Practices for GenAI Applications on AWS - Model Selection (Part 1)](https://www.youtube.com/watch?v=WEKTpzvJiec) (Amazon Web Services, 11 minutes) - Best practice approach for arriving at the right model for a given GenAI use case. Part of multi-part series on building robust GenAI applications.

--- a/bytesofpurpose-blog/docs/craft/generative-ai/genai-reading-list.mdx
+++ b/bytesofpurpose-blog/docs/craft/generative-ai/genai-reading-list.mdx
@@ -25,6 +25,8 @@ posts worth the time. A living list.
 - [Discovering and installing Claude Code plugins from marketplaces](https://code.claude.com/docs/en/discover-plugins)
 - [Connecting Claude Code to external tools via Model Context Protocol](https://code.claude.com/docs/en/mcp)
 
+- [How Anthropic teams use Claude Code for debugging, codebase navigation, and automation](https://claude.com/blog/how-anthropic-teams-use-claude-code) - Real internal workflows from the team that builds it.
+
 ## Agent development and frameworks
 
 - [Don't Build Agents, Build Skills Instead (YouTube, 2025-12-08)](https://youtu.be/CEvIs9y1uog) - Argues that Skills are the solution for packaging procedural knowledge that agents can dynamically load. Covers minimal form factor for portable, composable expertise and network effects of skill-based agents.
@@ -44,6 +46,9 @@ posts worth the time. A living list.
 - [Kiro CLI: agent configuration file reference for custom agents](https://kiro.dev/docs/cli/custom-agents/configuration-reference/)
 - [Prompt Caching Deep Dive](https://sankalp.bearblog.dev/how-prompt-caching-works/) - Technical explanation of how prompt caching works in LLM systems
 - [Awesome Security Hardening](https://github.com/decalage2/awesome-security-hardening) - Curated list of security hardening resources and best practices
+
+- [Evaluating AGENTS.md: whether repo-level context files help coding agents](https://arxiv.org/html/2602.11988v1) - A study on whether the context files we all write actually move the needle.
+- [Monitoring Azure OpenAI abuse via compromised API keys and model poisoning](https://redcanary.com/blog/threat-detection/azure-openai-abuse/) - The security side of running LLMs in production.
 
 ## Productivity and workflows
 
@@ -104,6 +109,38 @@ posts worth the time. A living list.
 - [Amazon Q Demos in 6 minutes (YouTube, 2024-04-10)](https://www.youtube.com/watch?v=-6AH74XD5M4) - Quick tour covering Q Business (chat, file interaction, data source connections) and Q Developer tools (code optimization, documentation for migration/modernization).
 - [Best Practices for GenAI Applications on AWS - Model Selection (Part 1) (YouTube, 2023-11-10)](https://www.youtube.com/watch?v=WEKTpzvJiec) - Best practice approach for arriving at the right model for a given GenAI use case. Part of multi-part series on building robust GenAI applications.
 
+## LLM architecture and agent reliability
+
+The reads that reshaped how I think about the field, kept as cards with the line that stuck and my note on why.
+
+<QuoteSet>
+
+<EditorialQuote source="Sebastian Raschka" reflection="His companion article covers 10 architectures released in January and February 2026 alone. The takeaway most people miss: performance correlates more with dataset quality and training recipes than architecture design. The field is converging on similar transformer variants. The differentiation is in the data.">
+Every major LLM architecture visualized side by side, with fact sheets.
+</EditorialQuote>
+
+[LLM Architecture Gallery with visual fact sheets](https://lnkd.in/gCNdCaEC)
+
+<EditorialQuote reflection="Agents operate in dynamic environments, take multi-step actions, and fail in ways that text generation benchmarks cannot capture. If you are building agents and still evaluating them like chatbots, start here.">
+The clearest explanation I have read of why traditional LLM benchmarks break down when you evaluate agents.
+</EditorialQuote>
+
+[A Hitchhiker's Guide to Agent Evaluation (ICLR 2026): why LLM benchmarks break for multi-step agents](https://lnkd.in/g6ecwQZw)
+
+<EditorialQuote source="Simon Willison" reflection="Not theory. Patterns from daily use of Claude Code and OpenAI Codex. His blog (simonwillison.net) is one of the most information-dense practitioner resources in the field.">
+Coding practices for building software with coding agents.
+</EditorialQuote>
+
+[Agentic Engineering Patterns from daily Claude Code and Codex use](https://lnkd.in/gMTP_7vG)
+
+<EditorialQuote source="Towards a Science of AI Agent Reliability" reflection="Borrowed from safety-critical engineering. Related benchmark research shows GPT-4o agents achieve 60% success on a single run but just 25% across eight consecutive runs. Reliability degrades with repetition.">
+Twelve metrics across four dimensions: consistency, robustness, predictability, safety.
+</EditorialQuote>
+
+[12 metrics across consistency, robustness, predictability, safety](https://lnkd.in/gzXSN3uB)
+
+</QuoteSet>
+
 ## GenAI tools and apps
 
 - [Supabase pricing: free plan and pay-as-you-go tiers](https://supabase.com/pricing)
@@ -122,5 +159,6 @@ posts worth the time. A living list.
 
 - [MAS-Orchestra: improving multi-agent reasoning via holistic orchestration and benchmarks](https://arxiv.org/abs/2601.14652)
 - [madewithclaude/awesome-claude-artifacts: curated list of Claude Artifacts examples](https://github.com/madewithclaude/awesome-claude-artifacts)
+- [Reddit: Claude subscriptions are up to 36x cheaper than API alternatives](https://www.reddit.com/r/ClaudeAI/comments/1qpcj8q/claude_subscriptions_are_up_to_36x_cheaper_than/) - A cost comparison worth knowing before you pick a plan.
 - [Reddit: Noteplan MCP Announcement](https://www.reddit.com/r/noteplanapp/comments/1r3q6k5/use_claude_desktopcode_to_work_with_noteplan/)
 - [Claude Plugin INstall Instructions](https://code.claude.com/docs/en/plugins-reference#plugin-update)

--- a/bytesofpurpose-blog/docs/craft/generative-ai/genai-tools.mdx
+++ b/bytesofpurpose-blog/docs/craft/generative-ai/genai-tools.mdx
@@ -1,0 +1,22 @@
+---
+slug: /generative-ai/tools
+title: '🔖 GenAI Tools I Like'
+sidebar_label: '🔖 Tools'
+kind: reading-list
+description: "GenAI and creative tools worth trying, pulled from my notes: music generation, terminal styling, and the utilities I keep bookmarked."
+authors: [oeid]
+tags: [generative-ai, genai, tools, reading-list]
+draft: true
+---
+
+The GenAI and adjacent creative tools I keep bookmarked, with a line on what each is good for.
+A living list.
+
+## Creative and generative tools
+
+- [Artlist AI Music Generator](https://toolkit.artlist.io/music-generator?mode=music&modelGroupID=356) - Generate royalty-free music tracks; handy for video and demo soundtracks.
+- [Artlist AI Suite pricing](https://artlist.io/page/pricing/max?source=toolkit&tab=ai-suite) - The plan details for the broader Artlist AI toolkit.
+
+## Terminal and developer styling
+
+- [ctxline.js.org](https://ctxline.js.org/) - A terminal/CLI styling library whose theme and aesthetic I keep coming back to for inspiration.

--- a/bytesofpurpose-blog/docs/craft/software-development/tips.mdx
+++ b/bytesofpurpose-blog/docs/craft/software-development/tips.mdx
@@ -1,0 +1,24 @@
+---
+slug: /software-development/tips
+title: '📌 Software Development Tips'
+sidebar_label: '📌 Tips'
+kind: tips
+description: "Practical software-development tips and rules of thumb, grouped by theme: what belongs in a CLAUDE.md, and more as I collect them."
+authors: [oeid]
+tags: [software-development, tips, claude, workflow]
+draft: true
+---
+
+The short, actionable pointers I keep coming back to in software work, pulled out of my notes and
+grouped by theme. Each one stands on its own. A living collection.
+
+## What belongs in a CLAUDE.md
+
+The sections worth putting in a `CLAUDE.md` (the context file that tells a coding agent how to work
+in a repo), so the guidance is complete rather than ad hoc:
+
+- **Mental models** - the concepts and framing the agent should reason with.
+- **Tenets** - the non-negotiable principles the work must uphold.
+- **Coding style and etiquette** - the conventions to match so new code reads like the old code.
+- **Testing and validation approach** - how a change is proven correct before it lands.
+- **Healing instructions** - how to recover when something breaks or drifts.

--- a/bytesofpurpose-blog/docs/handbook/README.mdx
+++ b/bytesofpurpose-blog/docs/handbook/README.mdx
@@ -83,6 +83,7 @@ list and find the format you are in the mood for. Here is the legend:
 | 🧪 | Tutorial | A hands-on, learn-by-doing walkthrough. "A Hands-On Way to", "Running X Locally". |
 | 📖 | Reference | A concept explainer or taxonomy. "A Taxonomy of", "What Does X Mean". |
 | 🔖 | Reading list | A curated, annotated list of external resources on a topic: grouped links, each with a note on why it is worth your time. |
+| 📌 | Tips | A collection of practical tips or rules of thumb on a topic: short, actionable pointers grouped by theme. |
 | 🎛️ | Showcase | A live showcase of one blog component/technique, with a list of posts that use it. The Components reference. |
 | 🎙️ | Event recap | Notes from a conference or event. |
 | 🧭 | Legend | A guide like this one: it indexes a set of posts and the conventions they share. |

--- a/bytesofpurpose-blog/scripts/lib/blog-kinds.json
+++ b/bytesofpurpose-blog/scripts/lib/blog-kinds.json
@@ -193,6 +193,14 @@
         {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
       ]
     },
+    "tips": {
+      "emoji": "📌",
+      "description": "A collection of practical tips / rules of thumb on a topic ('Tips for X', 'X Tips and Tricks'): short, actionable pointers grouped by theme, each standing on its own. The distilled operating wisdom.",
+      "outline": [
+        {"id": "tip-sections", "label": "tips grouped into H2/H3 sections, each a short actionable pointer (a list or a titled block) — not one long essay"},
+        {"id": "description", "label": "a non-empty `description:` frontmatter (powers the social card + share text)"}
+      ]
+    },
     "showcase": {
       "emoji": "🎛️",
       "description": "A showcase of one structural ABILITY of the blog: an embeddable component or technique (a card, a diagram, a code embed), demonstrated live, with a 'used in' index of the posts that leverage it. Lives in /legend/components (the site's component reference).",

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -136,6 +136,9 @@ const CHECKS = {
   // reference in another kind can't satisfy it.
   'curated-links': (fm, body) =>
     (body.match(/\[[^\]]+\]\(https?:\/\/[^)]+\)/g) || []).length >= 3,
+  // tips: actionable pointers grouped into H2/H3 sections (a list or titled blocks), not one
+  // long essay. Require at least one H2 plus a list item.
+  'tip-sections': (fm, body) => hasH2(body) && /^\s*[-*]\s+\S/m.test(body),
   // system-design / frontend-design: a UX mockup or an embedded live visual. A
   // <SlideDeck> IS the visual (a live, navigable reveal.js deck), so it counts.
   mockup: (fm, body) =>


### PR DESCRIPTION
## What

Deepen the NotePlan → blog migration with three capabilities you asked for, and use them to fan `References[GenAI]` out into four purpose-fit docs.

## New transformer capabilities (import-noteplan)

1. **Section-anchor deep links** — a record's `section` makes the table cell a deep link to the exact destination section: `…/reading-list#llm-architecture-and-agent-reliability`. A half-migrated file now shows precisely what landed where.
2. **Non-link content rows** — a record with `content` (no `url`) renders the moved text as a **code span** in the source cell, so tips/notes that aren't links still record *what* was moved.
3. **`--rebuild-migration`** — replace the whole managed table to **repoint** rows when a destination changes; still byte-exact above the sentinel.

Tests: **16 assertions** (was 8), covering anchors, fan-out dedup, content cells, and rebuild.

## New kind

- **`tips` (📌)** — practical tips / rules of thumb, with a `tip-sections` outline check + handbook legend row. (`reading-list` 🔖 shipped in #157.)

## Content — one source, four destinations (fan-out by nature)

`References[GenAI]` no longer lumps into one doc. It fans out (all `draft: true`):

| Cluster | → Doc |
|---|---|
| articles, papers, blogs (+ 4 LLM-arch insights as **`<EditorialQuote>` cards**) | `genai-reading-list.mdx` |
| the 16 conference/YouTube talks (author, length, summary) | **`genai-good-watches.mdx`** (new) |
| creative/style tools (Artlist, ctxline) | **`genai-tools.mdx`** (new) |
| the "what belongs in a CLAUDE.md" note | **`software-development/tips.mdx`** (new) |

## Migration ledger (non-destructive)

Rebuilt the NotePlan table to **84 rows**, each pointing at its true destination + section: 64 reading-list, 16 watches, 3 tools, 1 tips (as a **non-link content row**).

```
--rebuild → 84 rows
--verify  → ✓ body above the marker byte-identical (exit 0)
--audit   → ✓ no drops across all 33 Lists files (exit 0)
tests     → 16 assertions passed
docs      → 4/4 outline clean, legend-drift 0, no emoji collisions, no em-dash
```

## Skill

SKILL.md now documents fan-out, section deep links, enrich-don't-dump (quote cards + non-link content), `--rebuild-migration`, and the `cite`-renders-as-plain-text gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)