### PR TITLE
feat(software): migrate References[Tools] → diagramming + tools reading lists

### DIFF
--- a/bytesofpurpose-blog/docs/craft/software-development/diagramming-tools.mdx
+++ b/bytesofpurpose-blog/docs/craft/software-development/diagramming-tools.mdx
@@ -1,0 +1,30 @@
+---
+slug: /software-development/diagramming-tools
+title: '🔖 Diagramming and Docs-as-Code Tools'
+sidebar_label: '🔖 Diagramming tools'
+kind: reading-list
+description: "Tools for diagramming and docs-as-code: PlantUML, Kroki, D2, Penpot, mind maps, and the utilities I reach for."
+authors: [oeid]
+tags: [software-development, diagramming, plantuml, docs-as-code, reading-list]
+draft: true
+---
+
+The tools I reach for when turning ideas into diagrams and keeping diagrams as code: PlantUML and its
+ecosystem, text-to-diagram services, and open-source design tools. A living list.
+
+## Diagramming and PlantUML
+
+- [np.Templating: Date Module](https://nptemplating-docs.netlify.app/docs/templating-modules/date-module/)
+- [Penpot: open-source design platform](https://penpot.app/)
+- [Penpot vs Figma](https://penpot.app/penpot-vs-figma)
+- [Google Dataset Search](https://datasetsearch.research.google.com/search?src=0&query=shopping%20terms&docid=L2cvMTF2eW43NnJ4cg%3D%3D)
+- [evolus/pencil: open-source diagram + GUI prototyping](https://github.com/evolus/pencil)
+- [Pencil Project features](http://pencil.evolus.vn/Features.html)
+- [Smithy: AWS Interface Definition Language](https://awslabs.github.io/smithy/)
+- [MediaWiki: ParserFunctions extension](https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions)
+- [XWiki: Code Macro extension](http://extensions.xwiki.org/xwiki/bin/view/Extension/Code+Macro)
+- [Kroki: text-to-diagram service](https://kroki.io/)
+- [Docs-as-Code: mind maps](https://docs-as-co.de/news/mind-maps/)
+- [mrhaki blog: PlantUML posts](https://blog.mrhaki.com/search/label/PlantUML)
+- [D2: declarative diagramming language](https://d2lang.com/)
+- [Terrastruct diagram icons](https://icons.terrastruct.com)

--- a/bytesofpurpose-blog/docs/craft/software-development/tips.mdx
+++ b/bytesofpurpose-blog/docs/craft/software-development/tips.mdx
@@ -64,3 +64,12 @@ in a repo), so the guidance is complete rather than ad hoc:
 ## On team retros
 
 - Run a retro every two weeks, and add a little gamification. One framing that works: a boat sailing the ocean, asking what the headwinds and tailwinds are.
+
+## On mocking in tests
+
+- Know the difference: when you *mock* something you replace it entirely and must supply all its attributes; when you *spy* you only partially replace it, keeping the real behavior for the rest.
+
+## On diagramming
+
+- Use Figma, but lay the diagram out yourself rather than leaning on an auto mind-map. The manual layout is where the thinking happens.
+- Keep diagrams as code (PlantUML, D2, Kroki) so they version and review like everything else.

--- a/bytesofpurpose-blog/docs/craft/software-development/tools-reading-list.mdx
+++ b/bytesofpurpose-blog/docs/craft/software-development/tools-reading-list.mdx
@@ -15,8 +15,27 @@ Developer tools and services I keep bookmarked, with a line on what each is good
 
 - [Unsplash: free images](https://unsplash.com/)
 - [Construct Hub](https://constructs.dev/packages/simple-agentcore-runtime-patterns/v/0.0.1?lang=typescript)
-- [Browser Use](https://dotenvx.com/)
+- [dotenvx: encrypt your .env files](https://dotenvx.com/)
 - [Trim by OneMain | Save Money Automagically](https://www.asktrim.com)
-- [Since 2016 - Apple](https://noteplan.co/teams)
+- [NotePlan for Teams](https://noteplan.co/teams)
 - [Cline - AI Coding, Open Source and Uncompromised](https://cline.bot/)
 - [AI for Work | 2000+ Advanced ChatGPT Prompts for Professionals 🤖](https://www.aiforwork.co/)
+
+## More developer tools
+
+- [sharkdp/bat: a cat(1) clone with wings](https://github.com/sharkdp/bat)
+- [Rectangle: window management for macOS](https://rectangleapp.com/)
+- [VSCodium: open-source binaries of VSCode](https://vscodium.com/#why)
+- [DiffSense: semantic diff for code](https://diffsense.com/)
+- [ts-mockito (npm)](https://www.npmjs.com/package/ts-mockito)
+- [Watchman: file-watching service (install)](https://facebook.github.io/watchman/docs/install.html)
+- [wix/wml issue: wlm start does not load watchman](https://github.com/wix/wml/issues/38)
+- [Paste: clipboard manager (pricing)](https://pasteapp.io/pricing)
+- [NotePlan changelog](https://noteplan.co/changelog)
+- [FlareSolverr: proxy to bypass Cloudflare](https://github.com/FlareSolverr/FlareSolverr)
+- [DuckDB: in-process analytical database](https://duckdb.org/)
+- [microsoft/go-sqlcmd](https://github.com/microsoft/go-sqlcmd)
+
+## Blockchain and NFT
+
+- [NFT Calendar: NFT drops today](https://nftcalendar.io/)


### PR DESCRIPTION
## What

Migrate the NotePlan `References[Tools]` note (28 links, non-destructively) into a new diagramming-tools doc plus the existing tools and tips docs.

## Docs

| Doc | Change |
|---|---|
| `diagramming-tools.mdx` | **NEW** (`kind: reading-list`, 14 links): PlantUML, Kroki, D2, Penpot, Pencil, mind maps, wiki tools, dataset search |
| `tools-reading-list.mdx` | +13 general dev tools (bat, Rectangle, VSCodium, DiffSense, ts-mockito, Watchman, Paste, DuckDB, go-sqlcmd, FlareSolverr) + a Blockchain/NFT section; fixed two weak labels |
| `tips.mdx` | +2 sections (mocking vs spying, diagramming as code) |

## Excluded from the blog (kept in NotePlan)

An ephemeral Azure free-cluster URL (`dataexplorer.azure.com/freecluster`) — not a durable resource.

## Migration ledger (non-destructive)

**29 rows** on the NotePlan note, each deep-linked to its true destination + section (27 links + 2 non-link tip content rows).

```
--verify → ✓ body byte-identical (exit 0)
--audit  → ✓ no drops across all 33 files (exit 0)
tests    → 17 assertions passed
docs     → outline clean, no em-dash, 0 link errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)