### PR TITLE
feat(experiments): <ExperimentOverview> — on-brand, frontmatter-driven experiment header

### DIFF
--- a/.claude/skills/design-experiment/SKILL.md
+++ b/.claude/skills/design-experiment/SKILL.md
@@ -55,14 +55,22 @@ Create one Claude task per item below (TaskCreate), substituting specifics:
 ## Steps
 
 1. Create `blog/<YYYY-MM-DD>-<flag-key>.md` with `kind: experiment-plan`, `stage: designed`
-   (or `proposed`), `priority`, and the blog frontmatter (`title`/`sidebar_label`/`description`/
-   `authors`/`tags`/`date`). It becomes a card on the Experimentation board.
-2. Fill every section: hypothesis, motivation, variants table, metric + why, **placement
+   (or `proposed`), `priority`, `flag:` (the flag key), `owner:`, and the blog frontmatter
+   (`title`/`sidebar_label`/`description`/`authors`/`tags`/`date`). It becomes a card on the
+   Experimentation board.
+2. **Lead the body with `<ExperimentOverview />`** (registered globally; `src/components/
+   ExperimentOverview`). It reads `stage`/`flag`/`owner`/`date` from the frontmatter and renders the
+   on-brand Status/Owner/Flag/Created badges + a lifecycle bar (proposed → designed → running →
+   analyzing → concluded → rolled-out/abandoned) with the current stage highlighted. Being
+   frontmatter-driven, it CANNOT drift from the board's `stage` (both read the same field). Do NOT
+   hand-type the old `> **Status:** … Lifecycle: …` blockquote; it drifts. Pass `note="…"` for a
+   re-scope note. The stage vocab + emoji mirror the KanbanBoard experiments columns.
+3. Fill every section: hypothesis, motivation, variants table, metric + why, **placement
    + why here / why not elsewhere**, targeting, sample size/duration, risks, rollback. (The
    outline matches the `experiment-plan` kind contract in `scripts/lib/blog-kinds.json`.)
-3. Publishing the post (`draft: false`) is what puts the card on the board — a draft post is
+4. Publishing the post (`draft: false`) is what puts the card on the board — a draft post is
    NOT carded (and would 404 in prod). Keep `draft: true` only while it's not ready to show.
-4. Hand off to **`run-ab-test`**: it adds the registry entry (`src/experiments.ts`) + the
+5. Hand off to **`run-ab-test`**: it adds the registry entry (`src/experiments.ts`) + the
    component injection point, then creates/validates/launches the PostHog experiment.
 
 ## Cross-links

--- a/bytesofpurpose-blog/blog/2026-05-31-support-button-copy.md
+++ b/bytesofpurpose-blog/blog/2026-05-31-support-button-copy.md
@@ -10,11 +10,11 @@ date: 2026-05-31
 draft: false
 stage: running
 priority: medium
+flag: support-button-copy
+owner: Omar
 ---
 
-> **Status:** `running` (re-scoped 2026-06-01 from a copy test to a presentation test; same flag key) · **Owner:** Omar · **Flag:** `support-button-copy` · **Created:** 2026-05-31
->
-> Lifecycle: `proposed` → `designed` → `draft` → **`running`** → `analyzing` → `concluded` → `rolled-out` / `abandoned`
+<ExperimentOverview note="re-scoped 2026-06-01 from a copy test to a presentation test; same flag key" />
 
 Does the **presentation** of the coffee CTA, a plain text link vs. a styled button,
 change how often readers click through to PayPal? Both arms show the **same** copy

--- a/bytesofpurpose-blog/blog/2026-06-26-homepage-hero-anim.md
+++ b/bytesofpurpose-blog/blog/2026-06-26-homepage-hero-anim.md
@@ -10,11 +10,11 @@ date: 2026-06-26
 draft: false
 stage: designed
 priority: medium
+flag: homepage-hero-anim
+owner: Omar
 ---
 
-> **Status:** `designed` · **Owner:** Omar · **Flag:** `homepage-hero-anim` · **Created:** 2026-06-26
->
-> Lifecycle: `proposed` → **`designed`** → `running` → `analyzing` → `concluded` → `rolled-out` / `abandoned`
+<ExperimentOverview />
 
 Does the **way the homepage hero cards animate** change how often a visitor clicks into a
 section? All three arms show the **same** seven destination cards with the **same** copy and the

--- a/bytesofpurpose-blog/src/components/ExperimentOverview/index.tsx
+++ b/bytesofpurpose-blog/src/components/ExperimentOverview/index.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import styles from './styles.module.css';
+
+/**
+ * ExperimentOverview — the on-brand header block for an experiment post.
+ *
+ * Renders the Status / Owner / Flag / Created badges + a LIFECYCLE BAR (proposed → designed →
+ * running → analyzing → concluded → rolled-out / abandoned) with the CURRENT stage highlighted.
+ *
+ * FRONTMATTER-DRIVEN (no drift): it reads `stage`, `flag`, `owner`, and `date` straight from the
+ * post's own frontmatter via useBlogPost(), so the header can never disagree with the stage the
+ * Experimentation board reads from the same field. Author writes just:
+ *
+ *   <ExperimentOverview />
+ *
+ * (add `flag:` and `owner:` frontmatter alongside the existing `stage:` and `date:`). Optional props
+ * override the frontmatter for a one-off (e.g. a re-scoped note): <ExperimentOverview note="…" />.
+ *
+ * The stage vocabulary + emoji mirror the KanbanBoard experiments columns so the two stay in sync.
+ */
+
+// The experiment lifecycle: the 5 board stages + the 2 terminal outcomes. Emoji match KanbanBoard.
+const STAGES = [
+  {id: 'proposed', label: 'Proposed', emoji: '💡'},
+  {id: 'designed', label: 'Designed', emoji: '✏️'},
+  {id: 'running', label: 'Running', emoji: '🟢'},
+  {id: 'analyzing', label: 'Analyzing', emoji: '🔬'},
+  {id: 'concluded', label: 'Concluded', emoji: '✅'},
+] as const;
+// Terminal outcomes (one of these follows `concluded`); either can be the current stage.
+const OUTCOMES = [
+  {id: 'rolled-out', label: 'Rolled out', emoji: '🚀'},
+  {id: 'abandoned', label: 'Abandoned', emoji: '🗑️'},
+] as const;
+
+type Stage = (typeof STAGES)[number]['id'] | (typeof OUTCOMES)[number]['id'];
+
+interface Props {
+  /** Override the frontmatter stage (rare). */
+  stage?: Stage;
+  /** Override the frontmatter flag key. */
+  flag?: string;
+  /** Override the frontmatter owner. */
+  owner?: string;
+  /** A short parenthetical note next to the status (e.g. a re-scope note). */
+  note?: string;
+}
+
+function Badge({label, value}: {label: string; value: React.ReactNode}): React.JSX.Element {
+  return (
+    <span className={styles.badge}>
+      <span className={styles.badgeLabel}>{label}</span>
+      <span className={styles.badgeValue}>{value}</span>
+    </span>
+  );
+}
+
+export default function ExperimentOverview(props: Props): React.JSX.Element {
+  const {frontMatter, metadata} = useBlogPost();
+  const fm = (frontMatter || {}) as Record<string, unknown>;
+
+  const stage = (props.stage || (fm.stage as string) || 'proposed') as Stage;
+  const flag = props.flag || (fm.flag as string) || '';
+  const owner = props.owner || (fm.owner as string) || '';
+  const created = (metadata?.date || (fm.date as string) || '').toString().slice(0, 10);
+
+  // The current stage's index across the full lifecycle (stages + outcomes). Anything before it is
+  // "done", after it is "upcoming". A terminal outcome sits at the end.
+  const lifecycle = [...STAGES, ...OUTCOMES];
+  const currentIdx = lifecycle.findIndex((s) => s.id === stage);
+  const current = lifecycle[currentIdx] || STAGES[0];
+
+  return (
+    <aside className={styles.overview} aria-label="Experiment overview">
+      <div className={styles.badges}>
+        <Badge label="Status" value={`${current.emoji} ${current.label}`} />
+        {owner && <Badge label="Owner" value={owner} />}
+        {flag && <Badge label="Flag" value={<code className={styles.flag}>{flag}</code>} />}
+        {created && <Badge label="Created" value={created} />}
+        {props.note && <span className={styles.note}>{props.note}</span>}
+      </div>
+
+      <ol className={styles.lifecycle} aria-label="Lifecycle">
+        {STAGES.map((s, i) => {
+          const state = i < currentIdx ? 'done' : i === currentIdx ? 'current' : 'upcoming';
+          return (
+            <li key={s.id} className={styles[state]} title={s.label} aria-current={state === 'current'}>
+              <span className={styles.stageEmoji}>{s.emoji}</span>
+              <span className={styles.stageLabel}>{s.label}</span>
+            </li>
+          );
+        })}
+        {/* The terminal fork: rolled-out / abandoned. Highlight whichever is the current stage. */}
+        <li className={styles.fork} aria-hidden={!OUTCOMES.some((o) => o.id === stage)}>
+          {OUTCOMES.map((o) => {
+            const isCurrent = o.id === stage;
+            return (
+              <span key={o.id} className={isCurrent ? styles.current : styles.upcoming} title={o.label}>
+                <span className={styles.stageEmoji}>{o.emoji}</span>
+                <span className={styles.stageLabel}>{o.label}</span>
+              </span>
+            );
+          })}
+        </li>
+      </ol>
+    </aside>
+  );
+}

--- a/bytesofpurpose-blog/src/components/ExperimentOverview/styles.module.css
+++ b/bytesofpurpose-blog/src/components/ExperimentOverview/styles.module.css
@@ -1,0 +1,121 @@
+/* ExperimentOverview — the experiment post header: a badge row + a lifecycle progress bar.
+ * On-brand: a card surface + hairline, mint pastel for the CURRENT stage (with --tea-ink, the
+ * design-system tag-pill discipline), muted done stages, ghosted upcoming ones. */
+
+.overview {
+  margin: var(--space-5, 1.5rem) 0;
+  padding: var(--space-4, 1rem);
+  background: var(--ifm-background-surface-color, var(--ifm-color-emphasis-100));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--radius-md, 0.5rem);
+}
+
+/* --- the badge row --- */
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.badgeLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.badgeValue {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+}
+
+.flag {
+  font-size: 0.85rem;
+}
+
+.note {
+  font-size: 0.82rem;
+  font-style: italic;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* --- the lifecycle bar --- */
+.lifecycle {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: var(--space-1, 0.25rem);
+  list-style: none;
+  margin: var(--space-3, 0.75rem) 0 0;
+  padding: 0;
+}
+
+/* each stage is a pill; a chevron between them is drawn with ::after */
+.lifecycle > li,
+.fork > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-sm, 0.4rem);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.stageEmoji {
+  font-size: 0.9rem;
+}
+
+/* done: past stages, muted but legible */
+.done {
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-200);
+}
+
+/* current: the highlighted stage — mint pastel FILL with --tea-ink (the tag-pill discipline) */
+.current {
+  color: var(--tea-ink);
+  background: var(--tea-mint);
+  font-weight: 700;
+}
+
+/* upcoming: future stages, ghosted */
+.upcoming {
+  color: var(--ifm-color-emphasis-500);
+  background: transparent;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+}
+
+/* the terminal fork (rolled-out / abandoned) sits together with a slash between */
+.fork {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+  padding: 0 !important;
+  background: transparent !important;
+}
+.fork::before {
+  content: '/';
+  color: var(--ifm-color-emphasis-400);
+  margin: 0 0.15rem;
+  align-self: center;
+}
+
+/* On narrow screens the labels can hide, keeping the emoji trail readable. */
+@media (max-width: 600px) {
+  .stageLabel {
+    display: none;
+  }
+  .badgeLabel {
+    display: none;
+  }
+}

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -10,6 +10,7 @@ import Timeline from '@site/src/components/TimeLine';
 import TimelineItem from '@site/src/components/TimeLine/TimeLineItem';
 import BookmarkletButton from '@site/src/components/BookmarkletButton';
 import NotePlanButton from '@site/src/components/NotePlanButton';
+import ExperimentOverview from '@site/src/components/ExperimentOverview';
 import PremiumGate from '@site/src/components/PremiumGate';
 import Premium from '@site/src/components/Premium';
 import KanbanBoard from '@site/src/components/KanbanBoard';
@@ -89,6 +90,7 @@ export default {
   TimelineItem,
   BookmarkletButton,
   NotePlanButton,
+  ExperimentOverview,
   // Premium gating: <PremiumGate> is injected by the rehype-premium-encrypt plugin in
   // place of an encrypted doc body; <Premium> is an author-facing inline wrapper.
   PremiumGate,


### PR DESCRIPTION
## What

Replaces the hand-typed **Status/Owner/Flag/Lifecycle** blockquote at the top of experiment posts (the block from the screenshot) with a first-class component: an on-brand **badge row + lifecycle progress bar** with the current stage highlighted.

**Before** (hand-typed markdown, can drift from the frontmatter `stage`):
```
> **Status:** `designed` · **Owner:** Omar · **Flag:** `homepage-hero-anim` · **Created:** 2026-06-26
> Lifecycle: `proposed` → **`designed`** → `running` → …
```

**After:**
```
<ExperimentOverview />
```

### The component
`src/components/ExperimentOverview` (registered globally). **Frontmatter-driven, no drift:** it reads `stage`/`flag`/`owner`/`date` from the post's own frontmatter via `useBlogPost()`, so the header **cannot disagree** with the stage the Experimentation board reads from the same field. It renders:
- **Badge row:** Status · Owner · Flag · Created (clean uppercase labels + values).
- **Lifecycle bar:** proposed → designed → running → analyzing → concluded → rolled-out / abandoned, with the **current stage a mint pastel pill** (+ `--tea-ink`), past stages muted, upcoming ghosted. Stage vocab + emoji **mirror the KanbanBoard** experiments columns (💡✏️🟢🔬✅). Optional `note="…"` prop for a re-scope note. Mobile collapses the labels to the emoji trail.

### Also
- Converted the 2 experiment posts (`homepage-hero-anim`, `support-button-copy`): added `flag:`/`owner:` frontmatter, replaced the blockquote.
- **`design-experiment` skill**: lead the body with `<ExperimentOverview/>`, add the new frontmatter, and don't hand-type the drift-prone blockquote.

## Verified
- `make build` ✅ no broken links · `make validate-ds-tokens` ✅ · `make check-contrast` ✅
- **Visual pass** ✅ (screenshot): the badge row (STATUS ✏️ Designed · OWNER Omar · FLAG `homepage-hero-anim` · CREATED 2026-06-26) + the lifecycle bar with **Designed** highlighted, past/future stages muted/ghosted, in an on-brand card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)