### PR TITLE
chore(issues): track Prompt-hub Half B as backlog issue #176

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -26,3 +26,4 @@ dedup an issue outside the normal flow, update its status here in the same step.
 All screenshots: `~/Library/CloudStorage/Dropbox/bytesofpurpose-audits/2026-06-03/`
 | 79 | open | _(set key)_ | [#79](https://github.com/omars-lab/omars-lab.github.io/issues/79) | _(set source)_ | _(set path)_ |
 | 111 | open | _(set key)_ | [#111](https://github.com/omars-lab/omars-lab.github.io/issues/111) | _(set source)_ | _(set path)_ |
+| 176 | open | prompt-hub-half-b-skills-and-submodule | [#176](https://github.com/omars-lab/omars-lab.github.io/issues/176) surface .claude/skills + the prompts submodule as prompt posts (Half B) | prompt-hub backlog 2026-07-03 | (no screenshot — backlog item) |


### PR DESCRIPTION
## What

Records the deferred **Prompt-hub Half B** work as a durable backlog item, per the "track deferred findings as GitHub issues (deduped via ISSUES.md)" convention.

- Filed **#176** with the full scoping (54 `.claude/skills` + ~35 prompts in the public `prompts` submodule → prompt posts filed by area) and the three open decisions to resolve before building (generate-vs-author, one-Prompts-hub-vs-a-Skills-hub, and the infra/secret-skill **exposure** call).
- This PR fills in the `key` / `source` columns the `gh-issue-index-hook.sh` left as placeholders when it auto-appended the #176 row.

## Why

Task #32 was parked at the user's request ("hold on creating more prompt posts for now"). A task-list entry is ephemeral; the backlog belongs in GitHub so it survives. Task #32 is deleted now that #176 is the source of truth.

Only `ISSUES.md` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSDxrdyuQojgHxWCjvCeLn