### PR TITLE
feat(blog-ui): FlowDiagram — prop-driven flow figure with a build-time legibility gate

### DIFF
--- a/.claude/plans/snug-yawning-fox.md
+++ b/.claude/plans/snug-yawning-fox.md
@@ -1,0 +1,322 @@
+# Improving our blog, influenced by earlbear-blog + the frontend-design lens
+
+## Context
+
+The `earlbear-blog` (`/Users/omareid/Workspace/git-earlbear/earlbear-blog`, an Astro
+site) has independently evolved a set of ideas worth incorporating into our
+Docusaurus blog. Four parallel research passes over its commits, components, skills,
+and hooks — cross-checked against an inventory of what we already have — surface a
+**targeted** set of gaps (not a wholesale import; our governance culture, design
+system, and content-type component set are already richer in most dimensions).
+
+The three things earlbear does that we genuinely lack:
+
+1. **A prop-driven, build-time diagram kit with legibility gates.** We render diagrams
+   by hand-authoring raw mermaid (23 posts/docs do this; only 1 uses our animated
+   wrapper). Earlbear authors diagrams as *data* (`nodes`/`edges` arrays) through
+   zero-dependency components that generate inline SVG at build and **fail the build**
+   on a tangled layout or a dangling id. We have no `FlowDiagram`, `UseCaseDiagram`,
+   `ComparisonMatrix`, or `Accordion`.
+2. **"A picture is worth a thousand words" as governance.** An advisory hook nudges
+   when a section is a wall of text with no visual; a frontmatter contract declares the
+   visuals a post owes and checks the body delivers.
+3. **Editorial + rationale discipline** we don't have: a required **`questions` this
+   post answers** field (dovetails with our "frame each task around the MAIN QUESTION"
+   convention), a **used-but-not-imported MDX check** (catches the exact bug our
+   draft-exclusion build hides), and **feature "why"-docs with content-hash drift
+   auto-heal** (the crown-jewel governance idea).
+
+**Decisions locked with the user:** full diagram kit including `UseCaseDiagram`; adopt
+all four governance/editorial ideas; deliver as a **phased plan of independent PRs**
+(per our commit → PR → ask-to-merge → squash convention). Each phase below is its own
+branch/PR and can merge independently.
+
+**The frontend-design lens (applied throughout):** the diagram kit is not a generic
+Mermaid reskin — it is our *signature*. Every component derives its palette, type, and
+motion from `src/css/custom.css` tokens (no raw hex, per `implement-with-design-system`),
+so a flow/loop/use-case reads unmistakably as *our* blog. Boldness spent in one place:
+the **build-time legibility gate** (a diagram that can't be read cleanly does not ship)
+is the distinctive move; everything around it stays quiet and token-disciplined.
+
+---
+
+## Guiding constraints (repo conventions this plan honors)
+
+- **Components live in `@omars-lab/blog-ui`** (`packages/blog-ui/`), the reusable-component
+  package (tsup ESM+dts+bundled CSS, `file:`-linked, registered in
+  `src/theme/MDXComponents.tsx`). Follow the `modify-blog-ui-component` skill: edit
+  source under `packages/blog-ui/src/components/`, `make build-blog-ui` to rebuild+RELINK
+  (mind the Yarn-1 stale-dist cache gotcha), register in `MDXComponents.tsx`.
+- **Design system is the source of truth.** All color/type/motion via `custom.css`
+  tokens; no raw hex; pastels are accent fills only; all motion respects
+  `prefers-reduced-motion`. Enforced by `validate-ds-tokens` + `check-contrast`.
+- **No em-dash in reader-facing content** (blocking hook). Applies to any legend/label
+  text the components render. Our voice **keeps emoji** (opposite of earlbear's
+  no-emoji rule) — do not port their emoji ban.
+- **Governance pattern we already use** (and these additions follow): a `scripts/validate-*.js`
+  with a `--file`-scoped mode + a full-sweep mode, wired as a warn-tier PostToolUse
+  `Write|Edit` hook, with a blocking `make` gate. New hooks register in `.claude/settings.json`.
+- **Generated assets** are gitignored + rebuilt by `generate-assets` and blocked from
+  hand-editing; any new generated data (e.g. a diagram catalog JSON) follows that model.
+- **Every new interactive component gets a visual + mobile pass** (375px + desktop)
+  before its commit lands (operating convention).
+
+---
+
+## Phase 1 — `FlowDiagram` (the proof + the workhorse) · PR #1
+
+**Goal.** A prop-driven directed-flow component in `blog-ui` that renders inline SVG at
+build time in five shapes — `pipeline` (A→B→C), `loop` (nodes on an ellipse, last→first
+closes), `sequence` (vertical), `branch` (fan-out for forks/decisions), `swimlane`
+(labeled owner bands) — with **shape auto-inference** (back-edge → loop; out-degree ≥2 →
+branch) and a **build-time overlap gate** that throws (not warns) on a tangled layout or
+a dangling edge id, with an `allowOverlap` escape hatch.
+
+**Why it's the right first port.** Highest leverage (covers the majority of our 23
+hand-mermaid diagrams), and the layout math + gate functions are **pure TypeScript** that
+port from earlbear's `FlowDiagram.astro` unchanged. It proves the whole pattern on our
+React/Docusaurus stack before the expensive `UseCaseDiagram`.
+
+**Approach.**
+- New component `packages/blog-ui/src/components/FlowDiagram/` (`.tsx` + a CSS module or
+  bundled CSS). Port the pure-TS layout functions (branch longest-path levelling,
+  swimlane forward-edge ranking + compression, `rimPoint` edge geometry, the
+  segment-crossing overlap test) into a `layout.ts` helper — these are copy-with-attribution
+  from the Astro source.
+- **Astro→React translations** (all mechanical, documented in research):
+  `set:html` → render SVG as JSX; the inline-script detail modal → React `useState` +
+  a `<dialog>`/portal (simpler in React); `style={`--i:${i}`}` → `style={{'--i': i}}`;
+  the id `salt` (title slug) still namespaces gradient/marker ids so multiple diagrams
+  per page don't collide.
+- **Theming from our tokens:** define an 8-color data palette + surface/ink tokens in
+  `custom.css` (analogous to earlbear's `--eb-data-1..8`), draw-in edge animation via
+  `stroke-dasharray/dashoffset` gated behind `prefers-reduced-motion`. Node kinds
+  (`default`/`store`/`external`/`edge`) tint/mark boxes; optional `legend` prop renders a
+  key for the kinds actually used.
+- **The gate decision (conscious choice):** a thrown error fails `docusaurus build`
+  during SSG (same as Astro). Keep it a hard throw for `make build`, but message it
+  actionably (name the crossing edges / the dangling id) so an author can fix or set
+  `allowOverlap`.
+- Register in `MDXComponents.tsx`; add an `upgrade-post` catalog entry (WHAT/WHEN/HOW/gotchas).
+
+**Prove it (the `new-diagram-kind` discipline).** Convert **one real** hand-mermaid post
+to `<FlowDiagram>` as the proof it makes an actual post clearer; screenshot desktop +
+375px; confirm the gate fires on a deliberately-bad spec. Do not ship a bench page.
+
+**Files:** `packages/blog-ui/src/components/FlowDiagram/*` (new),
+`packages/blog-ui/src/index.ts` (export), `src/theme/MDXComponents.tsx` (register),
+`src/css/custom.css` (data palette + draw-in keyframes),
+`.claude/skills/upgrade-post/SKILL.md` (catalog entry), one converted post.
+
+---
+
+## Phase 2 — `ComparisonMatrix` + `Accordion` (the decision-post kit) · PR #2
+
+**Goal.** Two near-trivial ports that together serve decision/option posts.
+- **`ComparisonMatrix`** — a semantic `<table>` (proper `<th scope>`), options as columns
+  / criteria as rows, the `chosen` column highlighted + badged, ratings `yes|no|partial`
+  → glyph marks (● ○ ◐) with sr-only labels, scrolls in its own `overflow-x:auto` wrapper
+  on mobile. Build-time gate: every cell key must reference a real option id or throw.
+- **`Accordion`** — native `<details>/<summary>` (zero JS, keyboard-accessible free),
+  optional `verdict` pill ("chosen"/"rejected") so folded options stay scannable.
+
+**Note on overlap with what we have.** Our `OptionGrid`/`OptionTile`/`DecisionNote`
+(design-system specimens, used in 2 handbook files) show *explored design directions* with
+a chosen ring + WHY. `ComparisonMatrix` is the complementary **criteria×options table** for
+head-to-head decision posts — different job, keep both. The `upgrade-post` catalog entry
+should say when to reach for which.
+
+**Approach.** Near 1:1 JSX ports (research rated both TRIVIAL). Token-styled; `body`
+content passed as React children (drop earlbear's raw-HTML-string `set:html`). Register +
+catalog + prove each on a real decision post (a 375px + desktop pass; a matrix that
+overflows must scroll, not squish).
+
+**Files:** `packages/blog-ui/src/components/{ComparisonMatrix,Accordion}/*` (new),
+package export, `MDXComponents.tsx`, `custom.css` (matrix/mark styles),
+`upgrade-post/SKILL.md`.
+
+---
+
+## Phase 3 — `UseCaseDiagram` (the ambitious one) · PR #3
+
+**Goal.** A spec-honoring UML use-case diagram: actors outside a system-boundary rectangle,
+use cases as ovals inside, solid association lines, dashed `«include»`/`«extend»` arrows,
+with a **two-sided actor layout** (internal/system left, external right so lines fan to the
+nearest edge), **barycenter crossing reduction** (order rows by average input-order of the
+actors touching them), and **two blocking gates**: the ≥75%-crossing-free overlap gate and
+a unique **actor line-angle balance gate** (each actor's up/down line split within one, and
+its average line more horizontal than vertical).
+
+**Why it's phase 3.** Most sophisticated layout in the kit (research: MEDIUM port). Two
+extra Astro-isms beyond Phase 1: the actor-glyph function (rewrite to return **JSX**, not
+`set:html` strings) and the branded-monogram file read (`readFileSync` of an SVG) → inline
+our own actor glyphs as JSX (a person / a gear / our mark) rather than reading from disk.
+Mermaid has no real use-case support, so this is a capability we simply don't have any way
+to author today.
+
+**Approach.** Port `actors.ts` glyph math (gear = ring + computed teeth; person = head +
+shoulders arc, all `currentColor`) as JSX-returning functions. Port the side-pull +
+barycenter placement and both gates from `UseCaseDiagram.astro`. Click-to-focus modal via
+React state (surfaces computed "Used by / Includes / Extends"). Register + catalog + prove
+on a real post (our audience/actors map well to an "who uses X" post). Visual + mobile pass.
+
+**Files:** `packages/blog-ui/src/components/UseCaseDiagram/*` (new, incl. `actors.tsx`,
+`layout.ts`), package export, `MDXComponents.tsx`, `custom.css`, `upgrade-post/SKILL.md`.
+
+**Optional (defer unless wanted):** the ~130-line extended-Mermaid flowchart parser
+(`mermaid-parse.ts`, TRIVIAL port, pure TS) that lets authors write `flowchart LR` syntax
+that renders through `FlowDiagram`. Earlbear ships it but **no post uses it** — low ROI for
+us given our authors already write mermaid; note as a future option, don't build now.
+
+---
+
+## Phase 4 — Visual-density + visual-expectations governance · PR #4
+
+**Goal.** Make "wall of text with no visual" a *deliberate* choice, and let a post declare
+the visuals it owes.
+
+- **`scripts/validate-visual-density.js`** (+ `validate-visual-density-hook.sh`, warn-tier
+  PostToolUse `Write|Edit`; blocking `make validate-visual-density`). Port earlbear's
+  `check-visual-density.py` logic: split on H2; count **prose words only** (toggle out
+  fenced code, skip lines starting `<`/`|`/`import`); flag a section with `> ~280` words
+  and **no visual** (our `VISUAL_RE`: the new `FlowDiagram|UseCaseDiagram|ComparisonMatrix|
+  Accordion` + existing `DiagramWithFootnotes|Mockup|Walkthrough|Gif|SlideDeck|Timeline|
+  Carousel|SvgVariantGrid|Graph`, plus `<img>/<svg>/<table>`, markdown table rows, and a
+  code fence as a legit break). Advisory, names the section, never blocks.
+- **Visual-expectations via our existing `blog-kinds.json` outline contract** (do NOT add a
+  parallel `expects` field — we already have the seam). Extend `validate-post-outline.js`'s
+  per-kind `CHECKS`/`outline` so a kind can require a **visual element** satisfied by the new
+  components (e.g. a decision/comparison kind → `<ComparisonMatrix>` or `<Accordion>`; a
+  flow/architecture element → `<FlowDiagram>` or `<DiagramWithFootnotes>` or a mermaid fence).
+  This reuses machinery that already exists and stays warn-tier, matching earlbear's intent
+  ("a comparison post never ships as a wall of prose") without new frontmatter.
+
+**Files:** `scripts/validate-visual-density.js` (new), `.claude/hooks/validate-visual-density-hook.sh`
+(new), `.claude/settings.json` (wire), `Makefile` (target), `scripts/validate-post-outline.js`
++ `scripts/lib/blog-kinds.json` (extend visual elements for relevant kinds).
+
+---
+
+## Phase 5 — `questions` frontmatter field + rendered box · PR #5
+
+**Goal.** Every substantive post declares the reader-questions it answers (from "the request
+that prompted it"), rendered as a "Questions this post answers" box at the top, validated to
+be non-empty and each item ending in `?`.
+
+**Why it fits us specifically.** This is the frontmatter mirror of our existing operating
+convention "frame each task around the MAIN QUESTION." The task list already reads as
+questions-in-flight; this makes the *published post* carry the same framing for the reader.
+
+**Approach.**
+- Add optional `questions: string[]` to the blog/docs frontmatter (start **optional +
+  advisory**, unlike earlbear's required, to avoid retrofitting the whole corpus at once;
+  a follow-up can tighten to required-for-new-posts once seeded).
+- Render via a small `<PostQuestions>` treatment (a token-styled aside, accessible landmark)
+  — either a blog-ui component surfaced through a swizzle/wrapper, or (simplest) a
+  `DocItem`/`BlogPostItem` swizzle that reads the field. Confirm the exact render seam during
+  implementation (Docusaurus swizzle vs. an MDX component authors drop in; prefer the
+  automatic swizzle so it can't be forgotten).
+- **`scripts/validate-questions.js`** (+ warn hook + `make` gate): if `questions` present,
+  each must be non-empty and end in `?`. Wire the `author-blog-post` / `name-post` skills to
+  suggest the field from the driving task's MAIN QUESTION.
+
+**Files:** frontmatter schema / swizzled item (`src/theme/...`), a `<PostQuestions>` style,
+`scripts/validate-questions.js` (new) + hook + Makefile, `custom.css` (box style),
+`author-blog-post/SKILL.md` (mention the field).
+
+---
+
+## Phase 6 — Used-but-not-imported MDX check · PR #6
+
+**Goal.** Catch the "used `<FlowDiagram>` but forgot to import it" bug **statically** — the
+exact class our production build hides, because drafts are excluded from `docusaurus build`
+so a broken draft passes every existing gate until it renders.
+
+**Approach.** Port earlbear's `check-diagrams.py` reasoning to
+`scripts/validate-mdx-imports.js`: for each `.mdx`, every Capitalized JSX tag used must have
+a matching `import` **or** be a globally-registered `MDXComponents` component (our case is
+subtler than earlbear's — most of our components are auto-injected via `MDXComponents.tsx`
+and need NO import, so the check must load that registry as the allowlist and only flag tags
+that are neither imported nor globally registered). Strip code fences + inline-code spans;
+ignore lowercase tags; whitelist `Fragment`. **Blocking** (`make validate-mdx-imports`, exit
+2) + a PostToolUse hook, since a missing import is a real render break, not taste.
+
+**Files:** `scripts/validate-mdx-imports.js` (new, reads `MDXComponents.tsx` for the global
+allowlist), `.claude/hooks/validate-mdx-imports-hook.sh` (new), `.claude/settings.json`,
+`Makefile`.
+
+---
+
+## Phase 7 — Feature "why"-docs + content-hash drift auto-heal · PR #7 (heaviest)
+
+**Goal.** Document **why** a component/feature exists, linked to the exact code that
+implements it via content-hashed anchors; **auto-heal** when code moves (silently re-key),
+**warn** on real in-place drift, and **never** auto-bless changed content (that requires a
+human reconcile). This is the crown-jewel governance idea and the biggest build.
+
+**Approach (port earlbear's `features_lib.py` model, pure Python + git — 100% portable).**
+- `docs-internal/features/<id>.md` (or a repo-root `features/`): a `## Why` (durable prose)
+  + a `## Code` section of GitHub-permalink anchors (`blob/<sha>/<path>#Lstart-Lend — label`).
+- A cache `features/.anchors.json` keyed `path#Lstart-Lend` → `{block_hash, context_hash,
+  feature, label}`. Hashing **normalizes** (strip trailing ws, collapse blank runs) so
+  formatting edits don't trip; the ±3-line context hash disambiguates identical blocks.
+- Drift classifier: `ok` (hash matches) / `moved` (found elsewhere by sliding-window hash
+  match, unambiguous) / `drift` (same location, content changed) / `missing`. On `moved`,
+  auto-heal: re-key the cache + rewrite the permalink in the doc — silently, no noise.
+- **The invariant:** a hook may only re-key *unchanged* content; changed content needs the
+  reconcile flow (re-read the `## Why`, re-pin). Full sweep exits non-zero on unreviewed
+  drift → gate it in the deploy pre-flight.
+- Retarget for us: `owner/repo` = `omars-lab/omars-lab.github.io`; `SCAN_IGNORE_DIRS` adds
+  `build*`, `.docusaurus`, `node_modules`, `static/storybook`.
+- Ship with a **`feature-docs` skill** (author/reconcile flow) + a `manage-feature-docs`
+  entry in the skills map, and seed 3-5 real why-docs (e.g. the premium-gating architecture,
+  the diagram-legibility gate, the audience-of-one hero) so it starts alive, not empty.
+
+**Files:** `scripts/features_lib.py` + `features_check.py` (new, ported),
+`.claude/hooks/check-feature-docs-hook.sh` (new), `.claude/settings.json`, `Makefile`,
+`features/` dir + `README.md` + seed docs, `.claude/skills/feature-docs/SKILL.md` (new),
+CLAUDE.md skills-map row + a `.gitignore` entry for `.anchors.json` if we treat it as cache.
+
+---
+
+## Sequencing & independence
+
+- **1 → 2 → 3** are the diagram-kit build (each its own PR; 2 and 3 both depend on the
+  Phase-1 token/data-palette groundwork, so land 1 first, then 2 and 3 can go in either order).
+- **4** (visual-density/expectations) is best **after** the components exist, so its
+  `VISUAL_RE` / outline elements can reference them (soft dependency on 1–3; can start once
+  `FlowDiagram` lands).
+- **5** (questions field), **6** (mdx-imports check), **7** (feature-docs) are **fully
+  independent** of the diagram work and of each other — can be picked up in any order,
+  parallel to the component phases.
+- Recommended real-world order: **1, 6, 5** first (fast, high-value, low-risk), then **2, 3,
+  4** (the rest of the kit + its governance), then **7** (the heavy governance build) last.
+
+## Verification (per phase, end-to-end)
+
+- **Components (1-3):** `make build-blog-ui` (rebuild+relink; watch the Yarn-1 stale-dist
+  cache gotcha) → `make start`, open the converted proof post, confirm the diagram renders
+  and the **gate fires** on a deliberately-bad spec (`make build` should fail loudly) →
+  **visual + mobile pass** at 375px + desktop (tap targets, no horizontal overflow, matrix
+  scrolls) → `make validate-ds-tokens` + `make check-contrast` clean → real-browser check
+  per `verify-change`.
+- **Governance (4-7):** run the new `make validate-*` on a **planted violation** and confirm
+  it flags (exit non-zero / warn as designed) and passes clean on good input — the fail-closed
+  "prove it bites" discipline. For feature-docs, move a documented code block and confirm
+  the anchor **auto-heals** with no warning; change a block in place and confirm it **warns**.
+- **Whole-site regression** before each merge: `make build` succeeds (SSG runs the gates),
+  `make validate-links` / `validate-redirects` / `validate-seo` unaffected.
+
+## Explicitly NOT doing (earlbear-specific, low ROI, or conflicts with us)
+
+- Their **no-emoji / no-exclamation** voice rule (opposite of our deliberate emoji-in-kinds
+  system).
+- The **audience-split** dual internal/external build, **design-system vendoring** (`sync-design`),
+  **gh-pages-branch deploy** mechanics, **manage-authors** collection — all earlbear infra
+  workarounds we either don't need or already solve natively.
+- The **concurrent-commit** multi-session git-safety model — valuable in principle, but we
+  have our own commit → PR → squash convention; revisit only if we start running many
+  concurrent sessions on one clone.
+- The **extended-Mermaid parser** (Phase 3 note) — build only if authoring friction warrants.
+- The **"$/% needs a citation footnote"** rule — genuinely good, but a separate editorial
+  decision; note as a future option, out of scope here.

--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -93,6 +93,47 @@ graph LR
 Registered in `MDXComponents` (no import needed in docs, but importing is harmless). MANUAL
 opt-in — a re-import would clobber it, so only on finalized pages.
 
+### FlowDiagram (prop-driven flow, built-in legibility gate)
+
+WHAT: a directed-flow figure rendered as inline SVG from a `nodes`/`edges` spec (data, not a
+mermaid string, not an image). Five shapes, usually INFERRED from the graph so you rarely pass
+`shape`: `pipeline` (A → B → C), `loop` (a cycle: a back-edge to an earlier node), `sequence`
+(a vertical stack), `branch` (a fork / decision fan-out: a node with 2+ out-edges), `swimlane`
+(labeled owner bands via each node's `lane`). WHEN: a flow/loop/handoff/decision you'd have
+hand-drawn in mermaid. It fails the BUILD on a dangling edge id or a tangled (crossing) layout,
+so a flow ships only when it reads cleanly. HOW:
+
+```mdx
+<FlowDiagram
+  title="The habit loop"
+  desc="A cue triggers a routine, which delivers a reward; craving closes the loop."
+  legend
+  nodes={[
+    {id: 'cue', label: 'Cue', detail: 'The trigger that starts the loop.'},
+    {id: 'routine', label: 'Routine', detail: 'The behavior you run on autopilot.'},
+    {id: 'reward', label: 'Reward', detail: 'The payoff that makes it worth repeating.'},
+  ]}
+  edges={[
+    {from: 'cue', to: 'routine'},
+    {from: 'routine', to: 'reward'},
+    {from: 'reward', to: 'cue', label: 'craving'},
+  ]}
+/>
+```
+
+- Registered in `MDXComponents` (no import needed). `title` is required (SVG a11y + id salt);
+  pass `desc` for the accessible description (a missing `desc` warns to the console).
+- Node `kind`: `store` (datastore), `external` (outside the system, dashed), `edge` (trust
+  boundary). `legend` shows a key for the special kinds actually used.
+- A node with `detail` becomes clickable and opens a focus modal listing what feeds it / what
+  it feeds. All motion (edges draw in, boxes fade in) respects `prefers-reduced-motion`.
+- The overlap gate THROWS (fails `make build`) past 25% crossing edges. If a diagram is
+  legitimately dense, pass `allowOverlap` to downgrade it to a warning; better, reorder nodes
+  so the flow reads without backtracking, or split it.
+- WHEN NOT: for a diagram with steps that each need a sentence but no strong flow, or a
+  non-flow (class/ER/context) diagram, reach for `DiagramWithFootnotes` (mermaid + numbered
+  legend) instead. FlowDiagram is for flows; it is deliberately not a general mermaid renderer.
+
 ### Mockup (UX mockups — show what it LOOKS like)
 
 WHAT: a framed, theme-aware wrapper (`browser` / `window` / `phone` / `none` chrome) that

--- a/bytesofpurpose-blog/blog/2017-09-27-the-habit-loop.mdx
+++ b/bytesofpurpose-blog/blog/2017-09-27-the-habit-loop.mdx
@@ -17,12 +17,21 @@ itself: the case studies are worth it.
 
 <!-- truncate -->
 
-```mermaid
-flowchart LR
-    Cue["Cue<br/>(the trigger)"] --> Routine["Routine<br/>(the behavior)"]
-    Routine --> Reward["Reward<br/>(the payoff)"]
-    Reward -. "craving<br/>(anticipation)" .-> Cue
-```
+<FlowDiagram
+  title="The habit loop"
+  desc="A cue triggers a routine, which delivers a reward; a craving for that reward closes the loop back to the cue."
+  legend
+  nodes={[
+    {id: 'cue', label: 'Cue', detail: 'The trigger that starts the loop: a time, a place, an emotion, a preceding action.'},
+    {id: 'routine', label: 'Routine', detail: 'The behavior you run on autopilot once the cue fires.'},
+    {id: 'reward', label: 'Reward', detail: 'The payoff that tells your brain the loop is worth repeating.'},
+  ]}
+  edges={[
+    {from: 'cue', to: 'routine'},
+    {from: 'routine', to: 'reward'},
+    {from: 'reward', to: 'cue', label: 'craving'},
+  ]}
+/>
 
 ## The loop underneath everything
 

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -49,6 +49,7 @@ import {
 // (single source of truth; the blog consumes it). The bundled styles are imported once.
 import {
   DiagramWithFootnotes,
+  FlowDiagram,
   Mockup,
   Walkthrough,
   Assumption,
@@ -117,6 +118,13 @@ export default {
   // System-design posts: a diagram paired with a generated numbered legend (the badges
   // ①②③ are authored into the mermaid labels; this renders the matching explanations).
   DiagramWithFootnotes,
+  // FlowDiagram: a prop-driven directed-flow figure (pipeline/loop/sequence/branch/swimlane)
+  // rendered as inline SVG from a nodes/edges spec. Layout is deterministic and a build-time
+  // gate fails on a dangling edge id or a tangled (unreadable) layout, so a flow ships only
+  // when it reads cleanly. Use <FlowDiagram title=... nodes={[...]} edges={[...]} /> for a
+  // flow/loop/handoff instead of hand-authoring mermaid; DiagramWithFootnotes still wraps a
+  // hand-authored mermaid diagram when you want the numbered-legend treatment.
+  FlowDiagram,
   // UX mockups: a framed, theme-aware wrapper that turns live HTML into a UI mockup
   // (browser/window/phone chrome) — shows what a design would LOOK like.
   Mockup,

--- a/packages/blog-ui/src/components/FlowDiagram/index.tsx
+++ b/packages/blog-ui/src/components/FlowDiagram/index.tsx
@@ -1,0 +1,364 @@
+import React, {CSSProperties, useCallback, useEffect, useRef, useState} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+import {
+  computeFlowLayout,
+  inferShape,
+  BOX,
+  type FlowNode,
+  type FlowEdge,
+  type FlowShape,
+  type FlowNodeKind,
+  type NodeDetail,
+} from './layout';
+
+export type {FlowNode, FlowEdge, FlowShape, FlowNodeKind};
+
+/**
+ * FlowDiagram : a directed-flow diagram rendered as one inline SVG. The author
+ * writes a small `nodes`/`edges` spec (data, not an image), and the component
+ * lays it out deterministically at render time in one of five shapes, failing the
+ * build on a dangling edge id or a tangled (unreadable) layout.
+ *
+ * Shapes (usually inferred from the graph, rarely passed):
+ *   pipeline  a horizontal row A -> B -> C  (linear handoff)
+ *   loop      the row wrapped into a cycle (last node feeds the first)
+ *   sequence  a vertical stack, top -> bottom (ordered steps)
+ *   branch    a top-down fan-out for forks / decisions
+ *   swimlane  labeled horizontal bands, one per owning actor (`lane`)
+ *
+ * Node kinds tint/mark the box: default, store (a datastore), external (outside
+ * the system), edge (a trust-boundary marker). Pass `legend` to show a key for
+ * the special kinds actually used. A node with `detail` becomes clickable and
+ * opens a focus modal listing what feeds it and what it feeds.
+ *
+ * Usage in MDX:
+ *
+ *   <FlowDiagram title="Publish pipeline" legend
+ *     desc="Draft flows through review to a live deploy."
+ *     nodes={[
+ *       {id: 'draft', label: 'Draft'},
+ *       {id: 'review', label: 'Review', detail: 'A reader-experience pass.'},
+ *       {id: 'deploy', label: 'Deploy', kind: 'external'},
+ *     ]}
+ *     edges={[
+ *       {from: 'draft', to: 'review'},
+ *       {from: 'review', to: 'deploy', label: 'approved'},
+ *     ]}
+ *   />
+ */
+export interface FlowDiagramProps {
+  title: string;
+  desc?: string;
+  /** Force a shape; omit to let the graph pick (back-edge -> loop, fork -> branch). */
+  shape?: FlowShape;
+  nodes?: FlowNode[];
+  edges?: FlowEdge[];
+  /** Downgrade the build-time overlap gate to a console warning for this diagram. */
+  allowOverlap?: boolean;
+  /** Show a key for the special node kinds actually used (edge, store, external). */
+  legend?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const KIND_MEANING: Record<'edge' | 'store' | 'external', string> = {
+  store: 'datastore',
+  external: 'outside the system',
+  edge: 'trust boundary',
+};
+
+const FlowDiagram: React.FC<FlowDiagramProps> = ({
+  title,
+  desc,
+  shape: shapeProp,
+  nodes = [],
+  edges = [],
+  allowOverlap = false,
+  legend = false,
+  className,
+  style,
+}) => {
+  const shape: FlowShape = shapeProp ?? inferShape(nodes, edges, 'pipeline');
+  // computeFlowLayout throws on a broken/tangled spec : that fails the SSG build,
+  // which is the intended blocking gate (an unreadable diagram does not ship).
+  const layout = computeFlowLayout({
+    title,
+    desc,
+    shape,
+    nodes,
+    edges,
+    allowOverlap,
+    legend,
+  });
+
+  useEffect(() => {
+    for (const w of layout.warnings) console.warn(`[flow-diagram] warning: ${w}`);
+  }, [layout.warnings]);
+
+  const {svgW, svgH, salt, lanes, placed, edges: rEdges, details, interactive, legendKinds} =
+    layout;
+  const titleId = `${salt}-title`;
+  const descId = `${salt}-desc`;
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [active, setActive] = useState<NodeDetail | null>(null);
+  const openNode = useCallback(
+    (id: string) => {
+      const d = details.find((x) => x.id === id);
+      if (!d) return;
+      setActive(d);
+    },
+    [details],
+  );
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (active && !dlg.open && dlg.showModal) dlg.showModal();
+    if (!active && dlg.open) dlg.close();
+  }, [active]);
+
+  return (
+    <figure
+      className={clsx(styles.flow, styles[`shape-${shape}`], className)}
+      style={style}
+    >
+      <div className={styles.scroll}>
+        <svg
+          viewBox={`0 0 ${svgW} ${svgH}`}
+          role="img"
+          aria-labelledby={desc ? `${titleId} ${descId}` : titleId}
+          preserveAspectRatio="xMidYMid meet"
+        >
+          <title id={titleId}>{title}</title>
+          {desc && <desc id={descId}>{desc}</desc>}
+
+          <defs>
+            {placed.map((p) => {
+              const c1 = (p.gi % 8) + 1;
+              const c2 = ((p.gi + 2) % 8) + 1;
+              return (
+                <linearGradient
+                  key={p.gi}
+                  id={`${salt}-g${p.gi}`}
+                  x1="0%"
+                  y1="0%"
+                  x2="100%"
+                  y2="100%"
+                >
+                  <stop
+                    offset="0%"
+                    stopColor={`color-mix(in oklab, var(--bopflow-data-${c1}) 22%, var(--bopflow-surface))`}
+                  />
+                  <stop
+                    offset="100%"
+                    stopColor={`color-mix(in oklab, var(--bopflow-data-${c2}) 28%, var(--bopflow-surface))`}
+                  />
+                </linearGradient>
+              );
+            })}
+            <marker
+              id={`${salt}-arrow`}
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path
+                d="M 0 1 L 9 5 L 0 9"
+                fill="none"
+                stroke="context-stroke"
+                strokeWidth="1.5"
+              />
+            </marker>
+          </defs>
+
+          {lanes.length > 0 && (
+            <g className={styles.lanes}>
+              {lanes.map((lane, i) => (
+                <React.Fragment key={i}>
+                  <rect
+                    className={clsx(styles.laneBand, i % 2 === 1 && styles.laneBandAlt)}
+                    x={0}
+                    y={lane.top}
+                    width={svgW}
+                    height={lane.height}
+                  />
+                  <text
+                    className={styles.laneLabel}
+                    x={BOX.PAD / 2}
+                    y={lane.top + lane.height / 2}
+                  >
+                    {lane.name}
+                  </text>
+                </React.Fragment>
+              ))}
+            </g>
+          )}
+
+          <g className={styles.edgesG}>
+            {rEdges.map((ed, i) => {
+              const path = ed.curve
+                ? `M ${ed.x1} ${ed.y1} Q ${ed.mx + (ed.my - ed.y1) * 0.3} ${
+                    ed.my + (ed.x1 - ed.mx) * 0.3
+                  } ${ed.x2} ${ed.y2}`
+                : `M ${ed.x1} ${ed.y1} L ${ed.x2} ${ed.y2}`;
+              return (
+                <g className={styles.edge} key={i}>
+                  <path
+                    d={path}
+                    fill="none"
+                    markerEnd={`url(#${salt}-arrow)`}
+                    style={{'--len': ed.len.toFixed(1), '--i': i} as CSSProperties}
+                  />
+                  {ed.label && (
+                    <g>
+                      <rect
+                        className={styles.edgeChip}
+                        x={ed.mx - (ed.label.length * 6.6) / 2 - 5}
+                        y={ed.my - 5 - 11}
+                        width={ed.label.length * 6.6 + 10}
+                        height={16}
+                        rx={4}
+                      />
+                      <text x={ed.mx} y={ed.my - 5} className={styles.edgeLabel}>
+                        {ed.label}
+                      </text>
+                    </g>
+                  )}
+                </g>
+              );
+            })}
+          </g>
+
+          <g className={styles.nodesG}>
+            {placed.map((p) => {
+              const kind = p.node.kind ?? 'default';
+              const isBtn = interactive && !!p.node.detail;
+              const box = (
+                <>
+                  <rect
+                    x={p.cx - BOX.W / 2}
+                    y={p.cy - BOX.H / 2}
+                    width={BOX.W}
+                    height={BOX.H}
+                    rx={kind === 'store' ? 4 : 12}
+                    fill={`url(#${salt}-g${p.gi})`}
+                    className={clsx(styles.box, styles[`box-${kind}`])}
+                  />
+                  <text x={p.cx} y={p.cy} className={styles.label}>
+                    {p.node.label}
+                  </text>
+                </>
+              );
+              return isBtn ? (
+                <g
+                  key={p.node.id}
+                  className={clsx(styles.node, styles.nodeInteractive)}
+                  role="button"
+                  tabIndex={0}
+                  aria-haspopup="dialog"
+                  style={{'--i': p.gi} as CSSProperties}
+                  onClick={() => openNode(p.node.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      openNode(p.node.id);
+                    }
+                  }}
+                >
+                  {box}
+                </g>
+              ) : (
+                <g
+                  key={p.node.id}
+                  className={styles.node}
+                  style={{'--i': p.gi} as CSSProperties}
+                >
+                  {box}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+
+      {desc && <figcaption className={styles.caption}>{desc}</figcaption>}
+
+      {legendKinds.length > 0 && (
+        <ul className={styles.legend} aria-label="Node kinds key">
+          {legendKinds.map((k) => (
+            <li className={styles.legendItem} key={k}>
+              <svg className={styles.legendSwatch} viewBox="0 0 28 18" aria-hidden="true">
+                <rect
+                  x="1"
+                  y="1"
+                  width="26"
+                  height="16"
+                  rx={k === 'store' ? 2 : 5}
+                  className={clsx(styles.box, styles[`box-${k}`])}
+                  fill="var(--bopflow-surface-sunken)"
+                />
+              </svg>
+              <span className={styles.legendLabel}>{KIND_MEANING[k]}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {interactive && (
+        <dialog
+          ref={dialogRef}
+          className={styles.modal}
+          aria-labelledby={`${salt}-modal-title`}
+          onClose={() => setActive(null)}
+          onClick={(e) => {
+            if (e.target === dialogRef.current) setActive(null);
+          }}
+        >
+          <div className={styles.modalInner}>
+            <button
+              type="button"
+              className={styles.modalClose}
+              aria-label="Close"
+              onClick={() => setActive(null)}
+            >
+              &times;
+            </button>
+            <p className={styles.modalEyebrow}>{title} step</p>
+            <h3 id={`${salt}-modal-title`} className={styles.modalTitle}>
+              {active?.label}
+            </h3>
+            {active?.detail && <p className={styles.modalDetail}>{active.detail}</p>}
+            <dl className={styles.modalRels}>
+              {active?.from && active.from.length > 0 && (
+                <>
+                  <dt>From</dt>
+                  <dd>
+                    {active.from.map((s, i) => (
+                      <span key={i}>{s}</span>
+                    ))}
+                  </dd>
+                </>
+              )}
+              {active?.to && active.to.length > 0 && (
+                <>
+                  <dt>To</dt>
+                  <dd>
+                    {active.to.map((s, i) => (
+                      <span key={i}>{s}</span>
+                    ))}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </div>
+        </dialog>
+      )}
+    </figure>
+  );
+};
+
+export default FlowDiagram;

--- a/packages/blog-ui/src/components/FlowDiagram/layout.ts
+++ b/packages/blog-ui/src/components/FlowDiagram/layout.ts
@@ -1,0 +1,403 @@
+// FlowDiagram layout engine : pure, deterministic geometry + quality gates.
+//
+// This module is framework-agnostic (no React, no DOM): given a nodes/edges spec
+// it returns fully-placed boxes, rendered edges, and lane bands, throwing on a
+// spec that is broken (a dangling edge) or unreadable (a tangled layout). The
+// component in index.tsx renders the returned geometry as SVG.
+//
+// Ported from the earlbear-blog FlowDiagram.astro build-time script : the layout
+// math (branch longest-path levelling, swimlane forward-edge ranking, rimPoint
+// edge geometry, the segment-crossing overlap gate) is copied largely verbatim
+// because it is pure arithmetic that needs no browser (no getBBox, no random).
+
+export type FlowNodeKind = 'default' | 'store' | 'external' | 'edge';
+
+export interface FlowNode {
+  id: string;
+  label: string;
+  kind?: FlowNodeKind;
+  /** Which actor/system owns this step. Only used by shape="swimlane", where each
+   *  distinct lane becomes a labeled horizontal band. */
+  lane?: string;
+  /** Optional longer detail, surfaced in the click-to-focus modal. */
+  detail?: string;
+}
+
+export interface FlowEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export type FlowShape = 'pipeline' | 'loop' | 'sequence' | 'branch' | 'swimlane';
+
+export interface Lane {
+  name: string;
+  top: number;
+  height: number;
+}
+
+export interface PlacedNode {
+  node: FlowNode;
+  /** gradient index (0-based; the component maps it to a data-palette color) */
+  gi: number;
+  cx: number;
+  cy: number;
+}
+
+export interface RenderedEdge {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  mx: number;
+  my: number;
+  len: number;
+  label?: string;
+  curve: boolean;
+}
+
+export interface NodeDetail {
+  id: string;
+  label: string;
+  detail: string;
+  to: string[];
+  from: string[];
+}
+
+export interface FlowLayout {
+  shape: FlowShape;
+  salt: string;
+  svgW: number;
+  svgH: number;
+  lanes: Lane[];
+  placed: PlacedNode[];
+  edges: RenderedEdge[];
+  /** Per-node relationship data for the click-to-focus modal. */
+  details: NodeDetail[];
+  /** True if any node has `detail` : the diagram becomes interactive. */
+  interactive: boolean;
+  /** The special node kinds actually present, in legend order (edge, store, external). */
+  legendKinds: Array<'edge' | 'store' | 'external'>;
+  /** Non-fatal quality issues to surface via console.warn (a11y, disconnected, long labels). */
+  warnings: string[];
+}
+
+// ---- Geometry constants ---------------------------------------------------
+const BOX_W = 168;
+const BOX_H = 68;
+const GAP = 72; // gap between boxes along the flow
+const PAD = 32; // outer padding
+const LANE_LABEL_W = 128; // left gutter for lane labels (swimlane only)
+const OVERLAP_MIN_CLEAR = 0.75;
+
+/** Infer the shape from the graph so authors rarely need to pass one:
+ *   - a back-edge to an earlier node → a cycle → `loop`
+ *   - a node with 2+ outgoing edges → a fork → `branch`
+ *   - otherwise the given base shape stands (pipeline, or sequence for a stack). */
+export function inferShape(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+  base: FlowShape = 'pipeline',
+): FlowShape {
+  const index = new Map(nodes.map((n, i) => [n.id, i]));
+  const hasBackEdge = edges.some((e) => (index.get(e.to) ?? 0) <= (index.get(e.from) ?? 0));
+  const outDegree = new Map<string, number>();
+  for (const e of edges) outDegree.set(e.from, (outDegree.get(e.from) ?? 0) + 1);
+  const hasFork = [...outDegree.values()].some((d) => d >= 2);
+  if (hasBackEdge) return 'loop';
+  if (hasFork) return 'branch';
+  return base;
+}
+
+function rimPoint(cx: number, cy: number, tx: number, ty: number) {
+  // Intersection of the box border with the line toward (tx, ty).
+  const dx = tx - cx;
+  const dy = ty - cy;
+  if (dx === 0 && dy === 0) return { x: cx, y: cy };
+  const hw = BOX_W / 2;
+  const hh = BOX_H / 2;
+  const scale = 1 / Math.max(Math.abs(dx) / hw, Math.abs(dy) / hh);
+  return { x: cx + dx * scale, y: cy + dy * scale };
+}
+
+function segmentsCross(a: RenderedEdge, b: RenderedEdge): boolean {
+  const o = (px: number, py: number, qx: number, qy: number, rx: number, ry: number) =>
+    Math.sign((qy - py) * (rx - qx) - (qx - px) * (ry - qy));
+  const near = (p: number, q: number) => Math.abs(p - q) < 0.5;
+  const shareEndpoint =
+    (near(a.x1, b.x1) && near(a.y1, b.y1)) ||
+    (near(a.x1, b.x2) && near(a.y1, b.y2)) ||
+    (near(a.x2, b.x1) && near(a.y2, b.y1)) ||
+    (near(a.x2, b.x2) && near(a.y2, b.y2));
+  if (shareEndpoint) return false;
+  const o1 = o(a.x1, a.y1, a.x2, a.y2, b.x1, b.y1);
+  const o2 = o(a.x1, a.y1, a.x2, a.y2, b.x2, b.y2);
+  const o3 = o(b.x1, b.y1, b.x2, b.y2, a.x1, a.y1);
+  const o4 = o(b.x1, b.y1, b.x2, b.y2, a.x2, a.y2);
+  return o1 !== o2 && o3 !== o4;
+}
+
+export interface LayoutInput {
+  title: string;
+  desc?: string;
+  shape: FlowShape;
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+  allowOverlap: boolean;
+  legend: boolean;
+}
+
+/**
+ * Compute the full layout for a flow spec. Throws on a dangling edge id or a
+ * tangled layout (unless allowOverlap); collects softer issues into `warnings`
+ * for the caller to console.warn.
+ */
+export function computeFlowLayout(input: LayoutInput): FlowLayout {
+  const { title, desc, shape, nodes, edges, allowOverlap, legend } = input;
+  const salt = title.toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 8) || 'flow';
+  const horizontal = shape === 'pipeline' || shape === 'loop';
+  const warnings: string[] = [];
+
+  // ---- Content-quality gates (before geometry, so a bad spec fails fast) ----
+  const ids = new Set(nodes.map((n) => n.id));
+  const dangling = edges.filter((e) => !ids.has(e.from) || !ids.has(e.to));
+  if (dangling.length) {
+    const bad = dangling
+      .map(
+        (e) =>
+          `${!ids.has(e.from) ? `"${e.from}"` : e.from} -> ${
+            !ids.has(e.to) ? `"${e.to}"` : e.to
+          }`,
+      )
+      .join(', ');
+    throw new Error(
+      `FlowDiagram "${title}": edge references a node id that doesn't exist: ${bad}. ` +
+        `Check the from/to ids against your nodes list.`,
+    );
+  }
+  if (!allowOverlap) {
+    if (!desc || !desc.trim()) {
+      warnings.push(
+        `"${title}" has no desc : add desc= so screen readers get an accessible ` +
+          `description (rendered as the SVG <desc>).`,
+      );
+    }
+    if (nodes.length > 1) {
+      const touched = new Set(edges.flatMap((e) => [e.from, e.to]));
+      for (const n of nodes) {
+        if (!touched.has(n.id)) {
+          warnings.push(
+            `"${title}" node "${n.id}" (${n.label}) has no edges : it renders ` +
+              `floating. Connect it or remove it.`,
+          );
+        }
+      }
+    }
+    for (const n of nodes) {
+      if (n.label.length > 22) {
+        warnings.push(
+          `"${title}" label "${n.label}" is long and may clip its box : shorten it ` +
+            `or move detail into the node's \`detail\`.`,
+        );
+      }
+    }
+  }
+
+  // ---- Placement -----------------------------------------------------------
+  const lanes: Lane[] = [];
+  const pos = new Map<string, { cx: number; cy: number }>();
+
+  if (shape === 'swimlane') {
+    const laneNames: string[] = [];
+    for (const n of nodes) {
+      const ln = n.lane ?? '(unassigned)'; // fallback lane name for nodes with no `lane`
+      if (!laneNames.includes(ln)) laneNames.push(ln);
+    }
+    const order = new Map(nodes.map((n, i) => [n.id, i]));
+    const forward = edges.filter((e) => (order.get(e.to) ?? 0) > (order.get(e.from) ?? 0));
+    const rank = new Map<string, number>();
+    for (const n of nodes) rank.set(n.id, 0);
+    let changed = true;
+    let guard = 0;
+    while (changed && guard++ <= nodes.length) {
+      changed = false;
+      for (const e of forward) {
+        const cf = rank.get(e.from) ?? 0;
+        const ct = rank.get(e.to) ?? 0;
+        if (ct < cf + 1) {
+          rank.set(e.to, cf + 1);
+          changed = true;
+        }
+      }
+    }
+    const usedRanks = [...new Set([...rank.values()])].sort((a, b) => a - b);
+    const compress = new Map(usedRanks.map((r, i) => [r, i]));
+    const col = new Map([...rank].map(([id, r]) => [id, compress.get(r) ?? 0]));
+    const laneH = BOX_H + PAD;
+    laneNames.forEach((name, r) => {
+      lanes.push({ name, top: PAD + r * laneH, height: laneH });
+    });
+    const laneRow = new Map(laneNames.map((n, r) => [n, r]));
+    for (const n of nodes) {
+      const r = laneRow.get(n.lane ?? '(unassigned)') ?? 0;
+      const c = col.get(n.id) ?? 0;
+      pos.set(n.id, {
+        cx: LANE_LABEL_W + PAD + BOX_W / 2 + c * (BOX_W + GAP),
+        cy: PAD + r * laneH + laneH / 2,
+      });
+    }
+  } else if (shape === 'loop') {
+    const n = nodes.length;
+    const rx = Math.max(BOX_W, (n * (BOX_W + GAP)) / (2 * Math.PI));
+    const ry = Math.max(BOX_H * 1.6, (n * (BOX_H + GAP)) / (2 * Math.PI));
+    const cxC = PAD + rx + BOX_W / 2;
+    const cyC = PAD + ry + BOX_H / 2;
+    nodes.forEach((node, i) => {
+      const a = -Math.PI / 2 + (i / n) * 2 * Math.PI;
+      pos.set(node.id, { cx: cxC + Math.cos(a) * rx, cy: cyC + Math.sin(a) * ry });
+    });
+  } else if (shape === 'branch') {
+    const level = new Map<string, number>();
+    for (const n of nodes) level.set(n.id, 0);
+    let changed = true;
+    let guard = 0;
+    while (changed && guard++ < nodes.length + 2) {
+      changed = false;
+      for (const e of edges) {
+        const lf = level.get(e.from) ?? 0;
+        const lt = level.get(e.to) ?? 0;
+        if (lt < lf + 1) {
+          level.set(e.to, lf + 1);
+          changed = true;
+        }
+      }
+    }
+    const byLevel = new Map<number, string[]>();
+    for (const n of nodes) {
+      const l = level.get(n.id) ?? 0;
+      if (!byLevel.has(l)) byLevel.set(l, []);
+      byLevel.get(l)!.push(n.id);
+    }
+    const widest = Math.max(...[...byLevel.values()].map((v) => v.length));
+    const rowW = widest * BOX_W + (widest - 1) * GAP;
+    for (const [l, levelIds] of byLevel) {
+      const levelW = levelIds.length * BOX_W + (levelIds.length - 1) * GAP;
+      const startX = PAD + (rowW - levelW) / 2;
+      levelIds.forEach((id, i) => {
+        pos.set(id, {
+          cx: startX + BOX_W / 2 + i * (BOX_W + GAP),
+          cy: PAD + BOX_H / 2 + l * (BOX_H + GAP),
+        });
+      });
+    }
+  } else {
+    nodes.forEach((node, i) => {
+      const cx = horizontal ? PAD + BOX_W / 2 + i * (BOX_W + GAP) : PAD + BOX_W / 2;
+      const cy = horizontal ? PAD + BOX_H / 2 : PAD + BOX_H / 2 + i * (BOX_H + GAP);
+      pos.set(node.id, { cx, cy });
+    });
+  }
+
+  const cxs = [...pos.values()].map((p) => p.cx);
+  const cys = [...pos.values()].map((p) => p.cy);
+  const svgW =
+    shape === 'loop' || shape === 'branch' || shape === 'swimlane'
+      ? Math.max(...cxs) + BOX_W / 2 + PAD
+      : horizontal
+        ? PAD * 2 + nodes.length * BOX_W + (nodes.length - 1) * GAP
+        : PAD * 2 + BOX_W;
+  const svgH =
+    shape === 'swimlane'
+      ? PAD + lanes.reduce((h, l) => h + l.height, 0) + PAD
+      : shape === 'loop' || shape === 'branch'
+        ? Math.max(...cys) + BOX_H / 2 + PAD
+        : horizontal
+          ? PAD * 2 + BOX_H
+          : PAD * 2 + nodes.length * BOX_H + (nodes.length - 1) * GAP;
+
+  // ---- Edge geometry -------------------------------------------------------
+  const rendered: RenderedEdge[] = [];
+  for (const edge of edges) {
+    const a = pos.get(edge.from);
+    const b = pos.get(edge.to);
+    if (!a || !b) continue;
+    const s = rimPoint(a.cx, a.cy, b.cx, b.cy);
+    const e = rimPoint(b.cx, b.cy, a.cx, a.cy);
+    const len = Math.hypot(e.x - s.x, e.y - s.y);
+    rendered.push({
+      x1: s.x,
+      y1: s.y,
+      x2: e.x,
+      y2: e.y,
+      mx: (s.x + e.x) / 2,
+      my: (s.y + e.y) / 2,
+      len,
+      label: edge.label,
+      curve: shape === 'loop',
+    });
+  }
+
+  // ---- Overlap gate (build-time, blocking) ---------------------------------
+  if (shape !== 'loop') {
+    const crossed = new Set<number>();
+    for (let i = 0; i < rendered.length; i++) {
+      for (let j = i + 1; j < rendered.length; j++) {
+        if (segmentsCross(rendered[i], rendered[j])) {
+          crossed.add(i);
+          crossed.add(j);
+        }
+      }
+    }
+    const clear = rendered.length === 0 ? 1 : 1 - crossed.size / rendered.length;
+    if (clear < OVERLAP_MIN_CLEAR) {
+      const msg =
+        `FlowDiagram "${title}": only ${Math.round(clear * 100)}% of edges are ` +
+        `crossing-free (need >=${OVERLAP_MIN_CLEAR * 100}%). Reorder nodes so the ` +
+        `flow reads left-to-right (or top-to-bottom) without backtracking, or split ` +
+        `the diagram.`;
+      if (allowOverlap) warnings.push(`(allowOverlap set) ${msg}`);
+      else throw new Error(`${msg} To ship anyway, pass allowOverlap.`);
+    }
+  }
+
+  // ---- Modal / relationship data ------------------------------------------
+  const nodeLabel = new Map(nodes.map((n) => [n.id, n.label]));
+  const details: NodeDetail[] = nodes.map((n) => {
+    const to = edges
+      .filter((e) => e.from === n.id)
+      .map((e) => nodeLabel.get(e.to)!)
+      .filter(Boolean);
+    const from = edges
+      .filter((e) => e.to === n.id)
+      .map((e) => nodeLabel.get(e.from)!)
+      .filter(Boolean);
+    return { id: n.id, label: n.label, detail: n.detail ?? '', to, from };
+  });
+  const interactive = details.some((d) => d.detail);
+
+  const legendKinds = legend
+    ? (['edge', 'store', 'external'] as const).filter((k) => nodes.some((n) => n.kind === k))
+    : [];
+
+  const placed: PlacedNode[] = nodes.map((node, i) => {
+    const p = pos.get(node.id)!;
+    return { node, gi: i, cx: p.cx, cy: p.cy };
+  });
+
+  return {
+    shape,
+    salt,
+    svgW,
+    svgH,
+    lanes,
+    placed,
+    edges: rendered,
+    details,
+    interactive,
+    legendKinds: [...legendKinds],
+    warnings,
+  };
+}
+
+export const BOX = { W: BOX_W, H: BOX_H, PAD };

--- a/packages/blog-ui/src/components/FlowDiagram/styles.module.css
+++ b/packages/blog-ui/src/components/FlowDiagram/styles.module.css
@@ -1,0 +1,263 @@
+/* FlowDiagram — inline-SVG directed-flow figure. Themed entirely from the blog's
+   design-system tokens (Infima + our named tokens) so light and dark work with no
+   extra wiring. The --bopflow-* vars below are the local contract the component's
+   gradient fills / surfaces read; they alias real theme tokens (never raw hex,
+   except documented fallbacks). */
+
+.flow {
+  /* Data palette: brand green + tea pastels, extended to 8 hues. Node gradients
+     mix these ~22-28% into the surface, so boxes read as tinted paper, on-brand. */
+  --bopflow-data-1: var(--brand-green);
+  --bopflow-data-2: var(--tea-mint);
+  --bopflow-data-3: var(--tea-green);
+  --bopflow-data-4: var(--tea-pink);
+  --bopflow-data-5: #cfe3ff;
+  --bopflow-data-6: #ffe6b0;
+  --bopflow-data-7: #e3d1ff;
+  --bopflow-data-8: #bfe7d6;
+  --bopflow-surface: var(--ifm-background-surface-color, #f4f6f5);
+  --bopflow-surface-sunken: var(--ifm-background-color, #eef1ef);
+
+  margin: var(--space-8, 3.5rem) 0;
+}
+
+.scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.flow svg {
+  width: 100%;
+  height: auto;
+  min-width: 280px;
+  display: block;
+}
+
+/* A vertical sequence is a narrow, tall figure: cap its width and center it so
+   width:100% does not blow the boxes up to the full reading column. */
+.shape-sequence svg {
+  max-width: 260px;
+  margin: 0 auto;
+}
+
+.box {
+  stroke: var(--ifm-color-emphasis-300, #cbd2ce);
+  stroke-width: 1;
+}
+.box-store {
+  stroke: var(--ifm-color-emphasis-500, #8a938e);
+  stroke-dasharray: 0;
+}
+.box-external {
+  stroke-dasharray: 5 4;
+}
+.box-edge {
+  stroke: var(--ifm-color-primary);
+  stroke-width: 1.5;
+  stroke-dasharray: 3 3;
+}
+.label {
+  fill: var(--ifm-heading-color, #14201a);
+  font-family: var(--font-sans-body, system-ui);
+  font-size: 14px;
+  font-weight: 500;
+  text-anchor: middle;
+  dominant-baseline: central;
+}
+
+.edge path {
+  stroke: var(--ifm-color-emphasis-500, #8a938e);
+  stroke-width: 1.5;
+}
+/* Edge labels sit in a chip so they stay legible over lines and gradient boxes. */
+.edgeChip {
+  fill: var(--ifm-background-surface-color, #f4f6f5);
+  stroke: var(--bop-divider, rgba(26, 26, 26, 0.1));
+  stroke-width: 1;
+}
+.edgeLabel {
+  fill: var(--ifm-color-content-secondary, #5b625e);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  text-anchor: middle;
+  dominant-baseline: alphabetic;
+}
+.caption {
+  margin-top: var(--space-3, 0.75rem);
+  font-size: var(--text-caption, 0.85rem);
+  color: var(--ifm-color-content-secondary, #5b625e);
+  text-align: center;
+}
+
+/* Motion: edges draw in, boxes fade in. Reduced-motion falls to the final state. */
+.edge path {
+  stroke-dasharray: var(--len);
+  stroke-dashoffset: var(--len);
+  animation: bopflow-draw 480ms var(--ease-out, ease-out) forwards;
+  animation-delay: calc(var(--i, 0) * 100ms);
+}
+.node {
+  animation: bopflow-fade 320ms var(--ease-out, ease-out) both;
+  animation-delay: calc(var(--i, 0) * 80ms + 100ms);
+}
+@keyframes bopflow-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes bopflow-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .edge path {
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+    animation: none;
+  }
+  .node {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+/* Interactive nodes + modal. */
+.nodeInteractive {
+  cursor: pointer;
+}
+.nodeInteractive .box {
+  transition: stroke var(--duration-fast, 0.12s) var(--ease-standard, ease);
+}
+.nodeInteractive:hover .box,
+.nodeInteractive:focus-visible .box {
+  stroke: var(--ifm-color-primary);
+  stroke-width: 2;
+}
+.nodeInteractive:focus-visible {
+  outline: none;
+}
+
+.modal {
+  border: 1px solid var(--ifm-color-emphasis-300, #cbd2ce);
+  border-radius: var(--radius-lg, 14px);
+  padding: 0;
+  max-width: min(440px, 92vw);
+  width: 100%;
+  background: var(--ifm-background-surface-color, #f4f6f5);
+  color: var(--ifm-font-color-base, #1a1d1b);
+  box-shadow: var(--shadow-md, 0 4px 16px rgba(26, 26, 26, 0.16));
+}
+.modal::backdrop {
+  background: rgba(20, 32, 26, 0.4);
+}
+.modalInner {
+  position: relative;
+  padding: var(--space-6, 2rem);
+}
+.modalClose {
+  position: absolute;
+  top: var(--space-3, 0.75rem);
+  right: var(--space-3, 0.75rem);
+  border: none;
+  background: transparent;
+  font-size: var(--text-h4, 1.3rem);
+  line-height: 1;
+  color: var(--ifm-color-content-secondary, #5b625e);
+  cursor: pointer;
+  padding: var(--space-1, 0.25rem);
+  border-radius: var(--radius-sm, 0.4rem);
+}
+.modalClose:hover {
+  color: var(--ifm-font-color-base, #1a1d1b);
+  background: var(--ifm-background-color, #eef1ef);
+}
+.modalEyebrow {
+  font-size: var(--text-eyebrow, 0.8rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin: 0 0 var(--space-2, 0.5rem);
+}
+.modalTitle {
+  font-size: var(--text-h3, 1.5rem);
+  font-weight: 600;
+  margin: 0 0 var(--space-3, 0.75rem);
+  padding-right: var(--space-6, 2rem);
+}
+.modalDetail {
+  margin: 0 0 var(--space-4, 1rem);
+  color: var(--ifm-color-content-secondary, #5b625e);
+  line-height: 1.6;
+}
+.modalRels {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-2, 0.5rem) var(--space-4, 1rem);
+}
+.modalRels dt {
+  font-size: var(--text-eyebrow, 0.8rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-content-secondary, #5b625e);
+  align-self: center;
+}
+.modalRels dd {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 0.5rem);
+}
+.modalRels dd span {
+  font-size: var(--text-body-sm, 0.95rem);
+  background: var(--ifm-background-color, #eef1ef);
+  border: 1px solid var(--bop-divider, rgba(26, 26, 26, 0.1));
+  border-radius: var(--radius-pill, 3em);
+  padding: 0.125rem var(--space-3, 0.75rem);
+}
+
+/* Optional key for the special node kinds. */
+.legend {
+  list-style: none;
+  margin: var(--space-3, 0.75rem) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-4, 1rem);
+}
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+  font-size: var(--text-body-sm, 0.95rem);
+  color: var(--ifm-color-content-secondary, #5b625e);
+}
+.legendSwatch {
+  width: 28px;
+  height: 18px;
+  flex: none;
+}
+
+/* Swimlane bands: one labeled horizontal row per lane. */
+.laneBand {
+  fill: var(--ifm-background-color, #eef1ef);
+}
+.laneBandAlt {
+  fill: var(--ifm-background-surface-color, #f4f6f5);
+}
+.laneLabel {
+  fill: var(--ifm-color-content-secondary, #5b625e);
+  font-family: var(--font-sans-body, system-ui);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  dominant-baseline: central;
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -18,6 +18,20 @@ export type {GifProps, GifFrame} from './components/Gif';
 export {default as DiagramWithFootnotes, circledNumber} from './components/DiagramWithFootnotes';
 export type {DiagramWithFootnotesProps} from './components/DiagramWithFootnotes';
 
+// FlowDiagram — a prop-driven directed-flow diagram (pipeline/loop/sequence/branch/
+// swimlane) rendered as one inline SVG. The author writes a nodes/edges spec (data,
+// not an image); layout is deterministic and a build-time gate fails on a dangling
+// edge id or a tangled (unreadable) layout. Distinct from DiagramWithFootnotes,
+// which wraps a hand-authored mermaid diagram with a numbered legend.
+export {default as FlowDiagram} from './components/FlowDiagram';
+export type {
+  FlowDiagramProps,
+  FlowNode,
+  FlowEdge,
+  FlowShape,
+  FlowNodeKind,
+} from './components/FlowDiagram';
+
 export {default as Assumption} from './components/Assumption';
 export type {AssumptionProps} from './components/Assumption';
 


### PR DESCRIPTION
## What

Phase 1 of the earlbear-influenced improvement plan (`.claude/plans/snug-yawning-fox.md`): a prop-driven **FlowDiagram** component in `@omars-lab/blog-ui`. Authors write a `nodes`/`edges` spec (data, not a mermaid string, not an image) and the component lays it out deterministically as inline SVG in one of five shapes, usually inferred from the graph:

- `pipeline` (A → B → C), `loop` (a cycle), `sequence` (vertical stack), `branch` (fork / decision fan-out), `swimlane` (labeled owner bands).

The distinctive move (spent our boldness here): a **build-time legibility gate** throws on a dangling edge id or a tangled (crossing) layout, so a flow ships only when it reads cleanly. `allowOverlap` is the escape hatch.

## Why

We render diagrams by hand-authoring raw mermaid (23 posts/docs do this; only 1 uses the animated wrapper). FlowDiagram makes a flow **diffable data**, on-brand, and self-validating. It complements `DiagramWithFootnotes` (which still wraps a hand-authored mermaid diagram with a numbered legend); FlowDiagram is deliberately *not* a general mermaid renderer.

## How

- `layout.ts` — the pure-TS engine (shape inference, branch longest-path levelling, swimlane forward-edge ranking, `rimPoint` edge geometry, the segment-crossing overlap gate). Ported largely verbatim from the earlbear Astro source; framework-agnostic.
- `index.tsx` — renders the layout as SVG; the click-to-focus detail modal is React state + a native `<dialog>` (replacing Astro's inline-script IIFE).
- `styles.module.css` — themed entirely from our design-system tokens; a `--bopflow-*` data palette derived from brand-green + the tea pastels. All motion respects `prefers-reduced-motion`.
- Exported from the barrel, registered in `MDXComponents.tsx`, catalog entry added to the `upgrade-post` skill.

## Proof / verification

Converted `blog/2017-09-27-the-habit-loop` `.md` → `.mdx` as the real-post proof (the `Reward → Cue` back-edge auto-infers the `loop` shape). Slug is explicit and unchanged, so no redirect needed.

- ✅ `docusaurus build` succeeds (exit 0); the SVG renders **server-side** into `build/initiatives/the-habit-loop.html` (12 gradient refs, 17 `<svg>`, all node + edge labels present — no blank-component bug).
- ✅ The gate **bites**: a dangling edge id throws; valid pipeline + the habit loop pass (3/3 harness).
- ✅ Visual + mobile pass (desktop + 375px): the loop renders on-brand in dark mode, the From/To modal opens and lists computed relationships, no horizontal overflow, SVG scales responsively. Only console noise is the benign adblock-probe 404.
- ✅ `validate-ds-tokens` + `validate-em-dash` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)