### PR TITLE
feat(blog-ui): ComparisonMatrix + Accordion (the decision-post kit)

### DIFF
--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -134,6 +134,37 @@ so a flow ships only when it reads cleanly. HOW:
   non-flow (class/ER/context) diagram, reach for `DiagramWithFootnotes` (mermaid + numbered
   legend) instead. FlowDiagram is for flows; it is deliberately not a general mermaid renderer.
 
+### Decision kit: ComparisonMatrix + Accordion
+
+WHAT: two components for a post that argues a CHOICE. `ComparisonMatrix` is the head-to-head
+table (options are columns, criteria rows, the `chosen` column highlighted + badged;
+`yes`/`no`/`partial` render as ●/○/◐ marks with sr-only labels, any other string as literal
+text). `Accordion` is the narrative (foldable options on native `<details>`, zero JS, each
+with a `summary`, a React `body`, an optional `verdict` pill, an optional `open`). WHEN: a
+decision/comparison/critique post. The matrix answers "how do they score"; the accordion
+answers "why". HOW:
+
+```mdx
+<ComparisonMatrix title="Where to store the data" desc="Three stores vs our needs."
+  options={[{id:'pg',label:'Postgres'},{id:'sq',label:'SQLite',chosen:true}]}
+  criteria={[
+    {label:'Zero-ops', cells:{pg:'no', sq:'yes'}},
+    {label:'Cost', cells:{pg:'$$', sq:'free'}},
+  ]}/>
+
+<Accordion label="The options" items={[
+  {summary:'Rebuild from scratch', verdict:'rejected', body:<>Slow; loses the edge cases.</>},
+  {summary:'Keep SQLite', verdict:'chosen', open:true, body:<>Zero-ops, durable, free.</>},
+]}/>
+```
+
+- Both registered in `MDXComponents` (no import). Live demo: `/handbook/components/structural/decision-kit`.
+- ComparisonMatrix THROWS at build if a cell is keyed to an option id that is not in `options`.
+  It scrolls inside its own wrapper on mobile (never pushes the page sideways).
+- WHEN NOT: `OptionGrid`/`OptionTile`/`DecisionNote` show explored DESIGN directions with a
+  chosen ring + WHY (a design specimen). ComparisonMatrix is the feature-by-feature decision
+  TABLE. Use the matrix for "which option scores better", OptionGrid for "which mock we picked".
+
 ### Mockup (UX mockups — show what it LOOKS like)
 
 WHAT: a framed, theme-aware wrapper (`browser` / `window` / `phone` / `none` chrome) that

--- a/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
@@ -1,0 +1,105 @@
+---
+slug: /components/structural/decision-kit
+usage_pattern:
+  - '<ComparisonMatrix'
+  - '<Accordion'
+kind: showcase
+title: '🧩 Decision kit (ComparisonMatrix + Accordion)'
+description: 'Two components for decision posts: a ComparisonMatrix head-to-head table and an Accordion of foldable options, so a choice reads at a glance instead of as a wall of prose.'
+authors: [oeid]
+tags: [docusaurus, react, components, decision]
+draft: false
+---
+
+When a post argues a choice between options, two components carry it: a
+**ComparisonMatrix** for the head-to-head (options are columns, criteria are rows, the
+chosen option's column is highlighted), and an **Accordion** for the narrative (each
+option is a fold with a one-line summary, an expandable why, and an optional verdict pill).
+The matrix answers "how do they score"; the accordion answers "why".
+
+## ComparisonMatrix
+
+A real accessible table. Ratings of `yes` / `no` / `partial` render as marks (with
+screen-reader labels); any other string renders as literal text. The `chosen` column is
+highlighted and badged. The table scrolls inside its own wrapper on mobile. A build-time
+gate throws if a cell is keyed to an option id that does not exist.
+
+<ComparisonMatrix
+  title="Where to store the data"
+  desc="Comparing three stores against what this project needs."
+  options={[
+    {id: 'pg', label: 'Postgres'},
+    {id: 'sqlite', label: 'SQLite', chosen: true},
+    {id: 'redis', label: 'Redis'},
+  ]}
+  criteria={[
+    {label: 'Zero-ops', cells: {pg: 'no', sqlite: 'yes', redis: 'partial'}},
+    {label: 'Relational', cells: {pg: 'yes', sqlite: 'yes', redis: 'no'}},
+    {label: 'Durable on disk', cells: {pg: 'yes', sqlite: 'yes', redis: 'partial'}},
+    {label: 'Cost', cells: {pg: '$$', sqlite: 'free', redis: '$'}},
+  ]}
+/>
+
+```mdx
+<ComparisonMatrix
+  title="Where to store the data"
+  desc="Comparing three stores against what this project needs."
+  options={[
+    {id: 'pg', label: 'Postgres'},
+    {id: 'sqlite', label: 'SQLite', chosen: true},
+    {id: 'redis', label: 'Redis'},
+  ]}
+  criteria={[
+    {label: 'Zero-ops', cells: {pg: 'no', sqlite: 'yes', redis: 'partial'}},
+    {label: 'Relational', cells: {pg: 'yes', sqlite: 'yes', redis: 'no'}},
+    {label: 'Cost', cells: {pg: '$$', sqlite: 'free', redis: '$'}},
+  ]}
+/>
+```
+
+## Accordion
+
+Foldable options on native `<details>` / `<summary>`: zero JavaScript, keyboard-accessible
+by default. Each item has a `summary`, a React `body` (prose, a list, or a component), an
+optional `open` default, and an optional `verdict` pill so the decision stays scannable
+while folded.
+
+<Accordion
+  label="The options"
+  items={[
+    {
+      summary: 'Rebuild the store from scratch',
+      verdict: 'rejected',
+      body: (
+        <>It is the cleanest design on paper, but it throws away every edge case the current
+        store has already learned, and it is the slowest path to shipping.</>
+      ),
+    },
+    {
+      summary: 'Reach for a hosted database',
+      verdict: 'rejected',
+      body: <>Solves durability, but it adds an ops surface this project deliberately avoids.</>,
+    },
+    {
+      summary: 'Keep SQLite, add only the new surface',
+      verdict: 'chosen',
+      open: true,
+      body: (
+        <>Zero-ops, durable on disk, relational, and free. It keeps the proven core and adds
+        just the one capability the feature needs.</>
+      ),
+    },
+  ]}
+/>
+
+```mdx
+<Accordion
+  label="The options"
+  items={[
+    {summary: 'Rebuild from scratch', verdict: 'rejected', body: <>Slow, and we lose the edge cases.</>},
+    {summary: 'Keep SQLite, add the new surface', verdict: 'chosen', open: true, body: <>Zero-ops, durable, free.</>},
+  ]}
+/>
+```
+
+<UsedIn slug="/components/structural/decision-kit" />

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -50,6 +50,8 @@ import {
 import {
   DiagramWithFootnotes,
   FlowDiagram,
+  ComparisonMatrix,
+  Accordion,
   Mockup,
   Walkthrough,
   Assumption,
@@ -125,6 +127,18 @@ export default {
   // flow/loop/handoff instead of hand-authoring mermaid; DiagramWithFootnotes still wraps a
   // hand-authored mermaid diagram when you want the numbered-legend treatment.
   FlowDiagram,
+  // ComparisonMatrix: a criteria x options decision table (options are columns, criteria rows;
+  // the chosen option's column is highlighted + badged; yes/no/partial render as ●/○/◐ marks
+  // with sr-only labels). A real accessible <table> that scrolls on mobile; a build-time gate
+  // throws on a cell keyed to a nonexistent option. Use <ComparisonMatrix title=... options={[]}
+  // criteria={[]}/> for a head-to-head. (OptionGrid/DecisionNote show explored DESIGN directions
+  // with a chosen ring + WHY; ComparisonMatrix is the feature-by-feature decision table.)
+  ComparisonMatrix,
+  // Accordion: a foldable option list on native <details>/<summary> (zero JS, keyboard-accessible).
+  // Each item has a one-line summary, an expandable body, and an optional verdict pill. Pairs with
+  // ComparisonMatrix: the accordion carries the narrative, the matrix the head-to-head. Use
+  // <Accordion label=... items={[{summary, body, verdict?, open?}]}/> on a decision post.
+  Accordion,
   // UX mockups: a framed, theme-aware wrapper that turns live HTML into a UI mockup
   // (browser/window/phone chrome) — shows what a design would LOOK like.
   Mockup,

--- a/packages/blog-ui/src/components/Accordion/index.tsx
+++ b/packages/blog-ui/src/components/Accordion/index.tsx
@@ -1,0 +1,64 @@
+import React, {CSSProperties, ReactNode} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * Accordion : a foldable list of options built on native <details>/<summary>. Zero
+ * JavaScript, keyboard-accessible by default, design-system styled. Good for decision
+ * posts: each option is a fold with a one-line summary and an expandable body (the
+ * forces, the trade-off). Pairs with <ComparisonMatrix> (the head-to-head table);
+ * the accordion carries the narrative.
+ *
+ * The first item can be `open` to show a default. Optional `verdict` on an item renders
+ * a small pill (e.g. "chosen" / "rejected") so the decision is scannable while folded.
+ *
+ * Usage in MDX (body is React content, so it can hold prose, a list, or a component):
+ *
+ *   <Accordion
+ *     label="The options"
+ *     items={[
+ *       {summary: 'Rebuild from scratch', verdict: 'rejected', body: (
+ *         <>Too slow, and we lose the battle-tested edge cases.</>
+ *       )},
+ *       {summary: 'Wrap the existing engine', verdict: 'chosen', open: true, body: (
+ *         <>Keeps the proven core; adds only the new surface.</>
+ *       )},
+ *     ]}
+ *   />
+ */
+export interface AccordionItem {
+  summary: string;
+  /** Fold body: any React content (prose, a list, a component). */
+  body: ReactNode;
+  open?: boolean;
+  /** Small pill, e.g. "chosen" / "rejected". */
+  verdict?: string;
+}
+
+export interface AccordionProps {
+  items: AccordionItem[];
+  /** A short eyebrow above the list, e.g. "The options". */
+  label?: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const Accordion: React.FC<AccordionProps> = ({items, label, className, style}) => {
+  return (
+    <div className={clsx(styles.accordion, className)} style={style}>
+      {label && <p className={styles.label}>{label}</p>}
+      {items.map((item, i) => (
+        <details key={i} className={styles.item} open={item.open}>
+          <summary className={styles.summary}>
+            <span className={styles.summaryText}>{item.summary}</span>
+            {item.verdict && <span className={styles.verdict}>{item.verdict}</span>}
+            <span className={styles.chevron} aria-hidden="true" />
+          </summary>
+          <div className={styles.body}>{item.body}</div>
+        </details>
+      ))}
+    </div>
+  );
+};
+
+export default Accordion;

--- a/packages/blog-ui/src/components/Accordion/styles.module.css
+++ b/packages/blog-ui/src/components/Accordion/styles.module.css
@@ -1,0 +1,93 @@
+/* Accordion — native <details>/<summary> folds for decision/option posts. Zero JS,
+   keyboard-accessible by default. Themed from design-system tokens. */
+
+.accordion {
+  margin: var(--space-8) 0;
+  border: 1px solid var(--bop-divider);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.label {
+  margin: 0;
+  padding: var(--space-3) var(--space-5);
+  background: var(--ifm-background-color);
+  border-bottom: 1px solid var(--bop-divider);
+  font-size: var(--text-eyebrow);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+.item + .item {
+  border-top: 1px solid var(--bop-divider);
+}
+
+.summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  cursor: pointer;
+  list-style: none;
+  font-weight: 500;
+  color: var(--text-body);
+  transition: background var(--duration-fast, 0.12s) var(--ease-standard, ease);
+}
+.summary::-webkit-details-marker {
+  display: none;
+}
+.summary:hover {
+  background: var(--ifm-background-color);
+}
+.summary:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: -2px;
+}
+
+.summaryText {
+  flex: 1;
+}
+
+.verdict {
+  font-size: var(--text-caption);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-background-surface-color);
+  background: var(--ifm-color-primary);
+  border-radius: var(--radius-pill);
+  padding: 0.125rem var(--space-3);
+}
+
+.chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--ifm-color-content-secondary);
+  border-bottom: 2px solid var(--ifm-color-content-secondary);
+  transform: rotate(45deg);
+  transition: transform var(--duration-fast, 0.12s) var(--ease-standard, ease);
+  flex: none;
+}
+.item[open] > .summary .chevron {
+  transform: rotate(-135deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .chevron,
+  .summary {
+    transition: none;
+  }
+}
+
+.body {
+  padding: 0 var(--space-5) var(--space-5);
+  color: var(--text-body);
+  line-height: 1.6;
+}
+.body > :first-child {
+  margin-top: 0;
+}
+.body > :last-child {
+  margin-bottom: 0;
+}

--- a/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
+++ b/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
@@ -1,0 +1,158 @@
+import React, {CSSProperties, ReactNode} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+/**
+ * ComparisonMatrix : a criteria x options comparison for decision posts. Options are
+ * columns, criteria are rows, each cell is a rating (a yes/no/partial mark or a short
+ * value). The chosen option's column is highlighted and badged so the decision is
+ * scannable at a glance. Pairs with <Accordion> (which carries the narrative); the
+ * matrix carries the head-to-head.
+ *
+ * Rendered as a real HTML table (proper <th scope>) so a screen reader announces
+ * "Consistency, Option B: partial". Zero JS; the table scrolls inside its own wrapper
+ * on mobile rather than pushing the page sideways. A build-time gate throws if a cell
+ * references an option id that does not exist.
+ *
+ * Distinct from OptionGrid/DecisionNote (design-system specimens that show explored
+ * design directions with a chosen ring + WHY); ComparisonMatrix is the head-to-head
+ * feature table for a decision post.
+ *
+ * Usage in MDX:
+ *
+ *   <ComparisonMatrix
+ *     title="Storage options"
+ *     desc="Comparing three stores against our needs."
+ *     options={[
+ *       {id: 'a', label: 'Postgres'},
+ *       {id: 'b', label: 'SQLite', chosen: true},
+ *       {id: 'c', label: 'Redis'},
+ *     ]}
+ *     criteria={[
+ *       {label: 'Zero-ops', cells: {a: 'no', b: 'yes', c: 'partial'}},
+ *       {label: 'Relational', cells: {a: 'yes', b: 'yes', c: 'no'}},
+ *       {label: 'Cost', cells: {a: '$$', b: 'free', c: '$'}},
+ *     ]}
+ *   />
+ */
+export type Rating = 'yes' | 'no' | 'partial' | string;
+
+export interface MatrixOption {
+  id: string;
+  label: string;
+  /** Mark the winning option: its column is highlighted and badged. */
+  chosen?: boolean;
+}
+
+export interface MatrixCriterion {
+  label: string;
+  /** One cell per option, keyed by option id. 'yes'|'no'|'partial' render as marks;
+   *  any other string renders as literal text. */
+  cells: Record<string, Rating>;
+}
+
+export interface ComparisonMatrixProps {
+  title: string;
+  desc?: string;
+  options: MatrixOption[];
+  criteria: MatrixCriterion[];
+  className?: string;
+  style?: CSSProperties;
+}
+
+const MARK: Record<string, {glyph: string; label: string; cls: string}> = {
+  yes: {glyph: '●', label: 'yes', cls: 'yes'}, // ●
+  no: {glyph: '○', label: 'no', cls: 'no'}, // ○
+  partial: {glyph: '◐', label: 'partial', cls: 'partial'}, // ◐
+};
+
+function assertValid(props: ComparisonMatrixProps): string[] {
+  const {title, desc, options, criteria} = props;
+  const ids = new Set(options.map((o) => o.id));
+  for (const c of criteria) {
+    for (const key of Object.keys(c.cells)) {
+      if (!ids.has(key)) {
+        throw new Error(
+          `ComparisonMatrix "${title}": criterion "${c.label}" has a cell for "${key}", ` +
+            `which is not an option id. Check the cell keys against your options.`,
+        );
+      }
+    }
+  }
+  const warnings: string[] = [];
+  if (!desc || !desc.trim()) {
+    warnings.push(
+      `"${title}" has no desc: add desc= so screen readers get an accessible summary ` +
+        `of what is being compared.`,
+    );
+  }
+  return warnings;
+}
+
+const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
+  const {title, desc, options, criteria, className, style} = props;
+  // Throws (fails the build) on a cell keyed to a nonexistent option.
+  const warnings = assertValid(props);
+  React.useEffect(() => {
+    for (const w of warnings) console.warn(`[comparison-matrix] warning: ${w}`);
+  }, [warnings]);
+
+  const renderCell = (v: Rating | undefined): ReactNode => {
+    const mark = v ? MARK[v] : undefined;
+    if (mark) {
+      return (
+        <span className={clsx(styles.mark, styles[`mark-${mark.cls}`])} title={mark.label}>
+          <span aria-hidden="true">{mark.glyph}</span>
+          <span className={styles.sr}>{mark.label}</span>
+        </span>
+      );
+    }
+    return <span className={styles.value}>{v ?? ''}</span>;
+  };
+
+  return (
+    <figure className={clsx(styles.matrix, className)} style={style}>
+      <div className={styles.scroll}>
+        <table>
+          {desc && <caption className={styles.caption}>{desc}</caption>}
+          <thead>
+            <tr>
+              <th scope="col" className={styles.corner}>
+                {title}
+              </th>
+              {options.map((o) => (
+                <th
+                  key={o.id}
+                  scope="col"
+                  className={clsx(styles.option, o.chosen && styles.optionChosen)}
+                >
+                  <span className={styles.optionLabel}>{o.label}</span>
+                  {o.chosen && <span className={styles.chosenBadge}>chosen</span>}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {criteria.map((c, ri) => (
+              <tr key={ri}>
+                <th scope="row" className={styles.criterion}>
+                  {c.label}
+                </th>
+                {options.map((o) => (
+                  <td
+                    key={o.id}
+                    className={clsx(styles.cell, o.chosen && styles.cellChosen)}
+                  >
+                    {renderCell(c.cells[o.id])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </figure>
+  );
+};
+
+export default ComparisonMatrix;

--- a/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
+++ b/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
@@ -1,0 +1,120 @@
+/* ComparisonMatrix — a criteria x options decision table. Themed from the blog's
+   design-system tokens; light and dark work with no extra wiring. Zero JS. */
+
+.matrix {
+  margin: var(--space-8) 0;
+}
+
+.scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid var(--bop-divider);
+  border-radius: var(--radius-lg);
+}
+
+.matrix table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: var(--text-body-md);
+}
+
+.caption {
+  caption-side: bottom;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-body-sm);
+  color: var(--ifm-color-content-secondary);
+  text-align: left;
+}
+
+.matrix th,
+.matrix td {
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  border-bottom: 1px solid var(--bop-divider);
+}
+.matrix tbody tr:last-child th,
+.matrix tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.corner {
+  font-size: var(--text-eyebrow);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-content-secondary);
+  background: var(--ifm-background-color);
+}
+
+.option {
+  background: var(--ifm-background-color);
+  font-weight: 600;
+  vertical-align: bottom;
+  min-width: 120px;
+}
+.optionChosen {
+  background: var(--accent-tint);
+  color: var(--ifm-color-primary);
+}
+.optionLabel {
+  display: block;
+}
+.chosenBadge {
+  display: inline-block;
+  margin-top: var(--space-1);
+  font-size: var(--text-caption);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-background-surface-color);
+  background: var(--ifm-color-primary);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-2);
+}
+
+.criterion {
+  font-weight: 500;
+  color: var(--text-body);
+  white-space: nowrap;
+}
+
+.cell {
+  color: var(--text-body);
+}
+.cellChosen {
+  background: color-mix(in oklab, var(--accent-tint) 55%, transparent);
+}
+
+.mark {
+  font-size: var(--text-body-lg);
+  line-height: 1;
+}
+.mark-yes {
+  color: var(--ifm-color-primary);
+}
+.mark-no {
+  color: var(--ifm-color-content-secondary);
+}
+.mark-partial {
+  /* a warm amber for "partial"; no design-system token exists for it yet, so a
+     documented literal (kept distinct from brand green / content colors). */
+  color: #b8860b;
+}
+
+.value {
+  color: var(--ifm-color-content-secondary);
+  font-size: var(--text-body-sm);
+}
+
+/* Screen-reader-only text for the marks (so the glyph reads as "yes"/"no"/"partial"). */
+.sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -32,6 +32,23 @@ export type {
   FlowNodeKind,
 } from './components/FlowDiagram';
 
+// ComparisonMatrix — a criteria x options decision table (options are columns, criteria
+// rows; the chosen option's column is highlighted + badged; yes/no/partial render as marks).
+// A real accessible <table>; a build-time gate throws on a cell keyed to a nonexistent option.
+export {default as ComparisonMatrix} from './components/ComparisonMatrix';
+export type {
+  ComparisonMatrixProps,
+  MatrixOption,
+  MatrixCriterion,
+  Rating,
+} from './components/ComparisonMatrix';
+
+// Accordion — a foldable option list on native <details>/<summary> (zero JS). Each item has a
+// one-line summary, an expandable body, and an optional verdict pill ("chosen"/"rejected").
+// Pairs with ComparisonMatrix: the accordion carries the narrative, the matrix the head-to-head.
+export {default as Accordion} from './components/Accordion';
+export type {AccordionProps, AccordionItem} from './components/Accordion';
+
 export {default as Assumption} from './components/Assumption';
 export type {AssumptionProps} from './components/Assumption';
 


### PR DESCRIPTION
## What

Phase 4 of the earlbear-influenced plan (`.claude/plans/snug-yawning-fox.md`): two components for a post that argues a choice.

- **ComparisonMatrix** — a criteria × options head-to-head as a real accessible `<table>` (proper `<th scope>`). Options are columns, criteria rows; the `chosen` column is highlighted + badged; `yes`/`no`/`partial` render as ● ○ ◐ marks with screen-reader labels; any other string renders as literal text. Scrolls inside its own wrapper on mobile. A build-time gate throws if a cell is keyed to an option id that does not exist.
- **Accordion** — foldable options on native `<details>`/`<summary>` (zero JS, keyboard-accessible). Each item has a `summary`, a React `body` (prose / list / component, **not** a raw-HTML string), an optional `verdict` pill, and an optional `open` default. Chevron respects `prefers-reduced-motion`.

The matrix answers "how do they score"; the accordion answers "why".

## Why

Decision/comparison posts had no prop-driven support — you'd hand-roll a markdown table and stacked `<details>`. This makes the choice scannable and self-validating. Distinct from `OptionGrid`/`DecisionNote`, which show explored **design directions** with a chosen ring + WHY.

## How

Both are themed from design-system tokens (light + dark) and registered in `MDXComponents` (no per-post import). Barrel-exported. Catalog entry added to `upgrade-post`.

## Proof / verification

- ✅ Full `docusaurus build` succeeds; **both render server-side** in `build/handbook/components/structural/decision-kit.html`.
- ✅ The matrix gate **bites**: a cell keyed to a nonexistent option throws; valid matrices pass.
- ✅ Desktop + 390px visual pass: chosen-column green tint + CHOSEN badge + colored marks; accordion verdict pills + chevron rotate + open body. On mobile the matrix **scrolls internally** (Redis column off-screen, scroll thumb visible) rather than squishing — the page does not overflow.
- ✅ ds-tokens + em-dash clean.

Live demo + proof: a new `kind: showcase` page at `/handbook/components/structural/decision-kit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)