### PR TITLE
Add Fleetplane design post (with mockups/walkthrough) + author-post and verify-change skills

### DIFF
--- a/.claude/skills/author-post/SKILL.md
+++ b/.claude/skills/author-post/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: author-post
+description: The AUTHORING entry point for writing a new post/doc on the Bytes of Purpose site — routes to the right per-home guide once you know (or decide) WHERE the post lives. Asks "design, craft, journey, initiative, or thought?" and dispatches to a homes/<name>.md subfile that gives the frontmatter template, the kind: options for that home, the slug rule, the outline/convention contract, which validators to run, and the deep owning skill to hand off to. Use when the user says "write a post about X", "start a new design/craft/initiative post", "how do I author this for /craft", "draft this up as a post", or hands over finished content to be turned into a post. Distinct from organize-post (which CLASSIFIES where content goes); this skill AUTHORS it once the home is known — so it calls organize-post first when the home is unclear. Pairs with author-blog-post (frontmatter/MDX mechanics), import-co-design (the HLD→/designs transformer), author-walkthrough + upgrade-post (components), name-post (title voice), mature-content (firm up a thin draft), groom-initiatives + manage-hubs (boarding), link-glossary-terms + validate-links (finishing).
+---
+
+# Author a post (route to the right per-home guide)
+
+Every home on this site has its own **frontmatter shape, `kind:` vocabulary, slug rule, and
+outline contract**. Authoring a post correctly means authoring it correctly **for its home**.
+This skill is the **dispatcher**: decide the home, then open the matching guide under `homes/`
+and follow it. It does NOT duplicate the deep skills; each subfile is a short authoring checklist
+that cross-links to the single-source-of-truth skill for the mechanics.
+
+## Step 0 — know the home (classify first if unsure)
+
+If the request already names the home ("write a **design** post", "a new **/craft** technique",
+"log this **initiative**"), skip to the routing table. If it is ambiguous ("write up my notes on
+X", "turn this braindump into a post"), **do not guess** — run the **`organize-post`** skill
+first (the classifier: durable vs temporal, acted-on vs unactioned, which `kind:`), or ask the
+user with `AskUserQuestion`. `organize-post` decides WHERE and WHAT KIND; this skill takes that
+answer and AUTHORS it. If the content is thin/rough, mature it with **`mature-content`** before
+authoring.
+
+## Routing table — pick the home, read its guide
+
+| The post is… | Home / route | Read this guide | Deep skill it hands to |
+|---|---|---|---|
+| A **design / architecture** doc (HLD, system, service, UI, agent, or CLI design) | `/designs` blog | **`homes/design.md`** | `import-co-design` (from an HLD) · `author-walkthrough` |
+| A **durable "how I do the work"** learning (framework, pattern, technique, guide, hub, showcase) | `/craft` docs | **`homes/craft.md`** | `manage-hubs` · `maintain-showcase` · `reorganize-content` |
+| A **durable "why I build"** reflection (faith, growth, entrepreneurship, productivity) | `/journey` docs | **`homes/journey.md`** | (shares craft mechanics) `manage-docs-instances` |
+| A **temporal thing I DID** (project log, tinkering, research, prompt, experiment) | `/initiatives` blog | **`homes/initiatives.md`** | `groom-initiatives` · `design-experiment` · `manage-hubs` |
+| A **temporal thought** — an idea/question that OCCURRED to me, or a curated quote/principle | `/thoughts`, `/mindset`, `/questions` blogs | **`homes/thoughts.md`** | `groom-initiatives` (board an idea) · `upgrade-post` (quote/question kits) |
+| A **durable mental model** (`/knowledge`) or **habitual practice** (`/habits`) | `/knowledge`, `/habits` docs | **`homes/craft.md`** (same docs shape) | `manage-docs-instances` |
+| The **Changelog**, a **Handbook** legend page, or a **whole new docs instance** | `/changelog`, `/handbook`, new root | (no subfile) | `manage-changelog` · `manage-docs-instances` |
+
+> The site's placement model (durable vs temporal; acted-on vs unactioned; the thought kinds)
+> is owned by the CLAUDE.md tenet "durable (`/craft` + `/journey`) vs temporal (`/initiatives`)"
+> and the `organize-post` skill. This skill assumes the home is settled and gets the post WRITTEN.
+
+## Universal rules (apply to EVERY home — the subfiles only add the home-specific parts)
+
+These hold no matter which guide you open. The subfile will not repeat them.
+
+1. **No em-dash voice.** A literal `—` (U+2014) in reader-facing content (`docs`/`blog`/`designs`/
+   `changelog`) is BLOCKED by the em-dash hook, and a `--` sentence-dash bypass is blocked too.
+   Write with commas, colons, periods, or `·`. In mermaid labels, use the `&#8212;` entity (it
+   renders as a dash and the hook never sees it). See `review-reader-experience` ("the em-dash tell").
+2. **MDX-safety** (`.mdx`, and `.md` that uses components). A bare `<` before a space/digit parses
+   as JSX — write "under 100ms", not `< 100ms`, or escape to `&lt;`. A bare `{word}` parses as a JS
+   expression — put it in backticks/a code fence. Bare autolinks `<https://x>` become real markdown
+   links. Full list: `author-blog-post`.
+3. **`authors: [oeid]`** on everything.
+4. **`description:` is required and load-bearing** — 50 to 160 chars, non-empty, unique. It powers
+   `og:description` (SEO/social) AND the ShareButton message. See `manage-frontmatter-descriptions`.
+5. **Slugs are absolute (leading slash) and, in docs, INSTANCE-RELATIVE** (a `/craft` doc's slug is
+   relative to the craft root: `slug: /software-development/x` → `/craft/software-development/x`).
+   Editing a slug value 404s the old URL, so **a move pairs with a `{from,to}` client-redirect**
+   (validated by `validate-redirects`).
+6. **Name it for its nature** — a thought reads as an open QUESTION, an initiative as what I DID, a
+   durable doc as the lasting CONCEPT. Run `name-post` when titling.
+7. **Link the first genuine glossary term** (`link-glossary-terms`) and **lint links**
+   (`validate-links`) before finishing.
+8. **Validate before commit.** Run the gates the subfile names (outline / seo / structure /
+   redirects / links), plus a real render check for anything client-rendered (mermaid, mockups,
+   walkthroughs are draft-only + browser-rendered — prove them on the dev server, per `serve-locally`).
+
+## After authoring
+
+Draft posts stay `draft: true` until deliberately published — `publish-site` triages readiness,
+un-drafts, and deploys. Track the work as a task (CLAUDE.md convention), and if it was a
+reorg/move, follow `reorganize-content`.
+
+## Files
+
+- `homes/design.md` — authoring a `/designs` post (the *-design kinds, the mockup sidecar, the import-vs-hand-author fork).
+- `homes/craft.md` — authoring a `/craft` (or `/knowledge`/`/habits`) doc (the topic-folder contract, docs kinds).
+- `homes/journey.md` — authoring a `/journey` doc (shares craft mechanics; different nature + areas).
+- `homes/initiatives.md` — authoring an `/initiatives` blog post (the board/hub frontmatter).
+- `homes/thoughts.md` — authoring a `/thoughts`, `/mindset`, or `/questions` post (the thought/mindset/question kinds + title voice).
+
+## Learnings log (newest first)
+
+- 2026-07-04 — Created. Motivated by hand-authoring the Fleetplane `/designs` post from a pasted
+  implementation plan (not an `import-co-design` HLD): the conventions were spread across
+  `import-co-design` + `author-blog-post` + `author-walkthrough` + reading example posts, with no
+  single "author a post for THIS home" entry. This router consolidates the per-home authoring
+  checklist and cross-links the deep skills, without duplicating them.

--- a/.claude/skills/author-post/homes/craft.md
+++ b/.claude/skills/author-post/homes/craft.md
@@ -1,0 +1,68 @@
+# Authoring a `/craft` doc (and `/knowledge`, `/habits` — same shape)
+
+**Home:** the Craft docs instance (`bytesofpurpose-blog/docs/craft/…`, route `/craft`). Craft is
+the durable **"how I see the world / how I do the work"** — the outward how. Same mechanics apply
+to the sibling durable docs roots **`/knowledge`** (mental models) and **`/habits`** (practices);
+only the topic set + route differ. `/journey` is also docs-shaped but has its own guide.
+
+## The topic-folder contract (docs are folders, not loose files)
+
+Docs are organized as **topics** (a reader-facing topic under the instance), each a folder with:
+- a **README landing** carrying an **absolute, instance-relative `slug:`** (a topic README uses
+  `slug: /` → permalink `/craft`; a nested doc uses `slug: /software-development/patterns/x`).
+- a **`_category_.json`** (label + `position`; order via `position`, NEVER a numeric folder prefix).
+- optional `terminology/` (first) and `prompts/` (last).
+- **kebab-case** names, **no numeric name prefix**, no framing-word/topic-echo folders, depth ≤ 5.
+
+Full contract + validator: the **`review-reader-experience`** skill ("Topic-folder contract") and
+`scripts/validate-docs-structure.js` (`make validate-structure`).
+
+## Pick the `kind:`
+
+| kind | emoji | Use for | Owning skill |
+|---|---|---|---|
+| `pattern` | 🧱 | how tools COMPOSE (a multi-tool recipe) | `manage-hubs` (patterns hub) |
+| `technique` | 🔩 | a self-contained how-to | `manage-hubs` (techniques hub) |
+| `framework` | 🧩 | a reusable mental framework / model | — |
+| `tutorial` | 🧪 | a step-by-step walkthrough | — |
+| `reference` | 📖 | a lookup/reference doc | — |
+| `hub` | 🗂️ | a durable INDEX page cataloging posts by area via `<Catalog>` | **`manage-hubs`** (required registry entry) |
+| `showcase` | 🎛️ | a live component demo (the `/handbook/components/*` reference) | **`maintain-showcase`** |
+
+A **hub** and a **showcase** are special: each needs a registry/generator entry in the SAME change
+(hub → `HUBS` in `generate-hubs-data.js`; showcase → `usage_pattern` frontmatter). Do not author one
+without reading its owning skill.
+
+A doc that should appear on a hub also carries an **`area:`** (`backend`/`frontend`/`script`/`plugin`).
+
+## Frontmatter template
+
+```yaml
+---
+title: '<Concept name — the lasting thing>'
+description: <50 to 160 chars; no em-dash; feeds og + share>
+slug: /<topic>/<...>/<kebab>      # ABSOLUTE + INSTANCE-RELATIVE (no /craft prefix)
+kind: technique                   # per the table
+area: frontend                    # only if it cards on a hub
+authors: [oeid]
+tags: [<topic>, <2-4 more>]
+---
+```
+
+A topic README landing additionally pins itself: `sidebar_label: '👋 Welcome'` +
+`sidebar_position: 0` (see any `docs/craft/*/README.mdx`).
+
+## Conventions + validate
+
+- No em-dash; MDX-safe if it uses components. Link the first genuine glossary term
+  (`link-glossary-terms`). Healthy `description:` (`manage-frontmatter-descriptions`).
+- If this doc MOVED from another path, pair it with a `{from,to}` redirect and collapse any chain
+  (`reorganize-content` + `validate-redirects`).
+- Gates: `make validate-structure`, `make validate-seo`, `make validate-links`, and
+  `make validate-hubs` if it is or carries a hub-kind.
+
+## Cross-links
+
+`organize-post` (is this really durable-craft?) · `reorganize-content` (moving it in) ·
+`manage-hubs` · `maintain-showcase` · `manage-docs-instances` (adding a whole new root) ·
+`review-reader-experience` (the IA + the contract) · `author-blog-post` (MDX pitfalls).

--- a/.claude/skills/author-post/homes/design.md
+++ b/.claude/skills/author-post/homes/design.md
@@ -1,0 +1,93 @@
+# Authoring a `/designs` post
+
+**Home:** the Designs blog instance (`bytesofpurpose-blog/designs/`, route `/designs`).
+**File:** `designs/YYYY-MM-DD-<kebab>.mdx` (always `.mdx` — designs use components + mermaid).
+
+## First fork: import or hand-author?
+
+- **From a work-repo HLD** (`~/Workspace/work-git/docs/architecture/co-designs/public/CO-DESIGN-*-hld.md`)
+  → do NOT hand-write. Use the **`import-co-design`** skill: its Node transformer de-em-dashes,
+  fixes MDX, classifies diagrams, and is idempotent (re-run on source edits). Stop here.
+- **From a pasted plan, a spec, or from scratch** → hand-author with this guide.
+
+## Pick the `kind:` by structural nature
+
+The `kind:` drives the sidebar emoji and the outline contract (`validate-post-outline.js`). Choose
+by what the design STRUCTURALLY is, not by topic:
+
+| kind | emoji | Use when the design is… | Outline it must contain |
+|---|---|---|---|
+| `system-design` | 🏗️ | a whole-picture HLD (paints the entire idea) | an architecture view + a Decisions heading |
+| `backend-design` | ⚙️ | services / pipelines / data / infra / deploy | an architecture view + a Decisions heading |
+| `frontend-design` | 🎨 | a UI / client experience | a UI/structure view + a Decisions heading |
+| `agent-design` | 🤖 | an autonomous/LLM agent (its loop, tools, guardrails) | the agent's loop/capabilities + a Decisions heading |
+| `tooling-cli-design` | 🛠️ | a CLI/tool (its input→output transform / recipe) | the transform/recipe + a Decisions heading |
+| `design-story` | 📐 | a NARRATIVE about a design (thought-flagged) | narrates the WHY, links to the HLD |
+
+"Architecture view" is satisfied by a ` ```mermaid ` fence, a `<DiagramWithFootnotes>`, or a
+heading like Architecture/Components/Data flow/Pipeline/System. "Decisions" is satisfied by a
+heading matching `Key Decisions` / `Decisions` / `Trade-offs`.
+
+## Frontmatter template
+
+```yaml
+---
+slug: design-<kebab>                    # design posts are prefixed design-
+sidebar_label: <Short Label>            # a few words; the sidebar entry
+sidebar_position: <next free integer>   # grep '^sidebar_position:' designs/*.mdx | sort -n | tail -1, then +1
+title: '<Title: reads as the concept/system>'
+description: >-                          # 50 to 160 chars, no em-dash; feeds og + share
+  <one or two sentences>
+authors:
+  - oeid
+tags:
+  - system-design
+  - architecture
+  - <2-3 more>
+kind: backend-design                    # per the table above
+draft: true                             # designs land as drafts; publish-site un-drafts
+mockups: ./_mockups/<kebab>.mdx         # only if you add a mockup sidecar (below)
+---
+```
+
+## Body shape (mirror the other agentic designs)
+
+Open with a `:::note[Scope]` admonition, then `<!-- truncate -->`, then the body. A proven arc
+(see `designs/2026-06-22-self-healing-storefront.mdx`, `designs/2026-07-04-fleetplane.mdx`):
+Executive Summary (problem / solution / key decisions / value) → an animated architecture diagram
+→ components / data model → a **Key Decisions** section → closing. Rich-component catalog:
+`upgrade-post`.
+
+- **Animate the first mermaid block**: wrap it in `<div className="mermaid-animated flow-dot">` …
+  `</div>` and add `%% animate: flow` as the first line inside the fence. Dashes march; flow
+  diagrams get a traveling dot. Do NOT hardcode `classDef`/`style fill:` — the theme colors it in
+  light + dark. Mermaid labels that need a dash use `&#8212;`.
+- An **ER diagram** (` ```mermaid erDiagram `) is the clean way to render a star schema / data model.
+
+## Mockups + walkthroughs (the "what it looks like" upgrade)
+
+Design posts paint the screens with the **`_mockups/<kebab>.mdx` sidecar** — a default-exported
+`Mockups()` component of framed `<Mockup>` blocks and optional `<Walkthrough>` animations. This
+keeps the post body clean and is the pattern every agentic design uses. For a HAND-AUTHORED post
+you wire it yourself (no importer):
+
+1. Author `designs/_mockups/<kebab>.mdx` (`import {Mockup, Walkthrough} from '@omars-lab/blog-ui'`).
+2. Add `mockups: ./_mockups/<kebab>.mdx` to the post frontmatter.
+3. After `<!-- truncate -->`, hand-add `import Mockups from './_mockups/<kebab>.mdx';` then `<Mockups />`.
+
+Deep skill for the component APIs, step types, and the Claude-terminal scene: **`author-walkthrough`**.
+Worked hand-authored example: `designs/_mockups/fleetplane.mdx`.
+
+## Validate before commit
+
+- `make validate-outline` (or `node scripts/validate-post-outline.js <file>`) — the kind's outline.
+- `make validate-seo` — description/title length; `make validate-links`.
+- No em-dash: `grep -c $'—' <file> <sidecar>` must be 0.
+- **Render check** (mermaid + mockups + walkthroughs are client-rendered and draft-only): serve the
+  dev server and view/Playwright the page — see `serve-locally` + `author-walkthrough`'s verify block.
+
+## Cross-links
+
+`import-co-design` (HLD path) · `author-walkthrough` + `upgrade-post` (components) ·
+`implement-with-design-system` (on-brand CSS) · `author-blog-post` (MDX pitfalls) ·
+`author-mermaid` (diagram syntax) · `publish-site` (go live).

--- a/.claude/skills/author-post/homes/initiatives.md
+++ b/.claude/skills/author-post/homes/initiatives.md
@@ -1,0 +1,66 @@
+# Authoring an `/initiatives` post (a temporal thing I DID)
+
+**Home:** the Initiatives blog instance (`bytesofpurpose-blog/blog/`, route `/initiatives`; the
+legacy `/blog/*` and `/thoughts/*` roots both redirect here). An initiative is **temporal and
+acted-on** — a dated thing I did. Its frontmatter makes it a **kanban card** and/or a **hub card**.
+
+**File:** `blog/YYYY-MM-DD-<kebab>.md` (usually `.md`; use `.mdx` if it embeds components).
+
+## Pick the `kind:`
+
+| kind | emoji | Use for |
+|---|---|---|
+| `project` | 🔨 | a build / project log |
+| `tinkering` | 🔧 | a smaller hands-on experiment with a tool |
+| `research` | 🔬 | a research write-up (also cards on the Research board) |
+| `prompt` | 💬 | a reusable prompt / prompt-engineering log |
+| `experiment-plan` | 📝 | an A/B or product experiment BEFORE results (flips to `experiment-result` 📊 when the Outcome lands) |
+| `reflection` | 💭 | a dated reflection on work done |
+| `event-recap` | 🎙️ | a recap of a talk/event |
+
+Most of these carry an **`area:`** (`backend`/`frontend`/`script`/`plugin`) so they card on the
+matching **hub** (`manage-hubs`). Experiments are their own lifecycle — see below.
+
+## Frontmatter template
+
+```yaml
+---
+slug: <kebab>                     # blog slug (no design-/topic prefix)
+title: '🔨 <What I did — reads as a completed action>'   # kind emoji + action title
+description: <50 to 160 chars; no em-dash; feeds og + share>
+authors: [oeid]
+tags: [<3-5>]
+date: 2026-07-04                  # REQUIRED on blog posts (drives ordering + the timeline)
+draft: true
+kind: project
+area: backend                     # for the hub
+# --- kanban card fields, when it boards ---
+board: ideas                      # or omit; boards are per the kind→board map
+stage: backlog                    # backlog / in-progress / done (advancing = editing this)
+priority: low
+---
+```
+
+Body: intro → `<!-- truncate -->` → the log. Title VOICE matters — an initiative reads as what I
+DID (`name-post`).
+
+## Experiments have their own lifecycle
+
+An experiment is ONE `/initiatives` post whose `stage` places it on the **Experimentation board**.
+Do not hand-roll it — use the lifecycle skills in order: **`design-experiment`** (the plan) →
+`run-ab-test` → `analyze-experiment` → `decide-experiment` → `conclude-experiment`. The `kind:`
+flips `experiment-plan` → `experiment-result` when the Outcome lands.
+
+## Concluding an initiative
+
+When the work concludes, **distill the durable LEARNING up into `/craft`** (a `technique`/`pattern`/
+`framework` doc) — the temporal log stays; the lasting lesson graduates. See the CLAUDE.md
+durable-vs-temporal tenet + `groom-initiatives`.
+
+## Validate + cross-links
+
+- No em-dash; `date:` present; healthy `description:`. Gates: `make validate-seo`,
+  `make validate-links`, `make validate-hubs` (if it cards on a hub), `make validate-naming`.
+- `groom-initiatives` (board contract: kind/stage/priority, advancing, concluding) ·
+  `manage-hubs` (the by-area hub) · the experiment-lifecycle skills · `name-post` ·
+  `author-blog-post` (MDX/frontmatter) · `upgrade-post` (components).

--- a/.claude/skills/author-post/homes/journey.md
+++ b/.claude/skills/author-post/homes/journey.md
@@ -1,0 +1,44 @@
+# Authoring a `/journey` doc
+
+**Home:** the Journey docs instance (`bytesofpurpose-blog/docs/journey/…`, route `/journey`; the
+plugin `id` is still `'self'` internally, and old `/self/*` URLs 301 to `/journey/*`). Journey is
+the durable **"what drives me forward / why I build"** — the inward why, the counterpart to Craft's
+outward how.
+
+## It shares Craft's docs mechanics
+
+Journey is a docs instance with the **same topic-folder contract, slug rule, and validators** as
+Craft. **Read `homes/craft.md` for the mechanics** (topic README + `_category_.json`, absolute
+instance-relative slug, kebab names / no numeric prefix, `{from,to}` redirect on a move, the gates).
+Only two things differ:
+
+1. **The nature of the content.** Journey holds the inward "why": faith, principles that drive the
+   work, what building means. If a piece is really an outward "how I do the work" learning, it
+   belongs in `/craft`, not here — classify with `organize-post` when unsure.
+2. **The topics/areas.** Journey's topics are **faith, personal-growth, entrepreneurship,
+   productivity**. Slugs are instance-relative to the journey root (`slug: /faith/x` → `/journey/faith/x`).
+
+## Frontmatter template
+
+```yaml
+---
+title: '<The lasting "why" — a driver, a conviction, a lesson>'
+description: <50 to 160 chars; no em-dash; feeds og + share>
+slug: /<topic>/<kebab>            # ABSOLUTE + INSTANCE-RELATIVE (no /journey prefix)
+kind: reflection                  # or framework/reference as fits; see homes/craft.md table
+authors: [oeid]
+tags: [<topic>, <2-4 more>]
+---
+```
+
+## The other durable roots
+
+`/knowledge` (durable mental models) and `/habits` (habitual practices) are ALSO sibling durable
+docs roots with this same shape — author them per `homes/craft.md` too. Adding, renaming, or
+splitting a whole root instance is a bigger operation owned by **`manage-docs-instances`** (the
+8-touchpoint registration checklist).
+
+## Cross-links
+
+`homes/craft.md` (the shared docs mechanics) · `organize-post` (durable why vs how) ·
+`manage-docs-instances` (root-level changes) · `reorganize-content` (moves) · `author-blog-post`.

--- a/.claude/skills/author-post/homes/thoughts.md
+++ b/.claude/skills/author-post/homes/thoughts.md
@@ -1,0 +1,75 @@
+# Authoring a `/thoughts`, `/mindset`, or `/questions` post (a temporal thought)
+
+These three blog instances hold the **temporal thought and its curated forms**. The dividing line
+is **occurrence vs. curation**:
+
+- **`/thoughts`** — an idea/question that just **OCCURRED to me** and I have NOT acted on (the raw
+  mental event). Files: `bytesofpurpose-blog/thoughts/YYYY-MM-DD-<kebab>.md`.
+- **`/mindset`** — a thought I deliberately **KEEP to shape how I think** (curated inputs). Files:
+  `bytesofpurpose-blog/mindset/…`.
+- **`/questions`** — a deliberate **SET of questions** I ask. Files: `bytesofpurpose-blog/questions/…`.
+
+If the thought has been **acted on**, it is not a thought anymore — author it as an `/initiatives`
+post (`homes/initiatives.md`). If it distilled into a lasting lesson, it goes to `/craft`. Classify
+with `organize-post` when the graduation is unclear.
+
+## Pick the `kind:` (each carries exactly one collection flag)
+
+| kind | emoji | Home | It is… |
+|---|---|---|---|
+| `idea` | 💡 | `/thoughts` | an idea that occurred to me (unactioned) |
+| `simulation` | 🔮 | `/thoughts` | a "what if I ran this forward" thought |
+| `prediction` | 🎯 | `/thoughts` | a dated prediction |
+| `critique` | 🔍 | `/thoughts` | a critical read of something |
+| `research` | 🔬 | `/thoughts` | an open research thread (also boards) |
+| `design-story` | 📐 | `/thoughts` | a narrative about a design (points to the HLD in `/designs`) |
+| `quote-set` | 🗣️ | `/mindset` | a curated set of quotes that moved me |
+| `principle` | 🪞 | `/mindset` | a principle I live by |
+| `question-set` | ❓ | `/questions` | an important set of questions |
+
+## Title VOICE — the #1 tell to get right
+
+An unactioned thought must read as an **OPEN QUESTION**, not a finished thing. "Should I auto-surface
+my other work streams?" — NOT "My work-stream auto-surfacer". Titling an idea like a completed
+initiative is the classic mismatch `validate-naming` + `name-post` catch. Run **`name-post`** when titling.
+
+## Frontmatter template (a `/thoughts` idea; boards as an Ideas card)
+
+```yaml
+---
+slug: idea-<kebab>
+title: 'Should I <...>?'          # reads as an open question
+sidebar_label: '<Short?>'
+description: <50 to 160 chars; no em-dash; feeds og + share>
+authors: [oeid]
+tags: [ideas, <2-4 more>]
+date: 2026-07-04                  # REQUIRED
+kind: idea
+board: ideas                     # → a card on the Ideas board (/craft/product-management/ideas)
+stage: backlog
+priority: low
+draft: false
+---
+```
+
+Any theme tag you put on a `board:`-carrying post needs a one-line **gloss** in the tag registry
+(`src/lib/idea-tags.ts`) in the same change — the CLAUDE.md "board tag tooltip" convention.
+
+## Mindset + Questions specifics
+
+- **Mindset quotes** use the quote kit (`<EditorialQuote>`/`<PosterQuote>`/`<QuoteSet>` — see
+  `upgrade-post`). Settle attribution HONESTLY first (`verify-quote-attribution`) and, if adding a
+  `video=`, verify the link (`find-quote-video`).
+- **Questions** use the question-set kit (`<Question>` cards + badges, `<QuestionSection>` — see
+  `upgrade-post`).
+- Each instance has a reader legend that teaches the boundary by example
+  (`/thoughts/about-my-thoughts`, `/mindset/about-my-mindset`, `/questions/about-my-questions`).
+
+## Validate + cross-links
+
+- No em-dash; `date:` present; healthy `description:`; title-voice via `name-post`.
+  Gates: `make validate-naming`, `make validate-seo`, `make validate-idea-tags` (board posts),
+  `make validate-links`.
+- `organize-post` (which thought kind / has it graduated?) · `mature-content` (firm up a raw idea) ·
+  `groom-initiatives` (board an idea, advance it) · `upgrade-post` (quote/question kits) ·
+  `name-post` · `verify-quote-attribution` + `find-quote-video` (mindset) · `author-blog-post`.

--- a/.claude/skills/author-walkthrough/SKILL.md
+++ b/.claude/skills/author-walkthrough/SKILL.md
@@ -120,7 +120,21 @@ A `<Walkthrough>` is hand-crafted, so on an `import-co-design` post it must live
 3. The importer injects `import Mockups … <Mockups/>` after the truncate marker and PRESERVES
    it across re-imports; it never regenerates the sidecar. (See `import-co-design`.)
 
-For a hand-authored post (not an import), put the `<Walkthrough>` directly in the post body.
+For a hand-authored `designs/` post (one NOT driven by `import-co-design`, e.g. a design
+written from a pasted plan), the **sidecar is still the better home** — it keeps the post body
+readable and matches how every other agentic design post is structured. The only difference is
+there is no importer to inject the wiring, so you do it by hand:
+
+1. Author `designs/_mockups/<name>.mdx` exactly as above (default-exported `Mockups()`,
+   `import {Mockup, Walkthrough} from '@omars-lab/blog-ui'` at the top).
+2. Add `mockups: ./_mockups/<name>.mdx` to the post frontmatter (metadata/provenance).
+3. Hand-add, right after the `<!-- truncate -->` marker in the post body:
+   `import Mockups from './_mockups/<name>.mdx';` then `<Mockups />`.
+
+Putting the `<Walkthrough>` inline in the post body also works, but only prefer it for a
+throwaway one-off; the sidecar is the default. (Worked hand-authored example:
+`designs/_mockups/fleetplane.mdx` — a marquee walkthrough plus four static `<Mockup>`s,
+wired into `designs/2026-07-04-fleetplane.mdx` this way.)
 
 ## Verify (always prove — client-rendered)
 
@@ -158,6 +172,14 @@ The e2e spec `test/e2e/co-design-imports.spec.ts` has a worked assertion (the
 
 ## Learnings log (newest first)
 
+- 2026-07-04 — Sidecar works for HAND-AUTHORED posts too. Building the Fleetplane design
+  (`designs/2026-07-04-fleetplane.mdx`) from a pasted implementation plan (no `import-co-design`
+  source), the `_mockups/<name>.mdx` sidecar + `mockups:` frontmatter + a hand-added
+  `import Mockups … <Mockups/>` after the truncate marker gave the same clean structure as the
+  imported posts, without inlining a big `<Walkthrough>` into the body. Corrected the old advice
+  ("put it directly in the post body") to make the sidecar the default and inlining the
+  exception. The marquee walkthrough animated the transcript-viewer flow (sanitize-on-device to
+  audited raw access); four static `<Mockup>`s covered the other Phase 4 surfaces.
 - 2026-06-23 — Created. The walkthrough is a two-scene crossfade engine (app `<Mockup>` +
   built-in Claude CLI). dragSelect/type animate progressively (not instant) so it reads like
   a real session. Grid-stacking the scenes in one cell was the fix for the Claude scene

--- a/.claude/skills/verify-change/SKILL.md
+++ b/.claude/skills/verify-change/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: verify-change
+description: Decide HOW to verify a change to the Bytes of Purpose site and WHICH checks are runnable in your current environment. Two axes — (1) what did you change? (content/frontmatter, CSS, a component, redirects, the hero, a generator, a deploy) maps to the checks that matter; (2) where are you running? (a local Mac with everything installed, a constrained cloud container like Claude Code on the web, or CI) maps to what actually works. Catalogs the testing methods fastest-to-heaviest (grep-level, standalone validators, MDX-compile, generate-assets/typecheck, dev-server + Playwright render, prod build + e2e/visual, deploy verify) and the env-specific gotchas proven the hard way (the canvas native build fails in cloud containers, yarn workspaces are disabled so blog-ui's dist needs its own install, a stale webpack cache after a late dist build, draft posts only render on :3000). Use when asked "how do I test this?", "did this actually render?", "what should I run before committing?", or when a build/validator fails in a weird environment. Pairs with test/e2e/README.md (the Playwright deep-dive), serve-locally, modify-blog-ui-component (the build-blog-ui loop), validate-deployment + verify-prod-deployment (the deploy layer).
+---
+
+# Verify a change (which checks, in which environment)
+
+Verification here answers two questions at once. **What did you change?** decides which checks
+MATTER. **Where are you running?** decides which checks are RUNNABLE. This skill maps both, and
+records the env-specific walls proven by actually driving the full path in a cloud container.
+
+## The methods, fastest to heaviest
+
+| Tier | Method | Command | Needs | Proves |
+|---|---|---|---|---|
+| T0 | **Grep-level** | `grep -c $'—' <file>`; the MDX-hazard scan (bare `<`/`{` in prose) | nothing | no em-dash / no obvious MDX-breaker |
+| T1 | **Standalone validators** | `make validate-* / check-*` (or `node scripts/<v>.js`) | node + a tiny dep (`gray-matter`) | outline, seo, links, structure, naming, hubs, idea-tags, ds-tokens, contrast, em-dash |
+| T2 | **MDX compile** | `make check` (`npx docusaurus-mdx-checker -c <dir>`) | site `node_modules` (NOT canvas, NOT a build) | every `.md/.mdx` COMPILES (frontmatter, JSX, imports, mermaid fences) |
+| T3 | **Generators + types** | `npm run generate-assets`; `yarn typecheck` | site `node_modules` | generated JSON builds; TS type-checks |
+| T4 | **Dev-server render** | `make start` (:3000) + Playwright screenshot | full install + built `blog-ui` dist + Chromium | mermaid draws to SVG, mockups/walkthroughs/client components RENDER (draft posts show here) |
+| T5 | **Prod build + e2e** | `make build`; `make test-regression` (3 projects), `test-prod-checks`, `test-visual`; `yarn test` (jest unit) | full install + a working build | build-only transforms, a11y/SEO, PostHog, visual baselines, unit logic |
+| T6 | **Deploy verify** | `make validate-deployment`; `node scripts/verify-prod-deployment.mjs` | the LIVE site | the deployed bundle serves + renders (CDN-propagated) |
+
+**Rule of thumb:** run the CHEAPEST tier that can actually catch your change's failure mode. A
+content edit is usually fully covered by T0+T1+T2. A new client component is only truly proven at
+T4 (it can compile at T2 and still render blank). See the CLAUDE.md "visual + mobile pass"
+convention: a new interactive component is not done until it has been LOOKED AT (T4).
+
+## Axis 1 — what changed → which checks matter
+
+| You changed… | Run |
+|---|---|
+| **Prose / frontmatter** (`docs`/`blog`/`designs`/`changelog` `.md`/`.mdx`) | T0 em-dash + MDX-hazard; T1 `validate-post-outline` (design/kind outline), `validate-seo`, `validate-links`, `validate-naming` (thoughts), `validate-idea-tags` (board post), `validate-hubs` (hub/area), `validate-structure` (docs IA); T2 `make check` |
+| **A post with components / mermaid / mockups** | the above **+ T4** (only a browser proves mermaid/mockups/walkthroughs render) |
+| **`docusaurus.config.js` redirects** | `validate-redirects` (needs the FULL install — it imports the config → prism themes); after a MOVE, repoint + collapse chains |
+| **CSS (`src/css/custom.css`)** | `check-contrast`, `validate-ds-tokens`; if it touches the hero, `test-visual` |
+| **A `@omars-lab/blog-ui` or `src/` component** | `make build-blog-ui` (rebuild dist + relink), `yarn typecheck`, `yarn test` (jest), T4 render, the mobile/desktop audit (`audit-mobile-experience`) |
+| **The homepage hero** (`index.tsx`/`index.module.css`/`SplitFlap`) | `validate-hero-anchors`, `test-visual` |
+| **A generator or generated data** | `npm run generate-assets`, then validate the consumer (the block-generated-edits hook forbids editing the output directly) |
+| **A URL query param** | `validate-url-params` |
+| **A hero card PNG / arch asset** | `validate-arch-assets` |
+| **Anything, before deploy** | `make build` then `validate-seo-built` + `verify-premium`; after deploy, T6 |
+
+## Axis 2 — where you're running → what's runnable
+
+### Local Mac (the author's machine)
+Everything works: `make start`/`serve`/`build`/`test-regression`/`test-visual`, the LOCAL-ONLY
+validators (`validate-noteplan-links` resolves real notes; off-machine it is syntax-only), and
+deploy. **Visual-regression baselines are DPR/OS-specific — only trust `test-visual` here.**
+
+### Constrained cloud container (Claude Code on the web / this remote env)
+Proven behaviour, do not relearn it the hard way:
+
+- **No `node_modules` by default.** A full `yarn install` mostly succeeds but **exits non-zero on
+  the `canvas` native module** (node-pre-gyp 404 for the prebuilt binary, then the gyp source
+  build fails — no cairo/build toolchain). This does **not** block the JS site build; `canvas` is
+  transitive/optional. Treat that one error as expected.
+- **Yarn workspaces are DISABLED** here ("Workspaces can only be enabled in private projects"), so
+  `packages/blog-ui`'s devDeps (tsup) are NOT installed from the site tree → `make build-blog-ui`
+  fails at `tsup: not found`. Fix: `cd packages/blog-ui && yarn install` FIRST, then build. Its
+  relink step re-trips `canvas`, but the **tsup `dist/` is already built** by then (index.js /
+  index.css / index.d.ts), which is what the site imports.
+- **Stale webpack cache** bites if `blog-ui/dist` is built AFTER the dev server first compiled: the
+  server caches the `Module not found: @omars-lab/blog-ui` failure. Fix: `rm -rf node_modules/.cache
+  .docusaurus` and restart. Then it compiles clean.
+- **Chromium is pre-installed** at `/opt/pw-browsers/chromium-*/chrome-linux/chrome` (do NOT
+  `playwright install`). Playwright's node entry is CommonJS: `import pkg from
+  'playwright-core'; const { chromium } = pkg;`.
+- **External network is proxied** — a rendered page logs `ERR_CONNECTION_RESET` / `403` for
+  external fonts/analytics. Benign; not a page bug.
+- **Fast lane WITHOUT a full install** (covers most content changes in seconds): T0 greps + T1
+  validators + T2 MDX-compile. To run a validator without installing the whole tree, drop
+  `gray-matter` into a scratch dir and point `NODE_PATH` at it:
+  ```bash
+  mkdir -p /tmp/vend && ( cd /tmp/vend && npm install gray-matter )
+  cd bytesofpurpose-blog && NODE_PATH=/tmp/vend/node_modules node scripts/validate-post-outline.js <file>
+  ```
+  `make check` (MDX-compile of all files) works once the site `node_modules` exists and needs
+  neither canvas nor a build.
+
+### CI (GitHub Actions)
+The `validate-*` gates + `yarn test` + (optionally) a headless build. Local-only validators pass
+syntax-only. This is the enforcement layer; keep a change green here before asking to merge.
+
+## The full-render recipe in a cloud container (copy-paste)
+
+```bash
+cd bytesofpurpose-blog && yarn install --network-timeout 600000          # canvas error is expected/ignorable
+( cd ../packages/blog-ui && yarn install ) && make -C .. build-blog-ui   # dist builds; ignore the relink canvas error
+rm -rf node_modules/.cache .docusaurus                                    # clear the stale-cache trap
+npx docusaurus start --port 3000 --no-open                                # drafts render here; wait for "compiled successfully"
+# then screenshot with Playwright (executablePath = /opt/pw-browsers/chromium-*/chrome-linux/chrome)
+```
+Assert on the page: an `<h1>`, `.mermaid svg` count > 0, the `<Mockup>` frame count, no
+`Module not found`/error overlay. (Worked example: this session rendered `design-fleetplane` with
+3 mermaid SVGs + 4 mockups + the walkthrough, error overlay 0.)
+
+## Gotchas (proven)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `yarn install` exits 1 but node_modules is full | `canvas` native build failed (no toolchain) | Ignore unless you need canvas features; the JS build is fine. |
+| `make build-blog-ui` → `tsup: not found` | workspaces disabled → package devDeps not installed | `cd packages/blog-ui && yarn install` first. |
+| Dev server: `Module not found: @omars-lab/blog-ui` even after building dist | stale webpack/docusaurus cache from the pre-build compile | `rm -rf node_modules/.cache .docusaurus`, restart. |
+| A draft post 404s in a prod build but renders on :3000 | drafts are dev-only | Verify drafts at T4 (`make start`), not `make build`/T5. |
+| `import { chromium }` throws "Named export not found" | playwright-core is CommonJS | `import pkg from 'playwright-core'; const { chromium } = pkg;` |
+| A backgrounded `nohup … &` dev server dies when the wrapper exits | the child is in the wrapper's process group | run the server AS the background command (no inner `&`), or `setsid`. |
+| `validate-redirects` throws `Cannot find module 'prism-react-renderer'` | it imports `docusaurus.config.js` → prism | needs the full install; it is NOT a fast-lane validator. |
+
+## Cross-links
+
+`test/e2e/README.md` (the Playwright 3-project deep-dive — this skill routes TO it) · `serve-locally`
+(run :3000 vs :4173) · `modify-blog-ui-component` (the build-blog-ui + stale-dist loop) ·
+`deploy-site` (the build + secret-scan + SEO-built gates) · `validate-deployment` +
+`verify-prod-deployment` (T6, the live layer) · `audit-mobile-experience` / `audit-desktop-experience`
+(the visual pass a new component owes) · the individual validator owners named in CLAUDE.md.
+
+## Learnings log (newest first)
+
+- 2026-07-04 — Created after empirically driving the whole verification path in a cloud container to
+  prove the Fleetplane post renders. Findings that motivated the skill: (a) ~9 validators run with
+  only `gray-matter` via `NODE_PATH`; `validate-redirects` alone needs the full install. (b) `make
+  check` (docusaurus-mdx-checker) compiled all 260 MDX files with no build and no canvas — the best
+  cheap "does it compile" gate. (c) A full render is reachable in-container but only after: yarn
+  install (canvas error ignored), `packages/blog-ui` own install + tsup dist build, and a cache
+  clear; then Playwright (pre-installed Chromium) confirmed 3 mermaid SVGs + 4 mockups + the
+  walkthrough with zero error overlay.

--- a/bytesofpurpose-blog/designs/2026-07-04-fleetplane.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-04-fleetplane.mdx
@@ -1,0 +1,459 @@
+---
+slug: design-fleetplane
+sidebar_label: Fleetplane
+sidebar_position: 19
+title: 'Fleetplane: A Control Plane for a Claude Code Fleet'
+description: >-
+  A build-ready plan to standardize Claude Code across an engineering fleet and
+  turn on-device-sanitized session transcripts into metrics, dashboards, and a
+  bug pipeline.
+authors:
+  - oeid
+tags:
+  - system-design
+  - architecture
+  - ai-agents
+  - claude-code
+  - observability
+kind: backend-design
+draft: true
+---
+
+# Fleetplane: A Control Plane for a Claude Code Fleet
+
+:::note[Scope]
+This design defines **Fleetplane**: a system that (1) centralizes and standardizes Claude Code configuration across an engineering fleet, (2) collects and sanitizes session transcripts **on-device**, and (3) turns them into metrics, dashboards, an issue pipeline, and an investor-ready deck. It is written as a **phased, independently shippable** build: each phase stands on its own, and Stage 1 (1 to 100 engineers) is a strict subset of every later stage, so nothing built early is thrown away when you scale.
+:::
+
+<!-- truncate -->
+
+## Executive Summary
+
+**The problem.** An engineering org that has adopted Claude Code quickly faces three gaps at once. Every laptop drifts to its own config, so skills, agents, hooks, and permissions are inconsistent and unenforceable. The richest signal about how the fleet actually works, the session transcripts, sits on individual machines where it cannot be measured and, worse, contains raw secrets that must never leave the device. And leadership has no trustworthy numbers: tokens, spend, bugs found, adoption. There is no control plane.
+
+**The solution.** Fleetplane splits into two planes that never blur. A **config plane** (push) ships one versioned, enforced configuration to every laptop through a plugin marketplace plus MDM-deployed managed settings. A **data plane** (pull and analyze) runs a small on-device agent that sanitizes transcripts at the edge, mirrors only the clean output, and uploads it to a warehouse that feeds dashboards, a bug pipeline, and a deck studio. Raw transcripts never leave the laptop.
+
+**Key decisions.**
+- **D1 (Sanitize at the edge, decided):** the sanitizer runs on-device and is treated as production code with its own CI gate. Only sanitized output is ever uploaded.
+- **D2 (Marts-only frontend, decided):** the web app reads pre-aggregated serving tables, never fact tables, so every panel renders fast and the warehouse can evolve underneath it.
+- **D3 (Everything is IaC, decided):** the whole cloud stack is reproducible in a fresh AWS account in under an hour.
+- **D4 (Policy strictness, phased):** start with a marketplace allowlist; add strict plugin-only customization later, and only if config drift is actually observed.
+
+**Expected value.** Live token and cost dashboards exist after Phase 1, before any transcript pipeline is built. That is the point: value lands before collection. Everything after is layered on a foundation whose only expensive-to-get-wrong pieces (the sanitizer, the schema, the consent model) are over-built early and the rest is kept deliberately small.
+
+**Status and what is open.** The architecture, the invariants, and the star schema are settled. The open items are cultural more than technical: shipping the consent doc and the "what we collect" page before fleet-wide upload, and running the pilot gate on two or three volunteer laptops with a manual raw-versus-clean diff before rollout.
+
+---
+
+## The invariants that hold at every scale
+
+These rules do not bend as headcount grows. If a change would violate one, that is a signal to stop and flag it, not to proceed.
+
+| # | Invariant | Why it is non-negotiable |
+|---|-----------|--------------------------|
+| 1 | **Sanitize at the edge.** | Raw transcripts never leave the laptop. Only sanitized output is ever uploaded. |
+| 2 | **Transcripts are append-only.** | Sync is incremental by byte offset. On truncation or inode change, re-sanitize from zero. |
+| 3 | **The frontend reads marts only.** | The web app never queries fact tables, only pre-aggregated serving tables. |
+| 4 | **Everything is IaC.** | The entire cloud stack is reproducible in a fresh AWS account in under an hour. |
+| 5 | **Consent before collection.** | Ship the consent doc and the "what we collect" page before enabling fleet-wide upload. |
+| 6 | **The sanitizer is production code.** | It has its own test suite in CI and a version stamped on every uploaded file. |
+
+Rules 1 to 4 are technical. Rules 5 and 6 are cultural, and equally binding. The trap this whole design guards against is building Stage 3 infrastructure at Stage 1 headcount. Over-engineer only the sanitizer, the schema, and the consent model early. They are the only things expensive to get wrong later.
+
+---
+
+## Target Architecture (Stage 1: 1 to 100 engineers)
+
+Two planes, cleanly separated. The **config plane** pushes standardized configuration out to laptops. The **data plane** pulls sanitized transcripts back in and analyzes them. The animated view below traces the full loop; the boxed listing after it is the same picture in text.
+
+<div className="mermaid-animated flow-dot">
+
+```mermaid
+%% animate: flow
+graph LR
+    subgraph config["CONFIG PLANE &#8212; push"]
+        REPO[claude-fleet monorepo<br/>git]
+        MKT[Plugin Marketplace]
+        CORE[org-core plugin<br/>skills, agents, hooks, MCP]
+        MGD[managed-settings.json<br/>via MDM]
+        REPO --> MKT
+        REPO --> CORE
+        REPO --> MGD
+    end
+
+    subgraph laptop["ON-DEVICE"]
+        CC[Claude Code]
+        SYNC[cc-sync agent<br/>launchd / systemd]
+        SAN{{sanitize at edge}}
+        CLEAN[(clean mirror<br/>~/.claude-clean)]
+        CC --> SYNC --> SAN --> CLEAN
+    end
+
+    subgraph cloud["DATA PLANE &#8212; pull and analyze"]
+        S3[(S3 clean transcripts<br/>SSE-KMS, versioned)]
+        ETL[SQS to Lambda ETL]
+        PG[(Postgres<br/>facts plus marts)]
+        APP[Fleetplane web app<br/>Fargate, Tailscale-only]
+        GRAF[Grafana OSS<br/>live OTel metrics]
+    end
+
+    MKT -.installs.-> CC
+    CORE -.installs.-> CC
+    MGD -.enforces.-> CC
+    CLEAN -->|presigned upload| S3
+    S3 -->|S3 event| ETL --> PG --> APP
+    CC -.OTLP telemetry.-> GRAF
+
+```
+
+</div>
+
+Read as text, the Stage 1 topology is:
+
+```
+CONFIG PLANE (push)                     DATA PLANE (pull + analyze)
+─────────────────                       ──────────────────────────
+claude-fleet monorepo (git)             cc-sync agent (launchd/systemd, on each laptop)
+  ├─ plugin marketplace                   └─ sanitize → clean mirror → upload API
+  ├─ org-core plugin                    S3 (clean transcripts, SSE-KMS, versioned)
+  │    skills, agents, hooks, MCP         └─ S3 event → SQS → Lambda ETL
+  └─ managed-settings.json (via MDM)    Postgres (facts + marts, single instance)
+                                        Fleetplane web app (Fargate, Tailscale-only)
+                                          ├─ transcript viewer
+                                          ├─ plugin hub
+                                          ├─ dashboard
+                                          └─ deck studio
+                                        Grafana OSS (live OTel metrics)
+```
+
+---
+
+## Repository Layout
+
+Two repos, kept separate on purpose: they have different release cadences and different blast radii. A bad config push and a bad cloud deploy should never be the same commit.
+
+### `claude-fleet` (config plus on-device agent)
+
+```
+claude-fleet/
+├── .claude-plugin/
+│   └── marketplace.json                 # marketplace manifest
+├── plugins/
+│   └── org-core/
+│       ├── .claude-plugin/plugin.json
+│       ├── skills/
+│       │   ├── code-review/SKILL.md
+│       │   ├── release-notes/SKILL.md
+│       │   ├── fleet-setup/SKILL.md      # onboarding walkthrough
+│       │   └── fleet-doctor/SKILL.md     # diagnose broken installs
+│       ├── agents/
+│       │   ├── bug-hunter.md
+│       │   └── security-scan.md
+│       ├── hooks/
+│       │   ├── hooks.json                # SessionEnd flush + SessionStart self-heal
+│       │   └── health_check.py
+│       └── .mcp.json                     # issue-logger MCP server
+├── managed/
+│   └── managed-settings.json            # deployed via MDM, NOT git pull
+├── agent/                               # the cc-sync binary
+│   ├── src/
+│   │   ├── main.py (or main.rs/go)
+│   │   ├── sanitizer.py                 # THE critical component
+│   │   ├── mirror.py                    # byte-offset tailing + state
+│   │   └── upload.py                    # presigned-URL client
+│   ├── tests/
+│   │   ├── fixtures/                     # transcripts with planted secrets
+│   │   ├── test_sanitizer.py
+│   │   └── test_mirror.py
+│   └── packaging/
+│       ├── homebrew/cc-sync.rb
+│       ├── launchd/com.yourorg.cc-sync.plist
+│       └── systemd/cc-sync.{service,path,timer}
+└── ci/
+    ├── validate-plugins.yml
+    └── test-sanitizer.yml               # BLOCKS merge on any secret escape
+```
+
+### `fleetplane` (cloud: infra plus ETL plus web app)
+
+```
+fleetplane/
+├── infra/                               # Terraform or CDK
+│   ├── storage.tf                       # S3, KMS, lifecycle
+│   ├── ingest.tf                        # SQS, Lambda, DLQ
+│   ├── data.tf                          # RDS Postgres
+│   ├── app.tf                           # Fargate, ALB, Tailscale
+│   ├── auth.tf                          # upload API, secrets
+│   └── observability.tf                 # Grafana, CloudTrail, ADOT
+├── etl/
+│   ├── handler.py                       # S3-triggered parse → upsert
+│   ├── parse.py                         # JSONL → facts
+│   └── marts.sql                        # scheduled mart refresh
+├── api/                                 # FastAPI (or Next API routes)
+│   ├── main.py
+│   ├── auth.py                          # OIDC + RBAC
+│   ├── routes/{sessions,metrics,deck}.py
+│   └── presign.py                       # audited transcript URLs
+├── web/                                 # Next.js
+│   └── app/{transcripts,plugins,dashboard,deck}/
+├── deck/
+│   ├── generate.py                      # marts → PPTX
+│   └── narrate.py                       # Claude API drafts slide notes
+└── db/
+    ├── schema.sql                       # facts
+    └── marts.sql                        # serving layer
+```
+
+---
+
+## Phase 1: Config Plane (week 1)
+
+**Goal:** every laptop runs identical, versioned config, and live token and cost dashboards exist. Ship this before any collection.
+
+- **Task 1.1: Marketplace plus org-core skeleton.** Create the `claude-fleet` repo, `marketplace.json`, and the `org-core` plugin with `plugin.json`; add two starter skills (`code-review`, `release-notes`) and the `bug-hunter` agent. **Acceptance:** on a clean machine, adding the marketplace then installing `org-core` makes the skills and agent available.
+- **Task 1.2: Managed settings.** Author `managed/managed-settings.json` with `extraKnownMarketplaces`, `enabledPlugins`, a `strictKnownMarketplaces` allowlist, telemetry `env` vars (`CLAUDE_CODE_ENABLE_TELEMETRY`, the OTLP exporter and endpoint), `permissions.deny` (for example `Read(**/.env)` and `Bash(sudo:*)`), and a cleanup period. Document the MDM paths for macOS, Linux, and Windows. **Acceptance:** with the file in place, user or project settings cannot disable org-core or the telemetry env vars.
+- **Task 1.3: CI for plugins.** `validate-plugins.yml` lints every manifest and verifies skill and agent frontmatter. **Acceptance:** a malformed manifest fails the PR check.
+- **Task 1.4: Live telemetry dashboards.** Stand up Grafana OSS plus an ADOT collector on Fargate receiving OTLP from laptops into CloudWatch, with panels for active engineers per day, sessions, tokens by model, and estimated spend. **Acceptance:** a session on an enrolled laptop shows up in Grafana within minutes. **This is the Phase 1 win: value before the transcript pipeline exists.**
+
+:::tip[Decision to lock here]
+Policy strictness (D4). Start with the marketplace allowlist. Add strict plugin-only customization later, and only if you actually observe config drift.
+:::
+
+---
+
+## Phase 2: Collection plus Sanitize (weeks 2 to 3)
+
+**Goal:** sanitized JSONL lands in S3 from every laptop, and raw transcripts never leave a machine.
+
+### Task 2.1: The sanitizer (build this most carefully)
+
+This is the critical path. Everything downstream trusts that its output is clean. The pipeline runs in order, per JSONL line:
+
+1. **Secret scrub.** Gitleaks and trufflehog-style regexes plus a high-entropy detector over every text field. Replace matches with **typed** placeholders (`[REDACTED:aws_key]`, `[REDACTED:jwt]`, and so on) so analytics can still count occurrences.
+2. **Field allowlist.** Rebuild each event keeping only event type, timestamps, model, token usage, tool name plus a coarse input summary, subagent name, and error flags. Drop Read and Write file bodies by default (keep byte counts plus hashed paths).
+3. **Path and identity mapping.** Replace absolute paths with a salted hash of repo-root plus relative path; map OS user to an opaque `engineer_id`. The salt map lives only server-side.
+4. **Stamp `sanitizer_version`** on the output.
+
+The acceptance criteria here are **CI gates, not suggestions**:
+
+```
+test_no_secret_survives:  planted secrets → zero matches after sanitize; max entropy < threshold
+test_metrics_preserved:   token totals and tool-call counts identical pre/post sanitize
+```
+
+`ci/test-sanitizer.yml` **must block merge** on any failure. The two properties it proves, no secret escapes and no metric is lost, are exactly the two things the rest of the system takes on faith.
+
+### Task 2.2: Mirror plus sync (the rsync-like backbone)
+
+`mirror.py` maintains `~/.claude-clean/` mirroring `~/.claude/projects/` with sanitized lines only, tracking `(inode, bytes_sanitized, sha_prefix)` per file in `state.sqlite`. Each pass reads only the bytes beyond `bytes_sanitized` (the append-only tail); on shrink or inode change it re-sanitizes from zero. The sync step is a plain `aws s3 sync` of the clean mirror into a per-engineer prefix, and the binary is **run-to-completion** (`cc-sync --once`), not a resident daemon. **Acceptance:** appending to a transcript sanitizes only the new lines and re-uploads only the changed file; killing the process mid-run and rerunning produces no duplicate or corrupt uploads (idempotent by file plus offset).
+
+### Task 2.3: Triggers (launchd, systemd, hook)
+
+A user LaunchAgent (not a root LaunchDaemon) watches `~/.claude/projects` with a start interval and throttle; Linux gets a systemd user `.path` unit plus a `.timer`. A SessionEnd hook in org-core calls the same binary with a flush trigger. **Acceptance:** transcript writes trigger a sync within the throttle window with no long-lived watcher process, and a reboot with queued offline data flushes on next load.
+
+### Task 2.4: Distribution (brew, setup skill, self-heal)
+
+A Homebrew formula installs the binary and registers the service via `brew services` (with a scoop or winget path for Windows). The `fleet-setup` skill runs the install, verifies the service is loaded, fires a **synthetic-secret test session**, and confirms the redacted file landed in S3. The `fleet-doctor` skill diagnoses service-dead, token-expired, and upload-lag. A SessionStart self-heal hook verifies the service is loaded, the version is at or above the minimum, and the last upload was recent, then repairs or nags. **Acceptance:** a new engineer runs `/fleet-setup` and ends with a verified, uploading agent without touching a terminal manually.
+
+### Task 2.5: Consent plus governance artifacts
+
+Publish the exact field list collected, the consent doc, and the default team-level (not individual) dashboard scope. **Acceptance:** these exist and are linked from the plugin hub before fleet-wide upload is enabled.
+
+:::warning[Pilot gate]
+Enable on two or three volunteer laptops first. Manually diff sanitized output against the raw transcript before any fleet rollout. The sanitizer is the one component whose failure is unrecoverable, a leaked secret cannot be un-uploaded, so it earns a human diff before it earns trust.
+:::
+
+---
+
+## Phase 3: Ingest, Data Model, Dashboards, Bug Pipeline (weeks 3 to 4)
+
+### Task 3.1: Storage plus ingest spine
+
+The `cc-transcripts` bucket is SSE-KMS, versioned, public-access-blocked, with a lifecycle to Standard-IA, then Glacier, then expiry. Upload auth is a **presigned-URL API** (API Gateway plus Lambda): a device token in returns a short-lived presigned PUT scoped to that engineer's own prefix, and the IAM policy is **write-only, own-prefix only** (no List, no Get). Uploads fan out `S3 event → SQS (plus DLQ) → Lambda ETL`, and malformed files divert to a `quarantine/` prefix. **Acceptance:** an uploaded clean file appears as rows in Postgres within minutes; a deliberately corrupt file lands in quarantine, not the warehouse.
+
+### Task 3.2: Data model (star schema)
+
+Build exactly these tables. The skill and agent tables are projections of `tool_calls`, not independent facts.
+
+| Table | Grain | Key columns |
+|---|---|---|
+| `sessions` | one per session | session_id, engineer_id, repo_hash, model, started_at, duration, input/output/cache tokens, est_cost_usd, sanitizer_version |
+| `tool_calls` | one per tool_use | session_id, ts, tool_name, mcp_server, duration_ms, is_error, bytes_in/out |
+| `agent_runs` | one per subagent Task | session_id, agent_name, tokens, outcome |
+| `skill_uses` | one per skill invocation | session_id, skill_name, plugin_version |
+| `issues` | one per logged bug | issue_id, session_id, agent_name, severity, category, target, tracker_url, status |
+| `sites_analyzed` | one per audit target | target_id, first_seen, sessions_count, issues_found |
+
+The same shape as an entity model:
+
+```mermaid
+erDiagram
+    SESSIONS ||--o{ TOOL_CALLS : "emits"
+    SESSIONS ||--o{ AGENT_RUNS : "spawns"
+    SESSIONS ||--o{ SKILL_USES : "invokes"
+    SESSIONS ||--o{ ISSUES : "produces"
+    ISSUES }o--o| SITES_ANALYZED : "targets"
+
+    SESSIONS {
+        id session_id PK
+        string engineer_id
+        string repo_hash
+        string model
+        datetime started_at
+        int duration
+        int tokens_in_out_cache
+        float est_cost_usd
+        string sanitizer_version
+    }
+    TOOL_CALLS {
+        id id PK
+        id session_id FK
+        string tool_name
+        string mcp_server
+        int duration_ms
+        bool is_error
+    }
+    AGENT_RUNS {
+        id id PK
+        id session_id FK
+        string agent_name
+        int tokens
+        string outcome
+    }
+    SKILL_USES {
+        id id PK
+        id session_id FK
+        string skill_name
+        string plugin_version
+    }
+    ISSUES {
+        id issue_id PK
+        id session_id FK
+        string severity
+        string category
+        string tracker_url
+        string status
+    }
+    SITES_ANALYZED {
+        id target_id PK
+        datetime first_seen
+        int sessions_count
+        int issues_found
+    }
+```
+
+**Acceptance:** parsing a fixture transcript populates all applicable tables with correct counts.
+
+### Task 3.3: Marts (serving layer)
+
+A scheduled job (EventBridge to Lambda or Fargate) materializes `mart_daily_usage`, `mart_agent_leaderboard`, `mart_bug_funnel`, and `mart_deck_kpis`, targeting reads under 100ms. **Acceptance:** marts refresh on schedule and each is queryable in under 100ms. This is invariant 3 made concrete: the frontend will only ever touch these.
+
+### Task 3.4: Issue-logger MCP server
+
+One tool, `log_issue(title, severity, category, target, evidence, suggested_fix)`, writes the issues DB **and** opens or updates a GitHub issue, returning a `tracker_url`. It dedups on a fingerprint of `category + target + normalized_title` (repeats increment a counter), gates severity (Sev-1 and Sev-2 ping Slack; Sev-3 and lower go to the tracker only), and labels every agent-filed issue `agent-found`, holding it in triage until a human confirms. The `bug-hunter` agent is instructed to call `log_issue` for every confirmed finding. Critically, the **ETL also extracts the `log_issue` tool_use from transcripts and reconciles it against the live-filed issues**, so a mismatch flags a failed upload. **Acceptance:** a bug-hunter run files a deduplicated GitHub issue live, and the same issue is independently recovered from the transcript ETL.
+
+---
+
+## Phase 4: App Plane (Fleetplane) (weeks 4 to 5)
+
+Four experiences behind one API and one login.
+
+- **Task 4.1: API plus security model.** FastAPI (or Next API routes) with a DB role that is **read-only on marts**. Auth is OIDC via the IdP with httpOnly, SameSite session cookies. RBAC is enforced **in the API, not the UI** (`engineer`, `lead`, `exec`, `admin`). Transcript bodies are never proxied: the API issues short-lived presigned S3 GET URLs and **logs every access** (who viewed whose session). Hardening covers strict CSP, no third-party scripts, parameterized queries, rate limits, and dependency scanning; the network is reachable only via Tailscale with no public DNS. **Acceptance:** an `engineer`-role token cannot fetch another engineer's session, and every transcript fetch writes an audit-log row.
+- **Task 4.2: Transcript viewer.** A session list with filters (engineer, repo, agent), a rendered event stream plus a raw JSONL toggle, redactions visible as badges, and `log_issue` calls shown inline. **Acceptance:** viewing a session shows redaction badges, and raw access is a logged presigned download.
+- **Task 4.3: Plugin hub.** A marketplace landing showing org-core contents, current version, adoption percentage (from `skill_uses` by version), changelog, and a one-copy install command. **Acceptance:** adoption bars reflect real warehouse data and the copy button yields a working install command.
+- **Task 4.4: Dashboard.** KPI tiles (sessions, tokens, spend, bugs logged, active engineers, cost-per-confirmed-bug), a tokens-per-day trend, bugs by severity, an agent leaderboard with precision, skill adoption, and a fleet-health panel (plugin and sanitizer version spread, upload lag, and a sessions-missing-transcripts leak detector). Team-level by default; per-engineer drilldown is role-gated and audited. **Acceptance:** every panel reads a mart (not a fact table) and renders in under one second.
+- **Task 4.5: Deck studio.** A date-range picker drives a live 16:9 slide preview from `mart_deck_kpis` (sites analyzed, bugs by severity, tokens, cost, bug funnel, adoption); slide notes are drafted via the Claude API from the same numbers and frozen at generation time; a human approves before export to PPTX or PDF. **Acceptance:** regenerating for a new range updates all numbers, export produces a valid PPTX, and nothing exports without approval.
+
+---
+
+## The Sanitize-to-Serve Flow
+
+The end-to-end path of a single transcript line, from the laptop to a rendered slide, makes the plane separation concrete: everything left of S3 is on-device and secret-bearing; everything right of it is clean by construction.
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant SYNC as cc-sync (on-device)
+    participant S3 as S3 (clean)
+    participant ETL as SQS to Lambda ETL
+    participant PG as Postgres (facts plus marts)
+    participant APP as Fleetplane app
+
+    CC->>SYNC: append transcript line (raw, may hold secrets)
+    Note over SYNC: sanitize at edge<br/>scrub, allowlist, hash, stamp version
+    SYNC->>SYNC: write clean line to ~/.claude-clean
+    SYNC->>S3: presigned PUT (write-only, own prefix)
+    S3->>ETL: S3 event to SQS
+    ETL->>PG: parse JSONL to facts, upsert
+    Note over PG: scheduled job refreshes marts
+    APP->>PG: read marts only (never facts)
+    APP-->>APP: dashboards, viewer, deck
+```
+
+---
+
+## AWS Reference (Stage 1 defaults)
+
+| Concern | Stage 1 choice |
+|---|---|
+| Device auth | Presigned-URL upload API (write-only, own-prefix IAM) |
+| Storage | S3 plus SSE-KMS plus versioning plus lifecycle |
+| Ingest | S3 event to SQS (plus DLQ) to Lambda |
+| Warehouse | Single RDS Postgres (facts plus marts) |
+| ETL and jobs | Lambda plus EventBridge Scheduler |
+| App | One Fargate service behind an internal ALB |
+| Access | Tailscale subnet router (no public ingress) |
+| Dashboards | Grafana OSS container |
+| OTel | ADOT to CloudWatch |
+| Cost | roughly 50 to 150 USD per month |
+
+**Shared plumbing (all stages, non-negotiable):** Secrets Manager (DB creds, upload signing key, GitHub token), one KMS CMK for the bucket and RDS, private subnets with S3 and Secrets VPC endpoints, CloudTrail S3 data-events (the read-audit trail), and Terraform or CDK for everything.
+
+---
+
+## Scaling: build the next stage only when a signal fires
+
+The single most important discipline in this design is **not** building ahead of headcount. Each move below is triggered by an observed signal, never by anticipation.
+
+| Signal | Move to |
+|---|---|
+| ETL Lambda nears its 15-minute timeout, or analyst queries slow the app | Facts to a Parquet lake (S3 plus Glue plus Athena, dbt on Fargate); Postgres becomes marts only |
+| A second team wants different plugins or policy | Per-team plugins plus managed-settings drop-in fragments |
+| A plugin release breaks more than 10 laptops | Canary rings (`org-core@next` to 5 percent for 48h, then fleet) plus a fleet-version SLO |
+| The 9am sync herd throttles the upload API, or a second region onboards | Streaming ingest (Kinesis or Firehose) plus regional endpoints |
+| Any external compliance requirement touches transcripts | Server-side DLP (Macie) as a second scrub, legal hold, SIEM export |
+| Finance asks what team X spends | Chargeback marts plus cost-allocation tagging |
+
+**Stage 2 (100 to 1000) introduces SLOs:** upload lag p95 under 15 minutes, dashboard freshness under one hour, and a sanitizer escape rate of zero, verified by scheduled synthetic-secret canary sessions.
+
+**Stage 3 (1000+)** adds a plugin certification pipeline (static analysis plus sanitizer regression plus permission diff before listing), streaming ingest by default, server-side DLP as defense-in-depth, a lakehouse (Iceberg) with Redshift Serverless or Snowflake plus data contracts and lineage, and multi-tenant Fleetplane with policy-engine authz (Cedar or OPA) and SIEM export.
+
+**The trap, restated:** do not build Stage 3 at Stage 1 headcount. Over-engineer only the sanitizer, the schema, and the consent model early. They are the only things expensive to get wrong later.
+
+---
+
+## Key Decisions
+
+The four architectural commitments, and the reasoning that makes each non-negotiable.
+
+- **D1: Sanitize at the edge (decided).** The sanitizer runs on-device and is production code with its own CI gate, because a leaked secret cannot be un-uploaded. Two CI properties, no secret escapes and no metric is lost, are what the entire warehouse takes on faith, so they block merge.
+- **D2: The frontend reads marts only (decided).** Every panel targets a pre-aggregated serving table with sub-100ms reads. This lets the fact tables and even the whole warehouse engine evolve underneath the app without touching the UI, and it is what keeps dashboards fast as the corpus grows.
+- **D3: Everything is IaC (decided).** The full cloud stack is reproducible in a fresh AWS account in under an hour. This is what makes disaster recovery, a second region, and a security review tractable rather than heroic.
+- **D4: Policy strictness (phased).** Start with a marketplace allowlist and add strict plugin-only customization only if config drift is observed. Enforcing more than the org has earned the trust for creates friction that pushes engineers off the managed path entirely.
+
+The consent model (invariant 5) sits alongside these as an equally binding cultural decision: collection is gated on a published field list and a consent doc, and dashboards default to team-level scope, with per-engineer drilldown role-gated and audited.
+
+---
+
+## Build Order
+
+Each phase is independently shippable; ship them in order.
+
+- [ ] **Phase 0:** write the consent doc plus the "what we collect" page; lock the six invariants.
+- [ ] **Phase 1:** marketplace plus org-core plus managed-settings plus plugin CI plus live OTel dashboards.
+- [ ] **Phase 2:** the CI-gated sanitizer plus the mirror/sync agent plus launchd/systemd plus brew plus fleet-setup and fleet-doctor plus the self-heal hook; pilot on two or three laptops.
+- [ ] **Phase 3:** S3/SQS/Lambda ingest plus the presigned upload API plus the star schema plus marts plus the issue-logger MCP plus reconciliation.
+- [ ] **Phase 4:** the API (RBAC plus audited presign) plus the transcript viewer plus the plugin hub plus the dashboard plus the deck studio.
+- [ ] **Ongoing:** IaC everything; add scale components only when a trigger fires.
+
+The very first things worth handing to a coding agent, in order: scaffold both repos; implement `sanitizer.py` and its tests **first** (it is the critical path and its tests gate everything); build `org-core` and `managed-settings.json` so a laptop can enroll; then the mirror/sync agent and its triggers; then cloud ingest so uploads have somewhere to land. Everything else layers on those five.

--- a/bytesofpurpose-blog/designs/2026-07-04-fleetplane.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-04-fleetplane.mdx
@@ -17,6 +17,7 @@ tags:
   - observability
 kind: backend-design
 draft: true
+mockups: ./_mockups/fleetplane.mdx
 ---
 
 # Fleetplane: A Control Plane for a Claude Code Fleet
@@ -26,6 +27,12 @@ This design defines **Fleetplane**: a system that (1) centralizes and standardiz
 :::
 
 <!-- truncate -->
+
+import Mockups from './_mockups/fleetplane.mdx';
+
+<Mockups />
+
+---
 
 ## Executive Summary
 

--- a/bytesofpurpose-blog/designs/_mockups/fleetplane.mdx
+++ b/bytesofpurpose-blog/designs/_mockups/fleetplane.mdx
@@ -1,0 +1,176 @@
+---
+# Mockup sidecar for design-fleetplane.
+# Hand-authored UX mockups + one animated walkthrough for the four Phase 4 surfaces
+# (transcript viewer, plugin hub, dashboard, deck studio). The post links this file via its
+# frontmatter `mockups:` field and renders <Mockups /> after the truncate marker.
+---
+
+import {Mockup, Walkthrough} from '@omars-lab/blog-ui';
+
+export default function Mockups() {
+  const ff = 'var(--ifm-font-family-base)';
+  const mono = 'var(--ifm-font-family-monospace)';
+  const hair = '1px solid var(--ifm-color-emphasis-200)';
+
+  // A typed redaction badge: shows the secret was scrubbed, never the value.
+  const badge = (label, id) => (
+    <span id={id} style={{display: 'inline-block', padding: '0.02rem 0.4rem', borderRadius: '5px', background: 'rgba(74,155,142,0.15)', color: '#2f7d6f', border: '1px solid rgba(74,155,142,0.4)', fontFamily: mono, fontSize: '0.68rem', fontWeight: 700}}>{label}</span>
+  );
+
+  // A KPI tile for the dashboard mock.
+  const tile = (label, value, sub) => (
+    <div style={{flex: '1 1 120px', border: hair, borderRadius: '9px', padding: '0.55rem 0.65rem', background: 'var(--ifm-background-surface-color)'}}>
+      <div style={{fontSize: '0.62rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ifm-color-emphasis-600)'}}>{label}</div>
+      <div style={{fontWeight: 800, fontSize: '1.05rem', color: 'var(--ifm-color-primary)'}}>{value}</div>
+      <div style={{fontSize: '0.66rem', color: 'var(--ifm-color-emphasis-600)'}}>{sub}</div>
+    </div>
+  );
+
+  // Adoption bar for the plugin hub.
+  const adopt = (name, pct) => (
+    <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.25rem 0', fontSize: '0.74rem'}}>
+      <div style={{flex: '0 0 118px', fontFamily: mono}}>{name}</div>
+      <div style={{flex: '1 1 auto', height: '8px', borderRadius: '999px', background: 'var(--ifm-color-emphasis-200)', overflow: 'hidden'}}>
+        <div style={{width: pct, height: '100%', background: 'var(--ifm-color-primary)'}} />
+      </div>
+      <div style={{flex: '0 0 34px', textAlign: 'right', fontWeight: 700}}>{pct}</div>
+    </div>
+  );
+
+  // ---- The transcript-viewer scene, driven by the Walkthrough ----
+  const viewerScene = (
+    <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/transcripts/s_9c2e" caption="Open a session: redactions are badges, the agent's log_issue call is inline, and raw access is a logged download.">
+      <div style={{fontFamily: ff, minHeight: '290px'}}>
+        <div style={{display: 'flex', alignItems: 'center', gap: '0.6rem', padding: '0.55rem 0.85rem', borderBottom: hair, fontSize: '0.72rem'}}>
+          <strong style={{fontSize: '0.8rem'}}>session s_9c2e</strong>
+          <span style={{fontFamily: mono, color: 'var(--ifm-color-emphasis-700)'}}>eng_0f3a · repo#a1b2 · opus</span>
+          <button id="wt-raw" style={{marginLeft: 'auto', padding: '0.25rem 0.6rem', border: hair, borderRadius: '7px', background: 'var(--ifm-background-surface-color)', fontSize: '0.68rem', fontWeight: 700, cursor: 'pointer'}}>raw JSONL</button>
+        </div>
+        <div style={{padding: '0.7rem 0.9rem', display: 'flex', flexDirection: 'column', gap: '0.55rem', fontSize: '0.76rem'}}>
+          <div style={{padding: '0.4rem 0.55rem', borderRadius: '8px', background: 'var(--ifm-color-emphasis-100)'}}>
+            <span style={{fontWeight: 700}}>user</span> · deploy the release and rotate the token
+          </div>
+          <div style={{padding: '0.4rem 0.55rem', borderRadius: '8px', border: hair}}>
+            <span style={{fontFamily: mono, fontWeight: 700, color: 'var(--ifm-color-primary)'}}>Bash</span> · git push · redacted secret {badge('[REDACTED:aws_key]', 'wt-redaction')}
+          </div>
+          <div id="wt-issue" style={{padding: '0.4rem 0.55rem', borderRadius: '8px', border: '1px solid rgba(224,160,0,0.5)', background: 'rgba(224,160,0,0.06)'}}>
+            <span style={{fontFamily: mono, fontWeight: 700, color: '#b07a00'}}>log_issue</span> · Sev-2 · exposed key in deploy script
+            <span style={{marginLeft: '0.4rem', padding: '0.02rem 0.4rem', borderRadius: '999px', background: '#e0a000', color: '#fff', fontSize: '0.6rem', fontWeight: 800}}>agent-found</span>
+          </div>
+        </div>
+      </div>
+    </Mockup>
+  );
+
+  return (
+    <>
+      <h2>What it looks like</h2>
+
+      <p>The four Phase 4 surfaces sit behind one login and one API. The transcript viewer is
+      the one worth watching in motion: it is where the sanitize-at-edge invariant becomes
+      something a reviewer can see. A session is sanitized on-device, uploaded clean, then
+      opened here, where every redaction is a typed badge and every raw download is audited.</p>
+
+      <Walkthrough
+        steps={[
+          {type: 'scene', to: 'claude', say: 'cc-sync sanitizes the session on-device and uploads only clean JSONL',
+            prompt: 'cc-sync --once',
+            tools: [
+              {verb: 'Read', target: '~/.claude/projects', note: 'tailing new bytes'},
+              {verb: 'Scrub', target: 'secrets', note: '3 redacted: aws_key, jwt, path'},
+              {verb: 'Upload', target: 'presigned PUT', note: 'clean/eng_0f3a/*'},
+              {target: 'uploaded', done: true},
+            ]},
+          {type: 'scene', to: 'app', say: 'You open the session in the transcript viewer', hold: 400},
+          {type: 'highlight', target: '#wt-redaction', say: 'secrets show as typed badges, never the value'},
+          {type: 'highlight', target: '#wt-issue', say: "the agent's log_issue call is shown inline"},
+          {type: 'click', target: '#wt-raw', say: 'toggling raw JSONL is a logged, presigned download'},
+          {type: 'scene', to: 'claude', say: 'every raw access writes an audit row',
+            prompt: 'continue',
+            intro: 'Presigned GET issued (5 min). Access recorded.',
+            tools: [
+              {verb: 'Audit', target: 'transcript_access', note: 'who viewed whose session'},
+              {target: 'logged', done: true},
+            ]},
+        ]}
+      >
+        {viewerScene}
+      </Walkthrough>
+
+      <h2>Plugin hub</h2>
+
+      <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/plugins" caption="The marketplace landing: version, real adoption from skill_uses, and a one-copy install command.">
+        <div style={{fontFamily: ff, padding: '0.9rem 1rem', minHeight: '240px'}}>
+          <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem'}}>
+            <div style={{fontWeight: 800, fontSize: '0.95rem'}}>org-core</div>
+            <span style={{fontFamily: mono, fontSize: '0.68rem', padding: '0.05rem 0.4rem', borderRadius: '999px', background: 'var(--ifm-color-emphasis-200)'}}>v1.4.0</span>
+            <span style={{marginLeft: 'auto', fontSize: '0.72rem', color: 'var(--ifm-color-emphasis-700)'}}>skills, agents, hooks, MCP</span>
+          </div>
+          <div style={{fontFamily: mono, fontSize: '0.72rem', padding: '0.5rem 0.6rem', borderRadius: '8px', background: 'var(--ifm-color-emphasis-100)', marginBottom: '0.7rem', display: 'flex', alignItems: 'center'}}>
+            claude /plugin install org-core@org-fleet
+            <span style={{marginLeft: 'auto', padding: '0.1rem 0.5rem', borderRadius: '6px', background: 'var(--ifm-color-primary)', color: '#fff', fontSize: '0.66rem', fontWeight: 700}}>copy</span>
+          </div>
+          <div style={{fontSize: '0.66rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.3rem'}}>Adoption across the fleet</div>
+          {adopt('code-review', '92%')}
+          {adopt('release-notes', '74%')}
+          {adopt('fleet-setup', '68%')}
+          {adopt('security-scan', '41%')}
+        </div>
+      </Mockup>
+
+      <h2>Dashboard</h2>
+
+      <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/dashboard" caption="Every panel reads a mart, not a fact table, and renders in under a second. Team-level by default.">
+        <div style={{fontFamily: ff, padding: '0.9rem 1rem', minHeight: '260px'}}>
+          <div style={{display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.7rem'}}>
+            {tile('Sessions', '3,412', 'last 30d')}
+            {tile('Tokens', '1.8B', 'across models')}
+            {tile('Spend', '$4,120', 'estimated')}
+            {tile('Bugs logged', '128', '31 confirmed')}
+            {tile('Active engineers', '87', 'of 94 enrolled')}
+            {tile('Cost / bug', '$133', 'per confirmed')}
+          </div>
+          <div style={{display: 'flex', gap: '0.7rem'}}>
+            <div style={{flex: '1 1 auto', border: hair, borderRadius: '9px', padding: '0.6rem 0.7rem'}}>
+              <div style={{fontSize: '0.66rem', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.35rem'}}>Tokens per day</div>
+              <div style={{display: 'flex', alignItems: 'flex-end', gap: '3px', height: '48px'}}>
+                {[40, 55, 48, 70, 62, 85, 78, 92, 74, 88].map((h, i) => (
+                  <div key={i} style={{flex: 1, height: h + '%', background: 'var(--ifm-color-primary)', opacity: 0.35 + i * 0.06, borderRadius: '2px 2px 0 0'}} />
+                ))}
+              </div>
+            </div>
+            <div style={{flex: '0 0 190px', border: hair, borderRadius: '9px', padding: '0.6rem 0.7rem'}}>
+              <div style={{fontSize: '0.66rem', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.35rem'}}>Fleet health</div>
+              <div style={{fontSize: '0.72rem', display: 'flex', flexDirection: 'column', gap: '0.3rem'}}>
+                <div>sanitizer <strong>v7</strong> · 98% on latest</div>
+                <div>upload lag p95 · <strong>6 min</strong></div>
+                <div style={{color: '#c0473a'}}>leak detector · <strong>0 sessions missing</strong></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Mockup>
+
+      <h2>Deck studio</h2>
+
+      <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/deck" caption="A date range drives a live slide from mart_deck_kpis. Notes are drafted by the Claude API and frozen. Nothing exports without approval.">
+        <div style={{fontFamily: ff, padding: '0.9rem 1rem', minHeight: '250px'}}>
+          <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.6rem', fontSize: '0.74rem'}}>
+            <span style={{padding: '0.25rem 0.55rem', border: hair, borderRadius: '7px', fontFamily: mono}}>2026-01-01 to 2026-06-30</span>
+            <button style={{marginLeft: 'auto', padding: '0.3rem 0.7rem', border: 'none', borderRadius: '7px', background: 'var(--ifm-color-primary)', color: '#fff', fontWeight: 700, fontSize: '0.7rem', cursor: 'pointer'}}>Approve and export PPTX</button>
+          </div>
+          <div style={{aspectRatio: '16 / 9', border: hair, borderRadius: '10px', padding: '1rem 1.2rem', background: 'var(--ifm-background-surface-color)', display: 'flex', flexDirection: 'column', justifyContent: 'center'}}>
+            <div style={{fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--ifm-color-emphasis-600)'}}>Fleetplane · H1 2026</div>
+            <div style={{fontWeight: 800, fontSize: '1.15rem', margin: '0.2rem 0 0.6rem'}}>412 sites analyzed · 128 bugs found</div>
+            <div style={{display: 'flex', gap: '1.4rem', fontSize: '0.8rem'}}>
+              <div><div style={{fontWeight: 800, fontSize: '1.1rem', color: 'var(--ifm-color-primary)'}}>1.8B</div>tokens</div>
+              <div><div style={{fontWeight: 800, fontSize: '1.1rem', color: 'var(--ifm-color-primary)'}}>$4.1K</div>spend</div>
+              <div><div style={{fontWeight: 800, fontSize: '1.1rem', color: 'var(--ifm-color-primary)'}}>31</div>confirmed</div>
+              <div><div style={{fontWeight: 800, fontSize: '1.1rem', color: 'var(--ifm-color-primary)'}}>87</div>engineers</div>
+            </div>
+          </div>
+        </div>
+      </Mockup>
+    </>
+  );
+}


### PR DESCRIPTION
## What this does

Adds a new agentic **Fleetplane** design post to `/designs`, its UX mockups + walkthrough, and two new skills that came out of authoring and verifying it.

### Content
- **`designs/2026-07-04-fleetplane.mdx`** — a `backend-design` post for **Fleetplane**, a control plane that standardizes Claude Code across an engineering fleet, sanitizes session transcripts on-device, and turns them into metrics, dashboards, an issue pipeline, and a deck. Mirrors the other agentic designs (scope admonition, exec summary, the six invariants, an animated config/data-plane architecture diagram, the two-repo layout, the phased build plan, a star-schema ER diagram, a sanitize-to-serve sequence diagram, AWS reference, signal-driven scaling stages, Key Decisions, build-order checklist). `draft: true`.
- **`designs/_mockups/fleetplane.mdx`** — a marquee `<Walkthrough>` of the transcript-viewer flow (sanitize on-device, open the session with redactions as typed badges and the agent's `log_issue` inline, then a logged presigned raw download) plus four static `<Mockup>`s for the Phase 4 surfaces (transcript viewer, plugin hub with real `skill_uses` adoption, dashboard reading marts, deck studio). Wired via `mockups:` frontmatter + `<Mockups />` after the truncate marker.

### Skills
- **`.claude/skills/author-post/`** — a router skill that dispatches a "write a new post" request to a per-home guide (`homes/design.md`, `craft.md`, `journey.md`, `initiatives.md`, `thoughts.md`), each giving the frontmatter template, `kind:` options, slug rule, outline/convention contract, validators, and deep-skill hand-offs. Thin dispatcher; cross-links `organize-post`/`author-blog-post`/`import-co-design`/etc. rather than duplicating them.
- **`.claude/skills/verify-change/`** — how to verify a change by change-type × environment: the method catalog (grep → validators → MDX-compile → generate-assets/typecheck → dev-server render → prod build/e2e → deploy verify), which are runnable in a constrained cloud container vs a local Mac, and the env gotchas proven this session.
- **`.claude/skills/author-walkthrough/SKILL.md`** — corrected to make the `_mockups` sidecar the default for hand-authored (non-import) design posts, with Fleetplane as the worked example.

## Verification
- **Em-dash gate:** 0 occurrences in the post and sidecar.
- **Outline validator:** passes (`backend-design` needs an architecture view + a Decisions heading + description — all present).
- **SEO validator:** passes; description tightened to ~160 chars.
- **MDX compile:** `docusaurus-mdx-checker` compiled all 260 MDX files, including the post and sidecar.
- **Rendered on the dev server (`:3000`) via Playwright:** the Fleetplane page renders with 3 mermaid diagrams drawn to SVG, all 4 mockups framed, the walkthrough mounted, and zero error overlay. (Console errors were only the sandbox proxy blocking external fonts/analytics, which are benign.)

The post stays `draft: true` and is excluded from production until deliberately published (`publish-site`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hr7VLmBEBosTDpKjy1d7t

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hr7VLmBEBosTDpKjy1d7t)_