### PR TITLE
feat(blog-ui): UseCaseDiagram (UML use-case with build-time legibility gates)

### DIFF
--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -165,6 +165,40 @@ answers "why". HOW:
   chosen ring + WHY (a design specimen). ComparisonMatrix is the feature-by-feature decision
   TABLE. Use the matrix for "which option scores better", OptionGrid for "which mock we picked".
 
+### UseCaseDiagram (UML use-case, built-in legibility gates)
+
+WHAT: a UML use-case diagram as inline SVG. Actors sit OUTSIDE a system boundary; use cases
+are ovals INSIDE; a solid line is an `association`, dashed `«include»`/`«extend»` arrows relate
+use cases. WHEN: a "who uses X and what they do" figure (Mermaid has no real use-case support,
+so this is the only way to author one here). HOW:
+
+```mdx
+<UseCaseDiagram title="Bytes of Purpose" desc="Who works with the blog and what they do."
+  actors={[
+    {id:'author', label:'Author', kind:'internal'},
+    {id:'reader', label:'Reader'},
+    {id:'cron', label:'Scheduled job', kind:'system'},
+  ]}
+  useCases={[
+    {id:'write', label:'Write a post', detail:'Draft in MDX, run the validators.'},
+    {id:'publish', label:'Publish', detail:'Build and deploy.'},
+    {id:'read', label:'Read a post'},
+  ]}
+  links={[
+    {from:'author', to:'write'}, {from:'author', to:'publish'}, {from:'cron', to:'publish'},
+    {from:'reader', to:'read'}, {from:'publish', to:'write', type:'include'},
+  ]}/>
+```
+
+- Registered in `MDXComponents` (no import). Live demo: `/handbook/components/diagrams/use-case`.
+- Actor `kind`: `internal` (a filled mark) + `system` (a gear) pull LEFT; `external` (default,
+  a line person) pulls RIGHT, so lines fan to the nearest edge. The layout is deterministic.
+- TWO build-time gates THROW (fail `make build`): the overlap gate (>25% crossing lines) and the
+  actor line-angle BALANCE gate (an actor whose lines fan lopsidedly, i.e. it sits off-center from
+  its use cases). If a diagram legitimately needs it, pass `allowOverlap` to downgrade both to
+  warnings; better, give each actor use cases that straddle it vertically, reorder, or split.
+- A use case with `detail` opens a click-to-focus modal (Used by / Includes / Extends).
+
 ### Mockup (UX mockups — show what it LOOKS like)
 
 WHAT: a framed, theme-aware wrapper (`browser` / `window` / `phone` / `none` chrome) that

--- a/bytesofpurpose-blog/docs/handbook/components/diagrams/diagrams-use-case.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/diagrams/diagrams-use-case.mdx
@@ -1,0 +1,84 @@
+---
+slug: /components/diagrams/use-case
+usage_pattern:
+  - '<UseCaseDiagram'
+kind: showcase
+title: '🧩 Use-case diagram'
+description: 'A UML use-case diagram as inline SVG: actors outside a system boundary, use cases as ovals inside, with a build-time gate that fails on an unreadable (tangled) layout.'
+authors: [oeid]
+tags: [docusaurus, react, components, diagram, uml]
+draft: false
+---
+
+A UML use-case diagram answers "who uses this system, and what do they do". Actors sit
+outside a system boundary; use cases are ovals inside; a solid line is an association, and
+dashed `«include»` / `«extend»` arrows show how use cases relate. Mermaid has no real
+use-case support, so `UseCaseDiagram` is the way to author one here.
+
+The layout is deterministic and its readability is **enforced at build time**: internal and
+system actors pull to the left, external actors to the right, so association lines fan to the
+nearest edge; the use cases order by a crossing-reducer. Two gates fail the build if the
+result is still unreadable (too many crossing lines, or an actor whose lines fan lopsidedly).
+A use case with `detail` becomes clickable and opens a focus modal listing who uses it and
+what it includes or extends.
+
+<UseCaseDiagram
+  title="Bytes of Purpose"
+  desc="Who works with the blog and what each one does: the author writes, publishes, and reviews; the reader reads and shares; and a scheduled job runs the deploy."
+  actors={[
+    {id: 'reader', label: 'Reader'},
+    {id: 'author', label: 'Author', kind: 'internal'},
+    {id: 'cron', label: 'Scheduled job', kind: 'system'},
+  ]}
+  useCases={[
+    {id: 'read', label: 'Read a post'},
+    {id: 'share', label: 'Share a post', detail: 'Copy a tagged link or post it to LinkedIn.'},
+    {id: 'write', label: 'Write a post', detail: 'Draft in MDX, weave in components, run the validators.'},
+    {id: 'review', label: 'Review the site', detail: 'A reader-experience and mobile pass before shipping.'},
+    {id: 'publish', label: 'Publish', detail: 'Build the site and deploy it to GitHub Pages.'},
+  ]}
+  links={[
+    {from: 'reader', to: 'read'},
+    {from: 'reader', to: 'share'},
+    {from: 'author', to: 'write'},
+    {from: 'author', to: 'review'},
+    {from: 'author', to: 'publish'},
+    {from: 'cron', to: 'publish'},
+    {from: 'publish', to: 'write', type: 'include'},
+    {from: 'share', to: 'read', type: 'extend'},
+  ]}
+/>
+
+```mdx
+<UseCaseDiagram
+  title="Bytes of Purpose"
+  desc="Who works with the blog and what each one does."
+  actors={[
+    {id: 'author', label: 'Author', kind: 'internal'},
+    {id: 'reader', label: 'Reader'},
+    {id: 'cron', label: 'Scheduled job', kind: 'system'},
+  ]}
+  useCases={[
+    {id: 'write', label: 'Write a post', detail: 'Draft in MDX, run the validators.'},
+    {id: 'publish', label: 'Publish', detail: 'Build and deploy.'},
+    {id: 'read', label: 'Read a post'},
+    {id: 'share', label: 'Share a post'},
+  ]}
+  links={[
+    {from: 'author', to: 'write'},
+    {from: 'author', to: 'publish'},
+    {from: 'cron', to: 'publish'},
+    {from: 'reader', to: 'read'},
+    {from: 'reader', to: 'share'},
+    {from: 'publish', to: 'write', type: 'include'},
+    {from: 'share', to: 'read', type: 'extend'},
+  ]}
+/>
+```
+
+An `internal` actor pulls left (rendered with a filled mark), a `system` actor also pulls
+left (a gear), and an `external` actor pulls right (a line person). If a diagram gets too
+tangled to read, the build fails with an actionable message; pass `allowOverlap` to ship it
+as a warning instead, but prefer reordering or splitting.
+
+<UsedIn slug="/components/diagrams/use-case" />

--- a/bytesofpurpose-blog/src/theme/MDXComponents.tsx
+++ b/bytesofpurpose-blog/src/theme/MDXComponents.tsx
@@ -52,6 +52,7 @@ import {
   FlowDiagram,
   ComparisonMatrix,
   Accordion,
+  UseCaseDiagram,
   Mockup,
   Walkthrough,
   Assumption,
@@ -139,6 +140,14 @@ export default {
   // ComparisonMatrix: the accordion carries the narrative, the matrix the head-to-head. Use
   // <Accordion label=... items={[{summary, body, verdict?, open?}]}/> on a decision post.
   Accordion,
+  // UseCaseDiagram: a UML use-case diagram (actors outside a system boundary, use cases as ovals
+  // inside, solid association lines + dashed «include»/«extend»). A deterministic two-sided layout
+  // (internal/system actors pull left, external pull right) with barycenter crossing reduction; two
+  // build-time gates fail on an unreadable layout (too many crossing lines, or a lopsided actor
+  // line-fan). A use case with `detail` opens a click-to-focus modal. Use <UseCaseDiagram title=...
+  // actors={[]} useCases={[]} links={[]}/> for a "who uses X and what they do" figure. (Mermaid has
+  // no real use-case support, so this is the only way to author one here.)
+  UseCaseDiagram,
   // UX mockups: a framed, theme-aware wrapper that turns live HTML into a UI mockup
   // (browser/window/phone chrome) — shows what a design would LOOK like.
   Mockup,

--- a/packages/blog-ui/src/components/UseCaseDiagram/actors.tsx
+++ b/packages/blog-ui/src/components/UseCaseDiagram/actors.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+/**
+ * Actor glyphs for <UseCaseDiagram>.
+ *
+ * UML draws actors as stick figures outside the system boundary. We keep that
+ * PLACEMENT but swap the generic figure for cleaner marks, each drawn to a
+ * box x box square whose top-left is the local origin (0,0) so the caller can
+ * position it with a <g transform>. All strokes/fills use currentColor so the
+ * wrapping <g>'s color: controls the tint.
+ *
+ *   internal -> a filled user glyph (head + shoulders), for our own operators
+ *   external -> a line "person" (head + shoulders arc), for customers
+ *   system   -> a line gear, for automated / non-human actors (jobs, schedulers)
+ *
+ * Returning JSX (not an HTML string) keeps this framework-native: no
+ * dangerouslySetInnerHTML, no build-time file read.
+ */
+export type ActorKind = 'internal' | 'external' | 'system';
+
+export function ActorGlyph({kind, box}: {kind: ActorKind; box: number}): React.JSX.Element {
+  const c = box / 2;
+
+  if (kind === 'system') {
+    // A line gear: outer ring + eight teeth + hub.
+    const r = box * 0.3;
+    const sw = box * 0.05;
+    const teeth = Array.from({length: 8}, (_, i) => {
+      const a = (i * Math.PI) / 4;
+      return {
+        x1: c + Math.cos(a) * r,
+        y1: c + Math.sin(a) * r,
+        x2: c + Math.cos(a) * (r + box * 0.1),
+        y2: c + Math.sin(a) * (r + box * 0.1),
+      };
+    });
+    return (
+      <g fill="none" stroke="currentColor" strokeWidth={sw} strokeLinecap="round">
+        <circle cx={c} cy={c} r={r} />
+        {teeth.map((t, i) => (
+          <line key={i} x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} />
+        ))}
+        <circle cx={c} cy={c} r={box * 0.1} />
+      </g>
+    );
+  }
+
+  const headR = box * 0.16;
+  const headCy = box * 0.3;
+
+  if (kind === 'internal') {
+    // A FILLED user glyph, to read as "us" (distinct from the line customer).
+    return (
+      <g fill="currentColor" stroke="none">
+        <circle cx={c} cy={headCy} r={headR} />
+        <path
+          d={`M ${box * 0.18} ${box * 0.86} Q ${c} ${box * 0.5}, ${box * 0.82} ${box * 0.86} Z`}
+        />
+      </g>
+    );
+  }
+
+  // external -> line person: head circle + shoulders arc.
+  const sw = box * 0.06;
+  return (
+    <g fill="none" stroke="currentColor" strokeWidth={sw} strokeLinecap="round">
+      <circle cx={c} cy={headCy} r={headR} />
+      <path
+        d={`M ${box * 0.2} ${box * 0.82} Q ${c} ${box * 0.48}, ${box * 0.8} ${box * 0.82}`}
+      />
+    </g>
+  );
+}

--- a/packages/blog-ui/src/components/UseCaseDiagram/index.tsx
+++ b/packages/blog-ui/src/components/UseCaseDiagram/index.tsx
@@ -1,0 +1,304 @@
+import React, {CSSProperties, useCallback, useEffect, useRef, useState} from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+import {ActorGlyph} from './actors';
+import {
+  computeUseCaseLayout,
+  type Actor,
+  type UseCase,
+  type Link,
+  type ActorKind,
+  type UseCaseDetail,
+} from './layout';
+
+export type {Actor, UseCase, Link, ActorKind};
+
+/**
+ * UseCaseDiagram: a UML use-case diagram rendered as one inline SVG. Actors sit outside
+ * the system boundary, use cases are ovals inside, associations are solid lines, and
+ * <<include>> / <<extend>> are dashed arrows between use cases.
+ *
+ * Layout is deterministic and readability is ENFORCED at build time: actors split by side
+ * (internal/system pull left, external pull right) so lines fan to the nearest edge, use
+ * cases order by a barycenter crossing-reducer, and two gates fail the build if the result
+ * is unreadable (too many crossing lines, or an actor whose line fan is lopsided). A node
+ * with detail (or any relationship) becomes clickable and opens a focus modal.
+ *
+ * Usage in MDX:
+ *
+ *   <UseCaseDiagram
+ *     title="Blog"
+ *     desc="Who uses the blog and what they do."
+ *     actors={[
+ *       {id: 'author', label: 'Author', kind: 'internal'},
+ *       {id: 'reader', label: 'Reader'},
+ *       {id: 'cron', label: 'Scheduler', kind: 'system'},
+ *     ]}
+ *     useCases={[
+ *       {id: 'write', label: 'Write a post'},
+ *       {id: 'read', label: 'Read a post'},
+ *       {id: 'publish', label: 'Publish', detail: 'Build and deploy.'},
+ *     ]}
+ *     links={[
+ *       {from: 'author', to: 'write'},
+ *       {from: 'author', to: 'publish'},
+ *       {from: 'reader', to: 'read'},
+ *       {from: 'cron', to: 'publish'},
+ *       {from: 'publish', to: 'write', type: 'include'},
+ *     ]}
+ *   />
+ */
+export interface UseCaseDiagramProps {
+  title: string;
+  desc?: string;
+  actors: Actor[];
+  useCases: UseCase[];
+  links: Link[];
+  /** Downgrade the build-time overlap + balance gates to console warnings. */
+  allowOverlap?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const REL_ROWS: Array<{key: keyof UseCaseDetail; label: string}> = [
+  {key: 'usedBy', label: 'Used by'},
+  {key: 'includes', label: 'Includes'},
+  {key: 'includedBy', label: 'Included by'},
+  {key: 'extends', label: 'Extends'},
+  {key: 'extendedBy', label: 'Extended by'},
+];
+
+const UseCaseDiagram: React.FC<UseCaseDiagramProps> = ({
+  title,
+  desc,
+  actors,
+  useCases,
+  links,
+  allowOverlap = false,
+  className,
+  style,
+}) => {
+  // Throws (fails the SSG build) on a dangling link or an unreadable layout.
+  const layout = computeUseCaseLayout({title, desc, actors, useCases, links, allowOverlap});
+
+  useEffect(() => {
+    for (const w of layout.warnings) console.warn(`[usecase-diagram] warning: ${w}`);
+  }, [layout.warnings]);
+
+  const {
+    salt,
+    svgW,
+    svgH,
+    boundaryX,
+    boundaryY,
+    boundaryW,
+    boundaryH,
+    ovals,
+    actors: placedActors,
+    links: rLinks,
+    details,
+    interactive,
+    OVAL_W,
+    OVAL_H,
+    ACTOR_BOX,
+  } = layout;
+  const titleId = `${salt}-title`;
+  const descId = `${salt}-desc`;
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [active, setActive] = useState<UseCaseDetail | null>(null);
+  const openUc = useCallback(
+    (id: string) => {
+      const d = details.find((x) => x.id === id);
+      if (d) setActive(d);
+    },
+    [details],
+  );
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (active && !dlg.open && dlg.showModal) dlg.showModal();
+    if (!active && dlg.open) dlg.close();
+  }, [active]);
+
+  return (
+    <figure className={clsx(styles.ucd, className)} style={style}>
+      <div className={styles.scroll}>
+        <svg
+          viewBox={`0 0 ${svgW} ${svgH}`}
+          role="img"
+          aria-labelledby={desc ? `${titleId} ${descId}` : titleId}
+          preserveAspectRatio="xMidYMid meet"
+        >
+          <title id={titleId}>{title}</title>
+          {desc && <desc id={descId}>{desc}</desc>}
+
+          <defs>
+            {ovals.map((o) => {
+              const c1 = (o.gi % 8) + 1;
+              const c2 = ((o.gi + 3) % 8) + 1;
+              return (
+                <linearGradient key={o.gi} id={`${salt}-g${o.gi}`} x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop
+                    offset="0%"
+                    stopColor={`color-mix(in oklab, var(--bopucd-data-${c1}) 22%, var(--bopucd-surface))`}
+                  />
+                  <stop
+                    offset="100%"
+                    stopColor={`color-mix(in oklab, var(--bopucd-data-${c2}) 30%, var(--bopucd-surface))`}
+                  />
+                </linearGradient>
+              );
+            })}
+            <marker
+              id={`${salt}-arrow`}
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 1 L 9 5 L 0 9" fill="none" stroke="context-stroke" strokeWidth="1.5" />
+            </marker>
+          </defs>
+
+          <g className={styles.boundary}>
+            <rect x={boundaryX} y={boundaryY} width={boundaryW} height={boundaryH} rx="14" />
+            <text x={boundaryX + 18} y={boundaryY + 24} className={styles.boundaryLabel}>
+              {title}
+            </text>
+          </g>
+
+          <g className={styles.linksG}>
+            {rLinks.map((l, i) => (
+              <g key={i} className={clsx(styles.link, styles[`link-${l.type}`])}>
+                <line
+                  x1={l.x1}
+                  y1={l.y1}
+                  x2={l.x2}
+                  y2={l.y2}
+                  markerEnd={l.type === 'association' ? undefined : `url(#${salt}-arrow)`}
+                  style={{'--len': l.len.toFixed(1), '--i': i} as CSSProperties}
+                />
+                {l.type !== 'association' && (
+                  <text x={l.mx} y={l.my - 4} className={styles.stereotype}>
+                    {l.type === 'include' ? '«include»' : '«extend»'}
+                  </text>
+                )}
+              </g>
+            ))}
+          </g>
+
+          <g className={styles.usecases}>
+            {ovals.map((o) => {
+              const isBtn = interactive;
+              const oval = (
+                <>
+                  <ellipse
+                    cx={o.cx}
+                    cy={o.cy}
+                    rx={OVAL_W / 2}
+                    ry={OVAL_H / 2}
+                    fill={`url(#${salt}-g${o.gi})`}
+                  />
+                  <text x={o.cx} y={o.cy} className={styles.ucLabel}>
+                    {o.uc.label}
+                  </text>
+                </>
+              );
+              return isBtn ? (
+                <g
+                  key={o.uc.id}
+                  className={clsx(styles.oval, styles.ovalInteractive)}
+                  style={{'--i': o.gi} as CSSProperties}
+                  role="button"
+                  tabIndex={0}
+                  aria-haspopup="dialog"
+                  onClick={() => openUc(o.uc.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      openUc(o.uc.id);
+                    }
+                  }}
+                >
+                  {oval}
+                </g>
+              ) : (
+                <g key={o.uc.id} className={styles.oval} style={{'--i': o.gi} as CSSProperties}>
+                  {oval}
+                </g>
+              );
+            })}
+          </g>
+
+          <g className={styles.actorsG}>
+            {placedActors.map((p) => {
+              const gx = p.cx - ACTOR_BOX / 2;
+              const gy = p.cy - ACTOR_BOX / 2;
+              return (
+                <g key={p.actor.id} className={clsx(styles.actor, styles[`actor-${p.kind}`])}>
+                  <g transform={`translate(${gx} ${gy})`}>
+                    <ActorGlyph kind={p.kind} box={ACTOR_BOX} />
+                  </g>
+                  <text x={p.cx} y={p.cy + ACTOR_BOX / 2 + 16} className={styles.actorLabel}>
+                    {p.actor.label}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+      {desc && <figcaption className={styles.caption}>{desc}</figcaption>}
+
+      {interactive && (
+        <dialog
+          ref={dialogRef}
+          className={styles.modal}
+          aria-labelledby={`${salt}-modal-title`}
+          onClose={() => setActive(null)}
+          onClick={(e) => {
+            if (e.target === dialogRef.current) setActive(null);
+          }}
+        >
+          <div className={styles.modalInner}>
+            <button
+              type="button"
+              className={styles.modalClose}
+              aria-label="Close"
+              onClick={() => setActive(null)}
+            >
+              &times;
+            </button>
+            <p className={styles.modalEyebrow}>{title} use case</p>
+            <h3 id={`${salt}-modal-title`} className={styles.modalTitle}>
+              {active?.label}
+            </h3>
+            {active?.detail && <p className={styles.modalDetail}>{active.detail}</p>}
+            <dl className={styles.modalRels}>
+              {active &&
+                REL_ROWS.map(({key, label}) => {
+                  const items = active[key] as string[];
+                  if (!items || items.length === 0) return null;
+                  return (
+                    <React.Fragment key={key}>
+                      <dt>{label}</dt>
+                      <dd>
+                        {items.map((s, i) => (
+                          <span key={i}>{s}</span>
+                        ))}
+                      </dd>
+                    </React.Fragment>
+                  );
+                })}
+            </dl>
+          </div>
+        </dialog>
+      )}
+    </figure>
+  );
+};
+
+export default UseCaseDiagram;

--- a/packages/blog-ui/src/components/UseCaseDiagram/layout.ts
+++ b/packages/blog-ui/src/components/UseCaseDiagram/layout.ts
@@ -1,0 +1,435 @@
+// UseCaseDiagram layout engine: pure, deterministic geometry + two quality gates.
+//
+// Framework-agnostic (no React, no DOM). Given actors / useCases / links it returns
+// fully-placed ovals, actors, and rendered links, throwing on a broken spec (a dangling
+// link) or an unreadable layout (too many crossing lines, or an actor whose line fan is
+// lopsided). Ported from the earlbear-blog UseCaseDiagram.astro build-time script: the
+// side-pull placement, barycenter crossing reduction, the segment-crossing overlap gate,
+// and the actor line-angle balance gate are copied largely verbatim (pure arithmetic,
+// no browser needed).
+
+import type {ActorKind} from './actors';
+
+export type {ActorKind};
+
+export interface Actor {
+  id: string;
+  label: string;
+  kind?: ActorKind; // default 'external'
+}
+export interface UseCase {
+  id: string;
+  label: string;
+  /** Optional longer detail, surfaced in the click-to-focus modal. */
+  detail?: string;
+}
+export interface Link {
+  from: string; // actor id or use-case id
+  to: string; // use-case id
+  type?: 'association' | 'include' | 'extend'; // default association
+}
+
+export interface PlacedOval {
+  uc: UseCase;
+  gi: number;
+  cx: number;
+  cy: number;
+}
+export interface PlacedActor {
+  actor: Actor;
+  cx: number;
+  cy: number;
+  kind: ActorKind;
+  side: 'left' | 'right';
+}
+export interface RenderedLink {
+  type: 'association' | 'include' | 'extend';
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  mx: number;
+  my: number;
+  len: number;
+  fromActor?: string;
+}
+export interface UseCaseDetail {
+  id: string;
+  label: string;
+  detail: string;
+  usedBy: string[];
+  includes: string[];
+  includedBy: string[];
+  extends: string[];
+  extendedBy: string[];
+}
+
+export interface UseCaseLayout {
+  salt: string;
+  svgW: number;
+  svgH: number;
+  boundaryX: number;
+  boundaryY: number;
+  boundaryW: number;
+  boundaryH: number;
+  ovals: PlacedOval[];
+  actors: PlacedActor[];
+  links: RenderedLink[];
+  details: UseCaseDetail[];
+  interactive: boolean;
+  warnings: string[];
+  OVAL_W: number;
+  OVAL_H: number;
+  ACTOR_BOX: number;
+}
+
+// ---- Geometry constants ---------------------------------------------------
+const OVAL_W = 200;
+const OVAL_H = 74;
+const COL_GAP = 40;
+const ROW_GAP = 56;
+const ACTOR_BOX = 72;
+const ACTOR_GAP = 48;
+const PAD = 28;
+const ACTOR_LANE = 150;
+const LABEL_H = 26;
+const OVERLAP_MIN_CLEAR = 0.75;
+
+function ovalEdge(cx: number, cy: number, tx: number, ty: number) {
+  const rx = OVAL_W / 2;
+  const ry = OVAL_H / 2;
+  const dx = tx - cx;
+  const dy = ty - cy;
+  const denom = Math.hypot(dx / rx, dy / ry) || 1;
+  return {x: cx + dx / rx / denom, y: cy + dy / ry / denom};
+}
+
+function segmentsCross(a: RenderedLink, b: RenderedLink): boolean {
+  const o = (px: number, py: number, qx: number, qy: number, rx: number, ry: number) =>
+    Math.sign((qy - py) * (rx - qx) - (qx - px) * (ry - qy));
+  const near = (p: number, q: number) => Math.abs(p - q) < 0.5;
+  const shareEndpoint =
+    (near(a.x1, b.x1) && near(a.y1, b.y1)) ||
+    (near(a.x1, b.x2) && near(a.y1, b.y2)) ||
+    (near(a.x2, b.x1) && near(a.y2, b.y1)) ||
+    (near(a.x2, b.x2) && near(a.y2, b.y2));
+  if (shareEndpoint) return false;
+  const o1 = o(a.x1, a.y1, a.x2, a.y2, b.x1, b.y1);
+  const o2 = o(a.x1, a.y1, a.x2, a.y2, b.x2, b.y2);
+  const o3 = o(b.x1, b.y1, b.x2, b.y2, a.x1, a.y1);
+  const o4 = o(b.x1, b.y1, b.x2, b.y2, a.x2, a.y2);
+  return o1 !== o2 && o3 !== o4;
+}
+
+export interface UseCaseInput {
+  title: string;
+  desc?: string;
+  actors: Actor[];
+  useCases: UseCase[];
+  links: Link[];
+  allowOverlap: boolean;
+}
+
+export function computeUseCaseLayout(input: UseCaseInput): UseCaseLayout {
+  const {title, desc, actors, useCases, links, allowOverlap} = input;
+  const salt = title.toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 8) || 'ucd';
+  const warnings: string[] = [];
+
+  // ---- Content-quality gates ----
+  const ids = new Set([...actors.map((a) => a.id), ...useCases.map((u) => u.id)]);
+  const dangling = links.filter((l) => !ids.has(l.from) || !ids.has(l.to));
+  if (dangling.length) {
+    const bad = dangling
+      .map(
+        (l) =>
+          `${!ids.has(l.from) ? `"${l.from}"` : l.from} -> ${
+            !ids.has(l.to) ? `"${l.to}"` : l.to
+          }`,
+      )
+      .join(', ');
+    throw new Error(
+      `UseCaseDiagram "${title}": link references an id that doesn't exist: ${bad}. ` +
+        `Check the from/to against your actors and useCases.`,
+    );
+  }
+  if (!allowOverlap) {
+    if (!desc || !desc.trim()) {
+      warnings.push(
+        `"${title}" has no desc: add desc= so screen readers get an accessible description.`,
+      );
+    }
+    const touched = new Set(links.flatMap((l) => [l.from, l.to]));
+    for (const a of actors) {
+      if (!touched.has(a.id))
+        warnings.push(`"${title}" actor "${a.id}" (${a.label}) has no associations (floating).`);
+    }
+    for (const u of useCases) {
+      if (!touched.has(u.id))
+        warnings.push(`"${title}" use case "${u.id}" (${u.label}) has no links (floating).`);
+      if (u.label.length > 26)
+        warnings.push(`"${title}" use-case label "${u.label}" is long and may clip its oval.`);
+    }
+  }
+
+  // ---- Split actors by side ----
+  const leftActors = actors.filter((a) => (a.kind ?? 'external') !== 'external');
+  const rightActors = actors.filter((a) => (a.kind ?? 'external') === 'external');
+  const leftLane = leftActors.length ? ACTOR_LANE : 0;
+  const rightLane = rightActors.length ? ACTOR_LANE : 0;
+
+  const leftActorIds = new Set(leftActors.map((a) => a.id));
+  const rightActorIds = new Set(rightActors.map((a) => a.id));
+  const ucLeftTouch = new Map<string, number>();
+  const ucRightTouch = new Map<string, number>();
+  for (const uc of useCases) {
+    ucLeftTouch.set(uc.id, 0);
+    ucRightTouch.set(uc.id, 0);
+  }
+  for (const link of links) {
+    if (!ucLeftTouch.has(link.to)) continue;
+    if (leftActorIds.has(link.from))
+      ucLeftTouch.set(link.to, (ucLeftTouch.get(link.to) ?? 0) + 1);
+    else if (rightActorIds.has(link.from))
+      ucRightTouch.set(link.to, (ucRightTouch.get(link.to) ?? 0) + 1);
+  }
+  const pullsRight = (id: string) => (ucRightTouch.get(id) ?? 0) > (ucLeftTouch.get(id) ?? 0);
+
+  const rightUCsRaw = rightActors.length ? useCases.filter((u) => pullsRight(u.id)) : [];
+  const twoCol = rightUCsRaw.length > 0;
+  let leftUCs = twoCol ? useCases.filter((u) => !pullsRight(u.id)) : useCases;
+  let rightUCs: UseCase[] = rightUCsRaw;
+
+  // ---- Barycenter ordering within each column ----
+  const actorOrder = new Map<string, number>();
+  actors.forEach((a, i) => actorOrder.set(a.id, i));
+  function barycenter(uc: {id: string}): number {
+    const ys: number[] = [];
+    for (const link of links)
+      if (link.to === uc.id && actorOrder.has(link.from)) ys.push(actorOrder.get(link.from)!);
+    return ys.length ? ys.reduce((s, y) => s + y, 0) / ys.length : Number.MAX_SAFE_INTEGER;
+  }
+  const byBarycenter = (a: {id: string}, b: {id: string}) => barycenter(a) - barycenter(b);
+  leftUCs = [...leftUCs].sort(byBarycenter);
+  rightUCs = [...rightUCs].sort(byBarycenter);
+  const singleCol = [...useCases].sort(byBarycenter);
+  const perCol = twoCol ? Math.max(leftUCs.length, rightUCs.length) : useCases.length;
+
+  const boundaryW = PAD * 2 + (twoCol ? OVAL_W * 2 + ROW_GAP : OVAL_W);
+  const boundaryH = PAD * 2 + perCol * OVAL_H + (perCol - 1) * COL_GAP + 30;
+
+  const ucPos = new Map<string, {cx: number; cy: number}>();
+  const boundaryX = leftLane;
+  const boundaryY = 10;
+  function placeColumn(col: UseCase[], colIndex: number) {
+    col.forEach((uc, row) => {
+      const cx = boundaryX + PAD + OVAL_W / 2 + colIndex * (OVAL_W + ROW_GAP);
+      const cy = boundaryY + 30 + PAD + OVAL_H / 2 + row * (OVAL_H + COL_GAP);
+      ucPos.set(uc.id, {cx, cy});
+    });
+  }
+  if (twoCol) {
+    placeColumn(leftUCs, 0);
+    placeColumn(rightUCs, 1);
+  } else {
+    placeColumn(singleCol, 0);
+  }
+
+  // ---- Place actors at the barycenter of their use cases ----
+  const actorPosMap = new Map<
+    string,
+    {cx: number; cy: number; kind: ActorKind; side: 'left' | 'right'}
+  >();
+  function actorBarycenterY(id: string): number {
+    const ys: number[] = [];
+    for (const link of links)
+      if (link.from === id && ucPos.has(link.to)) ys.push(ucPos.get(link.to)!.cy);
+    return ys.length ? ys.reduce((s, y) => s + y, 0) / ys.length : boundaryY + boundaryH / 2;
+  }
+  function placeLane(lane: Actor[], side: 'left' | 'right', laneX: number) {
+    const cx = laneX + ACTOR_LANE / 2;
+    const desired = lane
+      .map((a) => ({a, y: actorBarycenterY(a.id)}))
+      .sort((p, q) => p.y - q.y);
+    const MIN_GAP = ACTOR_BOX + ACTOR_GAP;
+    const top = boundaryY + ACTOR_BOX / 2;
+    const bottom = boundaryY + boundaryH - ACTOR_BOX / 2 - LABEL_H;
+    let prev = -Infinity;
+    for (const d of desired) {
+      const y = Math.max(d.y, prev + MIN_GAP);
+      prev = y;
+      actorPosMap.set(d.a.id, {cx, cy: y, kind: d.a.kind ?? 'external', side});
+    }
+    const overshoot = prev - bottom;
+    if (overshoot > 0) {
+      for (const d of desired) {
+        const p = actorPosMap.get(d.a.id)!;
+        p.cy = Math.max(top, p.cy - overshoot);
+      }
+    }
+  }
+  placeLane(leftActors, 'left', 0);
+  placeLane(rightActors, 'right', boundaryX + boundaryW);
+
+  const svgW = boundaryX + boundaryW + rightLane + 20;
+  const svgH = boundaryY + boundaryH + LABEL_H + 20;
+
+  // ---- Link geometry ----
+  function anchor(id: string) {
+    const a = actorPosMap.get(id);
+    if (a) return {x: a.cx, y: a.cy, isActor: true, side: a.side};
+    const u = ucPos.get(id);
+    if (u) return {x: u.cx, y: u.cy, isActor: false as const, side: undefined};
+    return null;
+  }
+  const rendered: RenderedLink[] = [];
+  for (const link of links) {
+    const from = anchor(link.from);
+    const to = anchor(link.to);
+    if (!from || !to) continue;
+    const type = link.type ?? 'association';
+    let sx = from.x;
+    let sy = from.y;
+    if (from.isActor) {
+      const edge = ACTOR_BOX / 2 - 6;
+      sx = from.side === 'right' ? from.x - edge : from.x + edge;
+    } else {
+      const e = ovalEdge(from.x, from.y, to.x, to.y);
+      sx = e.x;
+      sy = e.y;
+    }
+    const e2 = ovalEdge(to.x, to.y, sx, sy);
+    const len = Math.hypot(e2.x - sx, e2.y - sy);
+    rendered.push({
+      type,
+      x1: sx,
+      y1: sy,
+      x2: e2.x,
+      y2: e2.y,
+      mx: (sx + e2.x) / 2,
+      my: (sy + e2.y) / 2,
+      len,
+      fromActor: from.isActor ? link.from : undefined,
+    });
+  }
+
+  // ---- Overlap gate ----
+  const crossed = new Set<number>();
+  for (let i = 0; i < rendered.length; i++) {
+    for (let j = i + 1; j < rendered.length; j++) {
+      if (segmentsCross(rendered[i], rendered[j])) {
+        crossed.add(i);
+        crossed.add(j);
+      }
+    }
+  }
+  const clearFraction = rendered.length === 0 ? 1 : 1 - crossed.size / rendered.length;
+  if (clearFraction < OVERLAP_MIN_CLEAR) {
+    const msg =
+      `UseCaseDiagram "${title}": only ${Math.round(clearFraction * 100)}% of association ` +
+      `lines are crossing-free (need >=${OVERLAP_MIN_CLEAR * 100}%). Put each use case near ` +
+      `the actors that use it (internal/system pull left, external pull right), split a busy ` +
+      `diagram, or remove incidental links.`;
+    if (allowOverlap) warnings.push(`(allowOverlap set) ${msg}`);
+    else throw new Error(`${msg} To ship anyway, pass allowOverlap.`);
+  }
+
+  // ---- Actor line-angle balance gate ----
+  for (const actor of actors) {
+    const lines = rendered.filter((l) => l.fromActor === actor.id);
+    if (lines.length < 2) continue;
+    let up = 0;
+    let down = 0;
+    let horiz = 0;
+    for (const l of lines) {
+      const dy = l.y2 - l.y1;
+      if (dy < -1) up++;
+      else if (dy > 1) down++;
+      if (Math.abs(l.y2 - l.y1) <= Math.abs(l.x2 - l.x1)) horiz++;
+    }
+    const imbalance = Math.abs(up - down);
+    const mostlyHorizontal = horiz / lines.length >= 0.5;
+    if (imbalance > 1 || !mostlyHorizontal) {
+      const msg =
+        `UseCaseDiagram "${title}": actor "${actor.label}" has an unbalanced line fan ` +
+        `(${up} up, ${down} down, ${horiz}/${lines.length} near-horizontal). Actors should ` +
+        `sit at the vertical center of the use cases they touch. Reorder the use cases, give ` +
+        `the diagram more vertical room, or split it.`;
+      if (allowOverlap) warnings.push(`(allowOverlap set) ${msg}`);
+      else throw new Error(`${msg} To ship anyway, pass allowOverlap.`);
+    }
+  }
+
+  // ---- Modal / relationship data ----
+  const actorLabel = new Map(actors.map((a) => [a.id, a.label]));
+  const ucLabel = new Map(useCases.map((u) => [u.id, u.label]));
+  const details: UseCaseDetail[] = useCases.map((uc) => {
+    const usedBy = links
+      .filter(
+        (l) => (l.type ?? 'association') === 'association' && l.to === uc.id && actorLabel.has(l.from),
+      )
+      .map((l) => actorLabel.get(l.from)!);
+    const includes = links
+      .filter((l) => l.type === 'include' && l.from === uc.id)
+      .map((l) => ucLabel.get(l.to)!)
+      .filter(Boolean);
+    const includedBy = links
+      .filter((l) => l.type === 'include' && l.to === uc.id)
+      .map((l) => ucLabel.get(l.from)!)
+      .filter(Boolean);
+    const extendsArr = links
+      .filter((l) => l.type === 'extend' && l.from === uc.id)
+      .map((l) => ucLabel.get(l.to)!)
+      .filter(Boolean);
+    const extendedBy = links
+      .filter((l) => l.type === 'extend' && l.to === uc.id)
+      .map((l) => ucLabel.get(l.from)!)
+      .filter(Boolean);
+    return {
+      id: uc.id,
+      label: uc.label,
+      detail: uc.detail ?? '',
+      usedBy,
+      includes,
+      includedBy,
+      extends: extendsArr,
+      extendedBy,
+    };
+  });
+  const interactive = details.some(
+    (d) =>
+      d.detail ||
+      d.usedBy.length ||
+      d.includes.length ||
+      d.includedBy.length ||
+      d.extends.length ||
+      d.extendedBy.length,
+  );
+
+  const ovals: PlacedOval[] = useCases.map((uc, i) => {
+    const p = ucPos.get(uc.id)!;
+    return {uc, gi: i, cx: p.cx, cy: p.cy};
+  });
+  const placedActors: PlacedActor[] = actors.map((a) => {
+    const p = actorPosMap.get(a.id)!;
+    return {actor: a, cx: p.cx, cy: p.cy, kind: p.kind, side: p.side};
+  });
+
+  return {
+    salt,
+    svgW,
+    svgH,
+    boundaryX,
+    boundaryY,
+    boundaryW,
+    boundaryH,
+    ovals,
+    actors: placedActors,
+    links: rendered,
+    details,
+    interactive,
+    warnings,
+    OVAL_W,
+    OVAL_H,
+    ACTOR_BOX,
+  };
+}

--- a/packages/blog-ui/src/components/UseCaseDiagram/styles.module.css
+++ b/packages/blog-ui/src/components/UseCaseDiagram/styles.module.css
@@ -1,0 +1,244 @@
+/* UseCaseDiagram: inline-SVG UML use-case figure. Themed from the blog's design-system
+   tokens so light and dark work with no extra wiring. The --bopucd-* vars are the local
+   contract the oval gradients read; they alias real theme tokens. */
+
+.ucd {
+  --bopucd-data-1: var(--brand-green);
+  --bopucd-data-2: var(--tea-mint);
+  --bopucd-data-3: var(--tea-green);
+  --bopucd-data-4: var(--tea-pink);
+  --bopucd-data-5: #cfe3ff;
+  --bopucd-data-6: #ffe6b0;
+  --bopucd-data-7: #e3d1ff;
+  --bopucd-data-8: #bfe7d6;
+  --bopucd-surface: var(--ifm-background-surface-color, #f4f6f5);
+
+  margin: var(--space-8, 3.5rem) 0;
+}
+
+.scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.ucd svg {
+  width: 100%;
+  height: auto;
+  min-width: 320px;
+  display: block;
+}
+
+/* System boundary */
+.boundary rect {
+  fill: var(--ifm-background-color, #eef1ef);
+  stroke: var(--ifm-color-emphasis-300, #cbd2ce);
+  stroke-width: 1.5;
+}
+.boundaryLabel {
+  fill: var(--ifm-color-content-secondary, #5b625e);
+  font-family: var(--font-sans-body, system-ui);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Use-case ovals */
+.oval ellipse {
+  stroke: var(--ifm-color-emphasis-300, #cbd2ce);
+  stroke-width: 1;
+}
+.ucLabel {
+  fill: var(--ifm-heading-color, #14201a);
+  font-family: var(--font-sans-body, system-ui);
+  font-size: 15px;
+  font-weight: 500;
+  text-anchor: middle;
+  dominant-baseline: central;
+}
+
+/* Actors */
+.actor-internal {
+  color: var(--ifm-color-primary);
+}
+.actor-external,
+.actor-system {
+  color: var(--ifm-color-content-secondary, #5b625e);
+}
+.actorLabel {
+  fill: var(--ifm-color-content-secondary, #5b625e);
+  font-family: var(--font-sans-body, system-ui);
+  font-size: 13px;
+  font-weight: 500;
+  text-anchor: middle;
+}
+
+/* Links: solid association, dashed include/extend. */
+.link line {
+  stroke: var(--ifm-color-emphasis-500, #8a938e);
+  stroke-width: 1.5;
+  fill: none;
+}
+.link-include line,
+.link-extend line {
+  stroke: var(--ifm-color-content-secondary, #5b625e);
+  stroke-dasharray: 5 4;
+}
+.stereotype {
+  fill: var(--ifm-color-content-secondary, #5b625e);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  text-anchor: middle;
+}
+
+/* Motion: association lines draw in, everything else fades in. */
+@keyframes bopucd-draw {
+  from {
+    stroke-dashoffset: var(--len);
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes bopucd-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.link-association line {
+  stroke-dasharray: var(--len);
+  stroke-dashoffset: var(--len);
+  animation: bopucd-draw 480ms var(--ease-out, ease-out) forwards;
+  animation-delay: calc(var(--i, 0) * 90ms);
+}
+.link-include line,
+.link-extend line,
+.stereotype,
+.actor,
+.oval {
+  animation: bopucd-fade 320ms var(--ease-out, ease-out) both;
+  animation-delay: calc(var(--i, 0) * 60ms + 120ms);
+}
+@media (prefers-reduced-motion: reduce) {
+  .link-association line {
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+    animation: none;
+  }
+  .link-include line,
+  .link-extend line,
+  .stereotype,
+  .actor,
+  .oval {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+.caption {
+  margin-top: var(--space-3, 0.75rem);
+  font-size: var(--text-caption, 0.85rem);
+  color: var(--ifm-color-content-secondary, #5b625e);
+  text-align: center;
+}
+
+/* Interactive ovals + focus modal (mirrors the FlowDiagram modal). */
+.ovalInteractive {
+  cursor: pointer;
+}
+.ovalInteractive ellipse {
+  transition: stroke var(--duration-fast, 0.12s) var(--ease-standard, ease);
+}
+.ovalInteractive:hover ellipse,
+.ovalInteractive:focus-visible ellipse {
+  stroke: var(--ifm-color-primary);
+  stroke-width: 2;
+}
+.ovalInteractive:focus-visible {
+  outline: none;
+}
+
+.modal {
+  border: 1px solid var(--ifm-color-emphasis-300, #cbd2ce);
+  border-radius: var(--radius-lg, 14px);
+  padding: 0;
+  max-width: min(440px, 92vw);
+  width: 100%;
+  background: var(--ifm-background-surface-color, #f4f6f5);
+  color: var(--ifm-font-color-base, #1a1d1b);
+  box-shadow: var(--shadow-md, 0 4px 16px rgba(26, 26, 26, 0.16));
+}
+.modal::backdrop {
+  background: rgba(20, 32, 26, 0.4);
+}
+.modalInner {
+  position: relative;
+  padding: var(--space-6, 2rem);
+}
+.modalClose {
+  position: absolute;
+  top: var(--space-3, 0.75rem);
+  right: var(--space-3, 0.75rem);
+  border: none;
+  background: transparent;
+  font-size: var(--text-h4, 1.3rem);
+  line-height: 1;
+  color: var(--ifm-color-content-secondary, #5b625e);
+  cursor: pointer;
+  padding: var(--space-1, 0.25rem);
+  border-radius: var(--radius-sm, 0.4rem);
+}
+.modalClose:hover {
+  color: var(--ifm-font-color-base, #1a1d1b);
+  background: var(--ifm-background-color, #eef1ef);
+}
+.modalEyebrow {
+  font-size: var(--text-eyebrow, 0.8rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin: 0 0 var(--space-2, 0.5rem);
+}
+.modalTitle {
+  font-size: var(--text-h3, 1.5rem);
+  font-weight: 600;
+  margin: 0 0 var(--space-3, 0.75rem);
+  padding-right: var(--space-6, 2rem);
+}
+.modalDetail {
+  margin: 0 0 var(--space-4, 1rem);
+  color: var(--ifm-color-content-secondary, #5b625e);
+  line-height: 1.6;
+}
+.modalRels {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-2, 0.5rem) var(--space-4, 1rem);
+}
+.modalRels dt {
+  font-size: var(--text-eyebrow, 0.8rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-content-secondary, #5b625e);
+  align-self: center;
+}
+.modalRels dd {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 0.5rem);
+}
+.modalRels dd span {
+  font-size: var(--text-body-sm, 0.95rem);
+  background: var(--ifm-background-color, #eef1ef);
+  border: 1px solid var(--bop-divider, rgba(26, 26, 26, 0.1));
+  border-radius: var(--radius-pill, 3em);
+  padding: 0.125rem var(--space-3, 0.75rem);
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -49,6 +49,19 @@ export type {
 export {default as Accordion} from './components/Accordion';
 export type {AccordionProps, AccordionItem} from './components/Accordion';
 
+// UseCaseDiagram — a UML use-case diagram (actors outside a system boundary, use cases as ovals
+// inside, association / include / extend links). Deterministic two-sided layout with barycenter
+// crossing reduction; two build-time gates fail on an unreadable layout (too many crossing lines,
+// or a lopsided actor line-fan). A use case with detail opens a click-to-focus modal.
+export {default as UseCaseDiagram} from './components/UseCaseDiagram';
+export type {
+  UseCaseDiagramProps,
+  Actor,
+  UseCase,
+  Link,
+  ActorKind,
+} from './components/UseCaseDiagram';
+
 export {default as Assumption} from './components/Assumption';
 export type {AssumptionProps} from './components/Assumption';
 


### PR DESCRIPTION
## What

Phase 5 of the earlbear-influenced plan (`.claude/plans/snug-yawning-fox.md`): a UML use-case diagram as inline SVG. Actors sit outside a system boundary; use cases are ovals inside; a solid line is an association and dashed `«include»` / `«extend»` arrows relate use cases.

## Why

Mermaid has no real use-case support, so there was no way to author one here. This is the most sophisticated component in the kit: a deterministic two-sided layout whose **readability is enforced at build time**.

## How

- **Two-sided layout**: internal and system actors pull left, external pull right, so association lines fan to the nearest edge. Use cases order by a barycenter crossing-reducer; each actor sits at the vertical center of the use cases it touches.
- **Two build-time gates** throw (fail `make build`): the overlap gate (>25% crossing lines) and the actor line-angle **balance** gate (a lopsided up/down fan). `allowOverlap` downgrades both to warnings.
- `layout.ts` — the pure-TS engine (all math + both gates). `actors.tsx` — the actor glyphs as **JSX** (filled user / gear / line person), no build-time file read, no `dangerouslySetInnerHTML`. `index.tsx` — SVG render + a React-state `<dialog>` modal (Used by / Includes / Extends). `styles.module.css` — token-themed, motion respects `prefers-reduced-motion`.

## Proof / verification

The balance gate **earned its keep**: my first showcase example failed the build with a lopsided Author fan (`0 up, 2 down`), and passed only once I made the layout genuinely readable (Author straddling its use cases). That is the fail-closed discipline working.

- ✅ Full `docusaurus build` renders it **server-side** (20 gradient refs, both stereotypes, all actors/ovals).
- ✅ All three gate behaviors fire in an isolated harness: dangling link throws, clean diagram lays out, `allowOverlap` returns-with-warnings on a tangle.
- ✅ Desktop + 390px visual pass: the two-sided UML layout reads cleanly (filled Author + gear Scheduled-job left, line-person Reader right, dashed `«include»`/`«extend»`, no tangle), the relationship modal opens, and the diagram scales to fit on mobile.
- ✅ ds-tokens + em-dash clean.

Live demo + proof: a `kind: showcase` page at `/handbook/components/diagrams/use-case`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)