### PR TITLE
feat(governance): visual-density nudge + outline contract knows the new components

### DIFF
--- a/.claude/hooks/validate-visual-density-hook.sh
+++ b/.claude/hooks/validate-visual-density-hook.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write: WARN (never block) when an H2 section is a wall of text
+# with no visual. A picture is worth a thousand words: when a section runs long with no
+# diagram / chart / image / table / code block, a visual usually carries the idea better
+# than three more paragraphs. Advisory only: a genuinely prose section is fine; the point
+# is to make a wall of text a DELIBERATE choice.
+#
+# Sibling of validate-post-outline-hook.sh / validate-questions-hook.sh (warn-tier). Pairs
+# with scripts/validate-visual-density.js + the upgrade-post skill (the component catalog).
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+case "$file_path" in
+  *.md|*.mdx) ;;
+  *) exit 0 ;;
+esac
+case "$file_path" in
+  */bytesofpurpose-blog/docs/*|*/bytesofpurpose-blog/blog/*|*/bytesofpurpose-blog/designs/*) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+# Skip sidecar/partials (filenames starting with _).
+case "$(basename "$file_path")" in
+  _*) exit 0 ;;
+esac
+
+proj="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+script="$proj/bytesofpurpose-blog/scripts/validate-visual-density.js"
+[ -f "$script" ] || exit 0
+
+out=$(node "$script" "$file_path" 2>&1)
+case "$out" in
+  *"[WARN:wall-of-text]"*)
+    printf '%s\n' "$out" >&2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-visual-density-hook.sh\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-post-outline-hook.sh\"",
             "timeout": 20
           },

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ validate-mdx-imports: ## Catch a Capitalized JSX tag used in .mdx but never impo
 validate-questions: ## Lint the optional `questions:` frontmatter (present → must be a list of items each ending in "?")
 	( cd ${SITEROOT} && node scripts/validate-questions.js $(DIRS) )
 
+validate-visual-density: ## Nudge: flag H2 sections that run long (>280 words) with no visual (advisory — a picture is worth a thousand words)
+	( cd ${SITEROOT} && node scripts/validate-visual-density.js $(DIRS) )
+
 validate-glossary: ## Find posts whose first use of a defined glossary term isn't linked (warn-tier candidates; judge + link via the link-glossary-terms skill)
 	( cd ${SITEROOT} && node scripts/validate-glossary-links.js $(DIRS) )
 

--- a/bytesofpurpose-blog/scripts/validate-post-outline.js
+++ b/bytesofpurpose-blog/scripts/validate-post-outline.js
@@ -126,7 +126,7 @@ const CHECKS = {
   'framework-laid-out': (fm, body) =>
     /^\s*\d+\.\s+\S/m.test(body) ||
     hasH2(body) ||
-    /<DiagramWithFootnotes[\s>]/.test(body) ||
+    /<(DiagramWithFootnotes|FlowDiagram|UseCaseDiagram|ComparisonMatrix)[\s>]/.test(body) ||
     /```mermaid/.test(body),
   // tutorial
   'steps-or-artifact': (fm, body) =>
@@ -143,11 +143,15 @@ const CHECKS = {
   // <SlideDeck> IS the visual (a live, navigable reveal.js deck), so it counts.
   mockup: (fm, body) =>
     Boolean(fm.mockups) || /<(Mockup|SlideDeck)[\s>]/.test(body),
+  // A decisions element is satisfied by a decisions/trade-offs heading, OR by a
+  // <ComparisonMatrix> / <Accordion> (which ARE the head-to-head + the option narrative).
   decisions: (fm, body) =>
-    /^#{1,4}\s+.*\b(key decisions?|decisions?|trade[-\s]?offs?)\b/im.test(body),
-  // backend-design: an architecture view (a diagram component, a mermaid fence, or a flow/components heading)
+    /^#{1,4}\s+.*\b(key decisions?|decisions?|trade[-\s]?offs?)\b/im.test(body) ||
+    /<(ComparisonMatrix|Accordion)[\s>]/.test(body),
+  // backend-design: an architecture view (a diagram component, a mermaid fence, or a flow/components heading).
+  // A <FlowDiagram> (pipeline/flow/swimlane) or <UseCaseDiagram> is a first-class architecture view too.
   architecture: (fm, body) =>
-    /<DiagramWithFootnotes[\s>]/.test(body) ||
+    /<(DiagramWithFootnotes|FlowDiagram|UseCaseDiagram)[\s>]/.test(body) ||
     /```mermaid/.test(body) ||
     /^#{1,4}\s+.*\b(architecture|components?|data ?flow|flow|pipeline|system)\b/im.test(body),
   // agent-design: the agent's loop / capabilities / tools

--- a/bytesofpurpose-blog/scripts/validate-visual-density.js
+++ b/bytesofpurpose-blog/scripts/validate-visual-density.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+/**
+ * validate-visual-density.js — nudge toward interleaving visuals: a picture is worth a
+ * thousand words.
+ *
+ * When an H2 section runs long with no diagram, chart, image, table, or even a code block,
+ * a visual almost always carries the idea better than three more paragraphs. This WARNS
+ * (never blocks) when a section exceeds a prose-word threshold with no visual, naming the
+ * section so the author knows where to reach for the component catalog (the upgrade-post
+ * skill). Advisory by design: a genuinely prose section (a reflection, a short note) is
+ * fine. The point is to make a wall of text a DELIBERATE choice, not an accident.
+ *
+ *   wall-of-text   An H2 section > WORD_THRESHOLD prose words with no visual.   [WARN]
+ *
+ * Prose-word count excludes fenced code, component/HTML lines, table rows, and imports, so
+ * it reflects only the prose a reader wades through. A fenced code block, a markdown table,
+ * or any of our visual components counts as a legitimate visual break.
+ *
+ * Usage:
+ *   node scripts/validate-visual-density.js [paths…]     # scan (default: blog docs)
+ *   node scripts/validate-visual-density.js --json        # machine-readable
+ *   node scripts/validate-visual-density.js --error-only  # exit 2 if any finding (strict gate)
+ *
+ * Exit codes: 0 clean · 1 findings (scan) · 2 findings (--error-only). Advisory: the HOOK
+ * runs it in default (warn) mode and never blocks; `make validate-visual-density` is the
+ * deliberate sweep.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_DIRS = ['blog', 'docs'];
+const WORD_THRESHOLD = 280;
+
+// What counts as a "visual" inside a section: one of our visual components, media, a
+// markdown table, or an embedded HTML widget/chart. Kept broad so a section that carries
+// ANY visual is never flagged. (A fenced code block is handled separately below.)
+const VISUAL_RE = new RegExp(
+  [
+    // our reusable visual components
+    '<FlowDiagram',
+    '<UseCaseDiagram',
+    '<ComparisonMatrix',
+    '<Accordion',
+    '<DiagramWithFootnotes',
+    '<Mockup',
+    '<Walkthrough',
+    '<Gif',
+    '<SlideDeck',
+    '<Timeline',
+    '<Carousel',
+    '<CategoryCarousel',
+    '<SvgVariantGrid',
+    '<Graph',
+    '<KanbanBoard',
+    '<Catalog',
+    '<OptionGrid',
+    '<Evidence',
+    // generic media / embedded widgets
+    '<figure',
+    '<img',
+    '<svg',
+    '<video',
+    '<iframe',
+    '<table',
+    '<canvas',
+    // a mermaid code fence is a visual (handled below via the fence check too, but a
+    // ```mermaid line also matches here for clarity)
+    '```mermaid',
+  ].join('|'),
+);
+// A markdown table row anywhere in the section also counts as a visual.
+const TABLE_ROW_RE = /^\s*\|.*\|/m;
+
+function stripFrontmatter(text) {
+  const m = text.match(/^---\n[\s\S]*?\n---\n?([\s\S]*)$/);
+  return m ? m[1] : text;
+}
+
+/** Words outside fenced code and component/HTML/table/import lines — the prose a reader
+ *  actually wades through. */
+function proseWordCount(sectionBody) {
+  const out = [];
+  let inFence = false;
+  for (const line of sectionBody.split('\n')) {
+    if (line.trimStart().startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const s = line.trimStart();
+    if (s.startsWith('<') || s.startsWith('|') || s.startsWith('import ')) continue;
+    out.push(line);
+  }
+  const words = out.join(' ').match(/[A-Za-z0-9']+/g);
+  return words ? words.length : 0;
+}
+
+function scanFile(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const findings = [];
+  const rel = path.relative(ROOT, file);
+  const body = stripFrontmatter(raw);
+
+  // Split into H2 sections. The preamble before the first H2 (the post's lead) is
+  // deliberately NOT checked: a lead paragraph is expected to be prose, not a wall of
+  // text mid-article, so flagging it is noise. The nudge targets BODY sections.
+  const parts = body.split(/^## (.+)$/m);
+  const sections = [];
+  for (let i = 1; i < parts.length; i += 2) {
+    sections.push([parts[i].trim(), parts[i + 1] || '']);
+  }
+
+  for (const [head, sec] of sections) {
+    // Skip machine-metadata blocks (managed by tooling, not reader prose).
+    if (/AI METADATA/i.test(head) || /DO NOT (REMOVE|MODIFY|EDIT)/i.test(head)) continue;
+    const hasVisual = VISUAL_RE.test(sec) || TABLE_ROW_RE.test(sec) || sec.includes('```');
+    const words = proseWordCount(sec);
+    if (words > WORD_THRESHOLD && !hasVisual) {
+      // line of the heading in the raw file (best-effort)
+      const idx = head === '(intro)' ? 0 : raw.indexOf(`## ${head}`);
+      const line = idx <= 0 ? 1 : raw.slice(0, idx).split('\n').length;
+      findings.push({
+        file: rel,
+        line,
+        severity: 'warn',
+        kind: 'wall-of-text',
+        detail: `section "${head}" is ${words} words with no visual.`,
+        suggest:
+          `A picture is worth a thousand words: interleave a diagram, chart, table, or ` +
+          `image (see the upgrade-post skill + the FlowDiagram / UseCaseDiagram / ` +
+          `ComparisonMatrix / Accordion catalog), or split the section.`,
+      });
+    }
+  }
+  return {findings};
+}
+
+function walk(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(full));
+    else if (/\.mdx?$/.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const errorOnly = args.includes('--error-only');
+  const targets = args.filter((a) => !a.startsWith('--'));
+  const dirs = (targets.length ? targets : DEFAULT_DIRS).map((d) =>
+    path.isAbsolute(d) ? d : path.join(ROOT, d),
+  );
+  const files = dirs.flatMap((d) =>
+    fs.existsSync(d) && fs.statSync(d).isDirectory() ? walk(d) : fs.existsSync(d) ? [d] : [],
+  );
+
+  const all = files.flatMap((f) => scanFile(f).findings);
+
+  if (json) {
+    console.log(JSON.stringify(all, null, 2));
+    process.exit(all.length ? (errorOnly ? 2 : 1) : 0);
+  }
+  if (!all.length) {
+    if (!errorOnly)
+      console.log(`✅ visual density: scanned ${files.length} files, no wall-of-text sections.`);
+    process.exit(0);
+  }
+  console.log(
+    `🔎 visual density: ${all.length} wall-of-text section(s) in ${files.length} files (advisory)\n`,
+  );
+  for (const p of all) {
+    console.log(`  ${p.file}:${p.line}  [${p.severity.toUpperCase()}:${p.kind}] ${p.detail}`);
+    console.log(`      ↳ ${p.suggest}`);
+  }
+  process.exit(errorOnly ? 2 : 1);
+}
+
+main();


### PR DESCRIPTION
## What

Phase 6 of the earlbear-influenced plan (`.claude/plans/snug-yawning-fox.md`): "a picture is worth a thousand words", in two halves.

## 1. Visual-density nudge

`scripts/validate-visual-density.js` flags an H2 **body** section running long (>280 prose words) with no visual, so a wall of text becomes a *deliberate* choice. Prose-word counting excludes code fences, component/HTML lines, table rows, and imports; a fenced code block, a markdown table, or any of our visual components counts as a visual break. **Warn-tier** (the hook never blocks; `make validate-visual-density` is the deliberate sweep).

Refinements over the earlbear original:
- The `(intro)` lead is **not** checked (a lead is expected to be prose, not a mid-article wall).
- Machine-metadata H2s (`AI METADATA` / `DO NOT REMOVE`) are skipped.

These dropped the corpus false positives from 78 → 60, leaving only genuine long-prose body sections (295–1078 words).

## 2. Visual-expectations via the existing outline seam

Rather than add a parallel `expects` frontmatter field, this teaches the existing `blog-kinds.json` outline contract about the new components. `validate-post-outline.js` now recognizes them as satisfiers: `architecture` accepts a `<FlowDiagram>` / `<UseCaseDiagram>`; `framework-laid-out` accepts those plus `<ComparisonMatrix>`; a `decisions` element is satisfied by a `<ComparisonMatrix>` or `<Accordion>`. **Non-breaking** (only adds satisfiers).

## Proof / verification

- ✅ The density check **bites** on a planted wall of text; passes when the same words carry a `<FlowDiagram>` or a code fence; `--error-only` exits 2.
- ✅ The hook warns and **exits 0** (never blocks).
- ✅ The outline validator still passes; the decision-kit showcase satisfies its `decisions` element via the matrix.
- ✅ em-dash clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)