### PR TITLE
feat(blog): questions frontmatter field + "Questions this post answers" box

### DIFF
--- a/.claude/hooks/validate-questions-hook.sh
+++ b/.claude/hooks/validate-questions-hook.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write: WARN (never block) on a malformed `questions:` field.
+#
+# `questions:` is the optional list of reader questions a post answers, rendered by the
+# <PostQuestions> box at the top of the post. The field is advisory, so this only nudges
+# (never blocks) when it is present but ill-formed: a scalar instead of a list, an empty
+# list, a blank item, or an item that does not read as a question (does not end in "?").
+#
+# Sibling of validate-post-outline-hook.sh (warn-tier). Pairs with
+# scripts/validate-questions.js + src/components/PostQuestions + the author-blog-post skill.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+case "$file_path" in
+  *.md|*.mdx) ;;
+  *) exit 0 ;;
+esac
+case "$file_path" in
+  */bytesofpurpose-blog/docs/*|*/bytesofpurpose-blog/blog/*|*/bytesofpurpose-blog/designs/*) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+# Fast skip: only run if the file actually declares a `questions:` field.
+grep -qE '^questions\s*:' "$file_path" 2>/dev/null || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+script="$proj/bytesofpurpose-blog/scripts/validate-questions.js"
+[ -f "$script" ] || exit 0
+
+out=$(node "$script" "$file_path" 2>&1)
+case "$out" in
+  *"[WARN:questions-"*)
+    printf '%s\n' "$out" >&2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,6 +53,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-questions-hook.sh\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-post-outline-hook.sh\"",
             "timeout": 20
           },

--- a/.claude/skills/author-blog-post/SKILL.md
+++ b/.claude/skills/author-blog-post/SKILL.md
@@ -140,6 +140,26 @@ make fix-blog-posts    # fix frontmatter for recently modified posts + placehold
 Blog posts support a truncation marker for list previews — add `<!-- truncate -->`
 after the intro so paginated lists show a short preview (a warning nags otherwise).
 
+### `questions:` — the reader questions a post answers (optional)
+
+A post MAY declare the reader questions it sets out to answer. They render as a
+"Questions this post answers" box at the top of the post (the `<PostQuestions>` box,
+mounted automatically by the swizzled blog/doc item — no import, no placement needed).
+This is the reader-facing mirror of the repo convention "frame each task around the
+MAIN QUESTION it answers": the questions usually come straight from the request that
+prompted the post.
+
+```yaml
+questions:
+  - What is the loop behind every habit?
+  - Why does willpower behave like a muscle rather than a fixed trait?
+```
+
+Rules (warn-validated by `validate-questions.js` + the `validate-questions` hook, and
+`make validate-questions`): the field is OPTIONAL, but when present it must be a YAML
+list (block `- item` form or inline `[a?, b?]`), non-empty, with each item a real
+question ending in `?` (not a topic label). Absent → the box simply does not render.
+
 ## Premium content (how to MARK it — the mechanics)
 
 > For *whether* a doc should be premium (the editorial policy — depth/originality

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ validate-footnotes: ## Verify evidence-footnote permalinks resolve (pinned SHA +
 validate-mdx-imports: ## Catch a Capitalized JSX tag used in .mdx but never imported/registered (a render break drafts hide)
 	( cd ${SITEROOT} && node scripts/validate-mdx-imports.js $(DIRS) --error-only )
 
+validate-questions: ## Lint the optional `questions:` frontmatter (present → must be a list of items each ending in "?")
+	( cd ${SITEROOT} && node scripts/validate-questions.js $(DIRS) )
+
 validate-glossary: ## Find posts whose first use of a defined glossary term isn't linked (warn-tier candidates; judge + link via the link-glossary-terms skill)
 	( cd ${SITEROOT} && node scripts/validate-glossary-links.js $(DIRS) )
 

--- a/bytesofpurpose-blog/blog/2017-09-27-the-habit-loop.mdx
+++ b/bytesofpurpose-blog/blog/2017-09-27-the-habit-loop.mdx
@@ -8,6 +8,10 @@ authors: [oeid]
 tags: [mindset, productivity]
 date: 2017-09-27
 draft: false
+questions:
+  - What is the loop behind every habit?
+  - Why does willpower behave like a muscle rather than a fixed trait?
+  - What actually changes a behavior, and what does not?
 ---
 
 A while back I read *The Power of Habit* by Charles Duhigg, and it changed how I

--- a/bytesofpurpose-blog/scripts/validate-questions.js
+++ b/bytesofpurpose-blog/scripts/validate-questions.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * validate-questions.js — lint the optional `questions:` frontmatter field.
+ *
+ * A post MAY declare `questions:` — the reader questions it sets out to answer (the
+ * reader-facing mirror of the repo convention "frame each task around the MAIN QUESTION").
+ * The <PostQuestions> box renders them at the top of the post. The field is OPTIONAL by
+ * design (so the existing corpus needn't be retrofitted at once), but WHEN PRESENT it must
+ * be well-formed, or the box reads wrong:
+ *
+ *   questions-empty       `questions:` is present but empty (an empty box, or a signal    [WARN]
+ *                         the author meant to fill it).
+ *   questions-not-list    `questions:` is a scalar, not a list.                           [WARN]
+ *   questions-blank-item  a list item is blank.                                           [WARN]
+ *   questions-not-a-q     a list item does not end in "?" (a topic label, not a question).[WARN]
+ *
+ * All WARN-tier: the field is advisory, so this nudges (never blocks). The blocking gate is
+ * `make validate-questions` for a deliberate full-corpus sweep.
+ *
+ * Usage:
+ *   node scripts/validate-questions.js [paths…]      # scan (default: blog docs)
+ *   node scripts/validate-questions.js --json         # machine-readable
+ *   node scripts/validate-questions.js --error-only   # exit 2 if any finding (for a strict gate)
+ *
+ * Exit codes: 0 clean · 1 findings (scan) · 2 findings (--error-only).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_DIRS = ['blog', 'docs'];
+
+/** Extract the raw YAML frontmatter block (between the leading --- fences). */
+function frontmatterBlock(src) {
+  if (!src.startsWith('---')) return null;
+  const end = src.indexOf('\n---', 3);
+  if (end === -1) return null;
+  return src.slice(3, end);
+}
+
+/**
+ * Parse the `questions:` value out of a frontmatter block without a YAML dep.
+ * Supports the two YAML list forms:
+ *   inline:   questions: [a?, b?]
+ *   block:    questions:\n  - a?\n  - b?
+ * Returns {present, items} where items is the array of raw string values, or null if the
+ * value is a scalar (present but not a list).
+ */
+function parseQuestions(fm) {
+  const lines = fm.split('\n');
+  const startIdx = lines.findIndex((l) => /^questions\s*:/.test(l));
+  if (startIdx === -1) return {present: false, items: []};
+
+  const header = lines[startIdx];
+  const afterColon = header.replace(/^questions\s*:/, '').trim();
+
+  // inline list form
+  if (afterColon.startsWith('[')) {
+    const inner = afterColon.replace(/^\[/, '').replace(/\]\s*$/, '');
+    if (inner.trim() === '') return {present: true, items: []};
+    const items = inner
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''));
+    return {present: true, items};
+  }
+
+  // a non-empty scalar on the same line → present but not a list
+  if (afterColon !== '' && !afterColon.startsWith('#')) {
+    return {present: true, items: null};
+  }
+
+  // block list form: collect following `  - item` lines
+  const items = [];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\s*-\s+/.test(l)) {
+      items.push(l.replace(/^\s*-\s+/, '').trim().replace(/^['"]|['"]$/g, ''));
+    } else if (/^\S/.test(l)) {
+      break; // next top-level key
+    } else if (l.trim() === '') {
+      continue;
+    } else {
+      break;
+    }
+  }
+  return {present: true, items};
+}
+
+function scanFile(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const findings = [];
+  const fm = frontmatterBlock(raw);
+  if (!fm) return {findings};
+  const {present, items} = parseQuestions(fm);
+  if (!present) return {findings};
+
+  const rel = path.relative(ROOT, file);
+  const line = raw.slice(0, raw.indexOf('questions:')).split('\n').length;
+  const add = (kind, detail, suggest) =>
+    findings.push({file: rel, line, severity: 'warn', kind, detail, suggest});
+
+  if (items === null) {
+    add(
+      'questions-not-list',
+      '`questions:` is a scalar, not a list.',
+      'Make it a YAML list: `questions:` then `  - ...?` items (or `[a?, b?]`).',
+    );
+    return {findings};
+  }
+  if (items.length === 0) {
+    add(
+      'questions-empty',
+      '`questions:` is present but empty.',
+      'Add the reader questions this post answers, or remove the field.',
+    );
+    return {findings};
+  }
+  items.forEach((q) => {
+    if (!q) {
+      add('questions-blank-item', 'a `questions:` item is blank.', 'Remove the blank item or fill it in.');
+    } else if (!q.endsWith('?')) {
+      add(
+        'questions-not-a-q',
+        `a \`questions:\` item does not end in "?": "${q}".`,
+        'Phrase it as a question (the box reads as "Questions this post answers").',
+      );
+    }
+  });
+  return {findings};
+}
+
+function walk(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (/\.mdx?$/.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const errorOnly = args.includes('--error-only');
+  const targets = args.filter((a) => !a.startsWith('--'));
+  const dirs = (targets.length ? targets : DEFAULT_DIRS).map((d) =>
+    path.isAbsolute(d) ? d : path.join(ROOT, d),
+  );
+  const files = dirs.flatMap((d) =>
+    fs.existsSync(d) && fs.statSync(d).isDirectory() ? walk(d) : fs.existsSync(d) ? [d] : [],
+  );
+
+  const all = files.flatMap((f) => scanFile(f).findings);
+
+  if (json) {
+    console.log(JSON.stringify(all, null, 2));
+    process.exit(all.length ? (errorOnly ? 2 : 1) : 0);
+  }
+  if (!all.length) {
+    if (!errorOnly)
+      console.log(`✅ questions: scanned ${files.length} files, every \`questions:\` field is well-formed.`);
+    process.exit(0);
+  }
+  console.log(`🔎 questions: ${all.length} finding(s) in ${files.length} files (advisory)\n`);
+  for (const p of all) {
+    console.log(`  ${p.file}:${p.line}  [${p.severity.toUpperCase()}:${p.kind}] ${p.detail}`);
+    console.log(`      ↳ ${p.suggest}`);
+  }
+  process.exit(errorOnly ? 2 : 1);
+}
+
+main();

--- a/bytesofpurpose-blog/src/components/PostQuestions/index.tsx
+++ b/bytesofpurpose-blog/src/components/PostQuestions/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+/**
+ * PostQuestions renders the "Questions this post answers" box from a post's
+ * `questions:` frontmatter (a list of reader questions the post sets out to answer,
+ * usually the questions behind the request that prompted it).
+ *
+ * This is the reader-facing mirror of the repo convention "frame each task around
+ * the MAIN QUESTION it answers": the working task list reads as questions in flight,
+ * and a published post carries the same framing so a reader sees, up front, exactly
+ * which questions it will resolve.
+ *
+ * It is mounted automatically by the swizzled blog/doc item wrappers (so an author
+ * never has to remember to place it); it renders nothing when `questions` is absent
+ * or empty. An accessible landmark region, not decoration.
+ */
+export interface PostQuestionsProps {
+  questions?: unknown;
+}
+
+function normalize(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((q) => (typeof q === 'string' ? q.trim() : ''))
+    .filter((q) => q.length > 0);
+}
+
+export default function PostQuestions({
+  questions,
+}: PostQuestionsProps): React.JSX.Element | null {
+  const items = normalize(questions);
+  if (items.length === 0) return null;
+  return (
+    <aside className={styles.box} aria-label="Questions this post answers">
+      <p className={styles.eyebrow}>Questions this post answers</p>
+      <ul className={styles.list}>
+        {items.map((q, i) => (
+          <li key={i} className={styles.item}>
+            {q}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/bytesofpurpose-blog/src/components/PostQuestions/styles.module.css
+++ b/bytesofpurpose-blog/src/components/PostQuestions/styles.module.css
@@ -1,0 +1,39 @@
+/* PostQuestions — the "Questions this post answers" box. A quiet sunken card that
+   sits between the post header and the body. Themed from design-system tokens so it
+   works in light and dark with no extra wiring. */
+
+.box {
+  margin: var(--space-5) 0 var(--space-6);
+  padding: var(--space-4) var(--space-5);
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--bop-divider);
+  border-left: 3px solid var(--ifm-color-primary);
+  border-radius: var(--radius-md);
+}
+
+.eyebrow {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-sans-body);
+  font-size: var(--text-eyebrow);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+.list {
+  margin: 0;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.item {
+  color: var(--text-body);
+  line-height: 1.55;
+}
+
+.item::marker {
+  color: var(--ifm-color-primary);
+}

--- a/bytesofpurpose-blog/src/theme/BlogPostItem/Content/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogPostItem/Content/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import {blogPostContainerID} from '@docusaurus/utils-common';
+import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import MDXContent from '@theme/MDXContent';
+import PostQuestions from '@site/src/components/PostQuestions';
+
+// Swizzled @theme/BlogPostItem/Content: re-implements the upstream component
+// (which just wraps the MDX body) and additionally renders the "Questions this
+// post answers" box from the post's `questions:` frontmatter, ABOVE the body,
+// on the full post page only (not on blog list cards, where isBlogPostPage is
+// false). See src/components/PostQuestions.
+export default function BlogPostItemContent({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}): React.JSX.Element {
+  const {isBlogPostPage, frontMatter} = useBlogPost();
+  return (
+    <div
+      // This ID is used for the feed generation to locate the main content.
+      id={isBlogPostPage ? blogPostContainerID : undefined}
+      className={clsx('markdown', className)}>
+      {isBlogPostPage && (
+        <PostQuestions questions={(frontMatter as {questions?: unknown}).questions} />
+      )}
+      <MDXContent>{children}</MDXContent>
+    </div>
+  );
+}

--- a/bytesofpurpose-blog/src/theme/DocItem/Content/index.tsx
+++ b/bytesofpurpose-blog/src/theme/DocItem/Content/index.tsx
@@ -5,6 +5,7 @@ import {useDoc} from '@docusaurus/plugin-content-docs/client';
 import Heading from '@theme/Heading';
 import MDXContent from '@theme/MDXContent';
 import ShareButton from '@site/src/components/ShareButton';
+import PostQuestions from '@site/src/components/PostQuestions';
 
 // Swizzled @theme/DocItem/Content: re-implements the upstream component (which
 // only renders a synthetic <h1> + the MDX body) and additionally mounts the
@@ -56,6 +57,7 @@ export default function DocItemContent({
           <ShareButton surface="doc-title" title={shareTitle} description={shareDescription} />
         </div>
       )}
+      <PostQuestions questions={frontMatter.questions} />
       <MDXContent>{children}</MDXContent>
     </div>
   );


### PR DESCRIPTION
## What

Phase 3 of the earlbear-influenced plan (`.claude/plans/snug-yawning-fox.md`): an optional `questions:` frontmatter field that renders as a "Questions this post answers" box at the top of a post.

## Why

This is the reader-facing mirror of the repo convention *"frame each task around the MAIN QUESTION it answers."* The working task list already reads as questions in flight; now a published post carries the same framing so a reader sees, up front, exactly which questions it resolves. (Adopted from earlbear-blog, where every post declares the questions behind the request that prompted it.)

## How

- `src/components/PostQuestions` — the token-styled box (a sunken aside, green eyebrow + left accent + green bullets). Renders nothing when the field is absent.
- **Mounted automatically** by the swizzled `DocItem/Content` and a new `BlogPostItem/Content` (gated on `isBlogPostPage` so it shows on the post page, not on list cards) — an author never has to import or place it.
- `scripts/validate-questions.js` — the field is **optional** (no corpus retrofit), but when present it must be a YAML list (block or inline), non-empty, each item ending in `?`. Warn-tier. Hook `validate-questions-hook.sh` (never blocks) + `make validate-questions`.
- The `author-blog-post` skill documents the field.

## Proof / verification

- ✅ Docusaurus accepts the new field on both blog and doc schemas (full `docusaurus build` succeeds).
- ✅ The box renders **server-side** in `build/initiatives/the-habit-loop.html`.
- ✅ Validator clean across 339 corpus files; bites on a planted scalar / non-question item / blank item / empty list.
- ✅ Desktop + 390px visual pass: box sits on-brand after the byline, questions wrap cleanly, no box overflow. (The page-level overflow chrome-devtools flags is a pre-existing navbar tooltip, not this change.)
- ✅ em-dash + ds-tokens + mdx-imports clean.

Proof post: `blog/2017-09-27-the-habit-loop.mdx` now declares three questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)