### PR TITLE
Decision-kit polish + clickable-cell justifications, and the deprecated-post mechanism

### DIFF
--- a/.claude/hooks/validate-deprecated-hook.sh
+++ b/.claude/hooks/validate-deprecated-hook.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write: WARN (never block) when a deprecated post/doc is
+# missing its `deprecated_reason` (or its `deprecated_for` replacement link 404s).
+#
+# A `deprecated: true` page stays live but shows a dev-only "Dep" badge + a red
+# banner. The banner's value is the REASON, so a deprecation with no
+# `deprecated_reason` renders a bare "⚠️ Deprecated" with nothing actionable. This
+# runs scripts/validate-deprecated.js after you edit a content file that mentions
+# `deprecated`, nudging you to fill in the reason. Warn-tier (exits 0, never blocks);
+# the gate is `make validate-deprecated`.
+#
+# Scope: a .md/.mdx under bytesofpurpose-blog/{docs,blog,designs,thoughts,mindset,questions}/
+# that actually contains `deprecated` (fast skip otherwise). The validator scans the
+# whole corpus; the edited file just triggers it.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+case "$file_path" in
+  *.md|*.mdx) ;;
+  *) exit 0 ;;
+esac
+case "$file_path" in
+  */bytesofpurpose-blog/docs/*) ;;
+  */bytesofpurpose-blog/blog/*) ;;
+  */bytesofpurpose-blog/designs/*) ;;
+  */bytesofpurpose-blog/thoughts/*) ;;
+  */bytesofpurpose-blog/mindset/*) ;;
+  */bytesofpurpose-blog/questions/*) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+# Fast skip: only bother if the file mentions deprecation at all.
+grep -qE '^deprecated\s*:' "$file_path" 2>/dev/null || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(printf '%s' "$input" | jq -r '.cwd // empty')}"
+script="$proj/bytesofpurpose-blog/scripts/validate-deprecated.js"
+[ -f "$script" ] || exit 0   # not this repo / not set up → stay out of the way
+
+out=$(cd "$proj/bytesofpurpose-blog" && node scripts/validate-deprecated.js 2>&1)
+if printf '%s' "$out" | grep -qE 'deprecated-(missing-reason|dangling-for)'; then
+  {
+    echo "⚠️  deprecated: a deprecated page is missing its reason (or has a dangling replacement)"
+    printf '%s\n' "$out" | grep -E 'deprecated-(missing-reason|dangling-for)|↳'
+    echo ""
+    echo "   Add \`deprecated_reason: '...'\` (and a valid \`deprecated_for: /url\`) to the frontmatter."
+    echo "   (advice only — not blocking. Run \`make validate-deprecated\` for the gate.)"
+  } >&2
+fi
+
+# WARN-only: always succeed so the edit is never blocked.
+exit 0

--- a/.claude/plans/cozy-churning-bumblebee.md
+++ b/.claude/plans/cozy-churning-bumblebee.md
@@ -1,0 +1,140 @@
+# Plan: a "deprecated" post mechanism, parallel to "draft"
+
+## Context
+
+Some posts/docs should stay live but be clearly marked as **deprecated** — kept for
+history/URL-stability, but a reader landing on one (e.g.
+`/handbook/components/diagrams/diagrams-mindnode`) should see it's outdated. Today the
+repo has a **draft** mechanism (`draft: true` frontmatter → a dev-only "D" pill in the
+sidebar + beside the post title, and native Docusaurus exclusion from prod). There is
+**no** "deprecated" concept and **no** real top-of-page banner anywhere — the draft
+signal is only a small badge.
+
+This adds a `deprecated: true` frontmatter flag that mirrors `draft:` as closely as
+possible: the **same "D"-style sidebar/title pill (rendered red, "Dep") gated dev-only
+like the draft badge**, PLUS a **red top-of-page banner** stating the deprecation reason
+(and an optional replacement link). Deprecated posts, unlike drafts, are **NOT excluded
+from the build** — they still ship — but per the decisions below the *visual signals*
+(badge + banner) are **dev/localhost-only**, exactly like the draft badge, so nothing
+leaks to real readers yet. It gets its own validator + hook, and the redirect gate learns
+about it.
+
+Decisions locked with the user:
+- **Visibility:** dev-only, gated on `isLocalhost()` + non-prod (mirrors the draft badge, NOT the prod-visible premium LockBadge).
+- **Banner scope:** BOTH docs and blog posts.
+- **Frontmatter:** flat fields — `deprecated: true` + `deprecated_reason: '...'` (+ optional `deprecated_for: /new/url`).
+- **Validation:** warn-only hook (nudge when `deprecated: true` lacks a reason) + extend the redirect/link guards so a redirect/link **to** a deprecated page is flagged.
+
+The design mirror is exact: everywhere the code does `data.draft === true` /
+`frontMatter.draft === true` / a `draftPermalinks` set / a `DraftBadge`, we add a
+`deprecated` sibling right next to it.
+
+---
+
+## The five layers (each mirrors an existing draft touchpoint)
+
+### 1. Plugin: publish the deprecated permalink set + reasons
+**File:** `bytesofpurpose-blog/plugins/draft-docs/index.js`
+
+- Add `const deprecatedPermalinks = new Set();` and `const deprecatedInfo = {};` alongside `draftPermalinks`/`blogDraftPermalinks` (the docs `deprecatedInfo` is keyed permalink → `{reason, replacement}` so the banner can read it via global data; the badge only needs the set).
+- In the docs `walk()` (next to `if (data.draft === true)` at ~line 105) add:
+  ```js
+  if (data.deprecated === true) {
+    const p = toPermalink(full, docsDir, data);
+    deprecatedPermalinks.add(p);
+    deprecatedInfo[p] = {reason: data.deprecated_reason || '', replacement: data.deprecated_for || ''};
+  }
+  ```
+- In the blog-instance loop (next to `if (data.draft === true)` at ~line 145) add the same for `blogDeprecatedPermalinks`/`blogDeprecatedInfo` using `permalink` (already computed via `toBlogPermalink`).
+- Add all four to the returned global-data object (~line 182): `deprecatedPermalinks`, `blogDeprecatedPermalinks`, `deprecatedInfo`, `blogDeprecatedInfo`.
+- Update the header docblock to mention the deprecated sets (note: unlike drafts, deprecated posts are NOT excluded from prod; the badge is dev-gated by choice).
+
+> The banner on the **doc page** and **blog post page** actually reads frontmatter
+> directly (`useDoc()` / `useBlogPost()`), so `deprecatedInfo`/`blogDeprecatedInfo` are a
+> convenience only — the sidebar set is the part that genuinely needs the plugin (sidebar
+> items have no frontmatter). Keep the reason on the frontmatter as the source of truth;
+> the banner reads it locally.
+
+### 2. Badge module (new), mirroring `draftBadge.tsx`
+**New files:**
+- `bytesofpurpose-blog/src/theme/DocSidebarItem/deprecatedBadge.tsx`
+- `bytesofpurpose-blog/src/theme/DocSidebarItem/deprecatedBadge.module.css`
+
+Copy `draftBadge.tsx` exactly, renaming: `useDeprecatedPermalinks`/`useBlogDeprecatedPermalinks`, exported `useIsDeprecated(href)` + `useIsBlogDeprecated(permalink)` (same `NODE_ENV==='production'` → false and `isLocalhost()` gating as draft), and `DeprecatedBadge()` rendering a red pill:
+```tsx
+<span className={styles.deprecatedBadge} title="Deprecated" aria-label="deprecated">Dep</span>
+```
+CSS copies `draftBadge.module.css` with a **red** palette instead of amber (e.g. light `color:#991b1b; background:#fecaca; border-color:#ef4444;` + a dark-mode block). This is authored CSS → the `validate-ds-tokens` hook will run; use plain hexes (badges aren't in its literal→token map, so it stays quiet — verify).
+
+### 3. On-page red banner (new component) + wired into both content swizzles
+**New files:**
+- `bytesofpurpose-blog/src/components/DeprecatedBanner/index.tsx`
+- `bytesofpurpose-blog/src/components/DeprecatedBanner/styles.module.css`
+
+Component (models `PostQuestions`): takes `{deprecated?, reason?, replacement?}`, returns `null` when not deprecated **or** not dev/localhost (import `isLocalhost` from `@site/src/experiments`, guard `process.env.NODE_ENV==='production'`), else renders a red callout:
+```tsx
+<aside className={styles.banner} role="note" aria-label="Deprecated">
+  <p className={styles.title}>⚠️ Deprecated</p>
+  {reason && <p className={styles.reason}>{reason}</p>}
+  {replacement && <p><a href={replacement}>See the current version →</a></p>}
+</aside>
+```
+CSS models `PostQuestions/styles.module.css` but red: `border-left: 3px solid` a red token, a light-red wash background, `--tea-ink`-style dark ink; add a `data-theme='dark'` variant. Reuse design-system spacing/radius tokens (`--space-*`, `--radius-md`) so contrast passes.
+
+Wire it in:
+- **Docs** — `src/theme/DocItem/Content/index.tsx`: read `frontMatter.deprecated/deprecated_reason/deprecated_for` from `useDoc()` (already destructures `frontMatter`), render `<DeprecatedBanner .../>` at the very top of the returned markdown `<div>` (above the share row).
+- **Blog** — `src/theme/BlogPostItem/Content/index.tsx`: read the same from `useBlogPost().frontMatter`, render the banner above `<PostQuestions>` and only when `isBlogPostPage` (so list cards don't show it).
+
+### 4. Badge render sites (append next to every existing draft badge)
+Same three files that render `DraftBadge`, add the deprecated sibling:
+- `src/theme/DocSidebarItem/Link/index.tsx`: `const isDeprecated = useIsDeprecated(href);` + `{isDeprecated && <DeprecatedBadge/>}` after `{isDraft && <DraftBadge/>}`.
+- `src/theme/BlogSidebar/Desktop/index.tsx` and `.../Mobile/index.tsx`: `useIsBlogDeprecated(item.permalink)` + `{isDeprecated && <DeprecatedBadge/>}` next to the draft badge.
+- `src/theme/BlogPostItem/Header/Title/index.tsx`: add `useIsDeprecatedPost(frontMatter)` (mirrors `useIsDraftPost`, reads `frontMatter.deprecated`, same dev gate) and render `<DeprecatedBadge/>` beside the title next to the draft badge.
+
+### 5. Validator + hook + Makefile + settings.json (mirrors validate-draft + validate-redirects)
+
+**New validator:** `bytesofpurpose-blog/scripts/validate-deprecated.js`
+- `#!/usr/bin/env node`, `require('fs'|'path'|'gray-matter')`, `ROOT = path.join(__dirname,'..')`, `Usage:`/`Exit:` docblock.
+- Scan the canonical content roots (reuse the `walk()` + `safeMatter()` shape from `validate-hubs.js`/`validate-redirects.js`): the five `docs/*` instances + blog instances `blog, designs, thoughts, mindset, questions`.
+- **WARN** (exit 0, but print a grep-able marker) when a file has `deprecated: true` but no non-empty `deprecated_reason`. Optional warn: `deprecated_for` points at a URL that doesn't resolve to a published page.
+- Exit 0 always (warn-tier); reserve exit 2 for a future hard rule if wanted.
+
+**New hook:** `.claude/hooks/validate-deprecated-hook.sh` (copy `validate-idea-tags-hook.sh` warn idiom; `chmod +x`)
+- Scope gate `case "$file_path"` to `*.md|*.mdx` under any `bytesofpurpose-blog/docs/*` or blog dir; resolve `proj`; run `node scripts/validate-deprecated.js`; grep output for the missing-reason marker; print to stderr; `exit 0`.
+
+**Makefile:** add near the other `validate-*` targets:
+```makefile
+validate-deprecated: ## Check every deprecated:true post/doc has a deprecated_reason (warn-only)
+	( cd ${SITEROOT} && node scripts/validate-deprecated.js )
+```
+(optionally add to `.PHONY`).
+
+**settings.json:** append one object to the `Write|Edit` PostToolUse `hooks` array:
+```json
+{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-deprecated-hook.sh\"", "timeout": 20 }
+```
+
+**Redirect + link guards (extend existing):**
+- `bytesofpurpose-blog/scripts/validate-redirects.js`: it already splits `published`/`draft` sets via `data.draft === true ? draft : published`. Add a `deprecated` set (a page can be both published-and-deprecated, so add its URL to `deprecated` **in addition** — don't move it out of `published`). Add a **warn-tier** `to-deprecated` finding: a redirect `to:` a deprecated page still resolves (it ships), so warn, don't error — "redirect points at a DEPRECATED page; consider pointing at its replacement." (Do NOT make it exit-2 — deprecated pages are live, so it's not a build-breaker.)
+- `bytesofpurpose-blog/scripts/validate-links.js`: it records `{rel, draft}` per route and warns on `link-to-draft`. Add a `deprecated` flag to the slug index and a warn-tier `link-to-deprecated` finding (a published page linking to a deprecated one). Mirror the existing `link-to-draft` code path.
+
+---
+
+## Files touched (summary)
+
+New (4): `deprecatedBadge.tsx` + `.module.css`, `DeprecatedBanner/index.tsx` + `styles.module.css`, `scripts/validate-deprecated.js`, `.claude/hooks/validate-deprecated-hook.sh`.
+Edited (~9): `plugins/draft-docs/index.js`; `DocSidebarItem/Link/index.tsx`; `BlogSidebar/{Desktop,Mobile}/index.tsx`; `BlogPostItem/Header/Title/index.tsx`; `DocItem/Content/index.tsx`; `BlogPostItem/Content/index.tsx`; `scripts/validate-redirects.js`; `scripts/validate-links.js`; root `Makefile`; `.claude/settings.json`.
+
+Reused utilities (don't reinvent): `isLocalhost()` (`@site/src/experiments`), `useDoc()`/`useBlogPost()` for frontmatter, `useAllPluginInstancesData('draft-docs-plugin')` for the sets, the `walk()`/`safeMatter()` validator helpers, `gray-matter` for frontmatter parse. The whole thing is a rename-clone of the draft path — no new architecture.
+
+---
+
+## Verification (end-to-end, prove it — don't assert it)
+
+1. **Pick a live test target.** The example `docs/handbook/components/diagrams/diagrams-mindnode.mdx` is currently `draft: true` (so it's excluded from prod and won't show a banner in a built site). For a real deprecated-but-live proof, flip a **published** doc to add `deprecated: true` + `deprecated_reason: 'MindNode embeds superseded by the new diagram kit.'` + `deprecated_for: /handbook/components/...` temporarily (revert after), OR set the mindnode doc `draft: false, deprecated: true` for the dev test.
+2. **Dev server** (`make start`, :3000 — restart if the route table is stale): navigate to the deprecated page. Confirm (a) the **red "Dep" pill** in the left sidebar next to that doc, and (b) the **red banner** with the reason at the top of the page. For a blog post target, confirm the pill on the sidebar list card + beside the title, and the banner on the full post page (not on list cards).
+3. **Dev-only gate:** `make build && make serve` (prod build, :4173) — confirm the pill and banner do **NOT** appear (dev-only, like drafts). This proves the `isLocalhost()`/`NODE_ENV` gate.
+4. **Validator:** `make validate-deprecated` on a `deprecated: true` file with no `deprecated_reason` → prints the warn marker; with a reason → clean. Trigger the hook by editing such a file and confirm the stderr nudge (warn, non-blocking).
+5. **Redirect/link guards:** add a temporary redirect `to:` the deprecated page → `make validate-redirects` emits the warn `to-deprecated` (not an error/exit-2). A published page linking to the deprecated one → `make validate-links` emits `link-to-deprecated`. Revert temporaries.
+6. **Visual + mobile pass** (per repo convention for a new interactive component): view the banner at 375px + desktop, light + dark — no horizontal overflow, ≥16px text, banner readable, contrast AA (`make check-contrast` still passes since the banner reuses tokens; verify the red hexes if any land in the contrast PAIRS).
+7. Revert any temporary frontmatter/redirect/link test edits so the tree is clean.

--- a/.claude/plans/twinkly-weaving-walrus.md
+++ b/.claude/plans/twinkly-weaving-walrus.md
@@ -1,0 +1,260 @@
+# Plan: `refine-design-post` skill — audit for generality, minimalism, and clarity
+
+## Context
+
+**Why:** The design posts (`bytesofpurpose-blog/designs/`, 22 posts, `kind: *-design`) are the
+first target for a repeatable content-quality pass. The author wants a skill they *invoke on a
+post* that surfaces (1) over-wordiness, (2) places a diagram/table would beat prose, (3) concrete
+trims — and, equally important, two things the initial exploration and the follow-up messages made
+central:
+
+- **Generality over specifics (trade-secret safety).** Some of these patterns were worked on with an
+  employer. The guiding theme is *"information being general"*: generalizable patterns are fine to
+  share; employer-specific detail, proprietary names, internal system names, and secret-sauce
+  specifics are NOT. The skill must actively flag leak-risk and push each passage toward the
+  reusable, generalizable pattern.
+- **Minimalism + a per-section question-set.** The author is a minimalist who starts from *why this
+  matters → its value → what it enables → who benefits → what they'd do with it*. There is a
+  **set of questions each section should answer**. The skill must capture that question-set and use
+  it as the structural rubric: a section is "wordy" when prose doesn't advance a core question, and
+  "thin" when a required question goes unanswered.
+
+**Outcome:** An invocable skill that produces a **prioritized findings report (await approval, no
+edits until confirmed)** against these axes, PLUS a **living style guide inside the skill** that
+grows from the author's feedback — so that when we later author a *new* design post, there is shared,
+consistent guidance to write in the author's style. Bootstrapped from the real patterns already
+visible in the existing design posts.
+
+**Is it self-healing? Yes, by design — and the design makes forgetting impossible, not just
+discouraged.** The skill gets better with every post because three things compound: (1) a MANDATORY
+capture step ends each audit by writing any reusable lesson back into the guide files (the durable,
+version-controlled accumulator), (2) a **Stop-hook reminder** — the repo's established fail-closed
+nudge pattern (`changelog-archive-reminder.sh`, `discover-journey-reminder`) — fires after an audit
+session and catches an un-captured lesson so the loop can't silently rot, and (3) a **reconcile mode**
+periodically promotes rules that recurred across many audits into stronger, higher-priority rules and
+resolves contradictions, so the guide gets SHARPER with volume, not merely longer. Post N is audited
+against everything learned from posts 1..N-1.
+
+**Decisions locked (from clarifying Qs + follow-ups):**
+- **Question-set coverage is a first-class audit check.** Auditing a post for style *is* checking
+  whether it answers the core per-section questions. The report must state, per section, which
+  required questions are answered and which are missing — a missing answer is a finding, not just a
+  side note.
+- **Guidance lives in the skill's own files** (version-controlled, the house pattern) and
+  `author-blog-post` / `author-post` cross-link to it. No memory file.
+- **Report + await approval** is the default output; generalizations get captured only from what the
+  author confirms.
+- **Validation machinery IS in scope** (revised per follow-up: "ensure our plan enumerates all
+  tasks including implementing validation hooks"). We ship the skill first, then add a warn-tier
+  `validate-*.js` + PostToolUse hook + settings registration + Makefile target for the few
+  MECHANICAL rules — following the repo's proven 4-layer pattern. Judgment-heavy axes (real
+  wordiness, leak-risk nuance) stay with the skill; only greppable rules get the hook, so
+  false-positives don't kill the guard.
+
+## What we're building
+
+A new top-level skill dir: `.claude/skills/refine-design-post/` containing:
+
+1. **`SKILL.md`** — the invocable audit skill (the procedure + the report format).
+2. **`STYLE-GUIDE.md`** — the *living* guidance list, seeded now from the real corpus patterns, grown
+   from the author's feedback. This is the "shared guidance for writing in my style" artifact and the
+   thing new-post authoring will read.
+3. **`SECTION-QUESTIONS.md`** — the per-section question-set rubric (the minimalist "answer these
+   questions per section" contract).
+
+Splitting into three files follows the repo's own convention (`author-post` uses `homes/*.md`
+subfiles) and keeps SKILL.md a lean router while the two rubric files grow independently.
+
+## File 1 — `SKILL.md` (the audit procedure)
+
+Frontmatter (repo house style — exactly two fields, `name` = dir name, dense `description` with
+verb-first summary + em-dash specifics + `Use when …` triggers + `Pairs with …`):
+
+```yaml
+---
+name: refine-design-post
+description: Audit a /designs post for GENERALITY (no employer/trade-secret specifics — keep only the reusable pattern), MINIMALISM (does each section answer its core question-set: why it matters, its value, what it enables, who benefits, what they'd do with it), CLARITY (over-wordiness, redundant restatements, hedges, throat-clearing), and VISUAL LEVERAGE (prose that should be a mermaid diagram or table). Produces a prioritized findings report with quoted excerpts + suggested trims/generalizations; makes NO edits until you approve each. As you give feedback, it captures generalizable style rules back into STYLE-GUIDE.md so new posts stay consistent. Use when "review/tighten/refine this design post", "is this too wordy / too specific", "am I leaking anything", "make this more general", "does this need a diagram". Pairs with author-blog-post + author-post (which read STYLE-GUIDE.md when writing new posts), review-reader-experience (whole-site IA audit), upgrade-post (add the diagram once flagged).
+---
+```
+
+Body sections:
+- **H1 + framing** — one-sentence problem statement + `Pairs with` line.
+- **The four audit axes** (the heart), each a short subsection with what to look for + real corpus
+  examples drawn from the exploration:
+  - **1. Generality / leak-risk** — flag proprietary/internal system names, employer-specific
+    numbers, one-off internal processes, "we did X at $COMPANY" specifics. For each: is this the
+    *generalizable pattern* or the *specific instance*? Rewrite toward the pattern. (This axis is
+    listed FIRST — it's the author's stated guiding theme.)
+  - **2. Minimalism / question-set coverage** — run each section against `SECTION-QUESTIONS.md`; a
+    section that doesn't answer its core questions is either thin (add) or padded (cut). Start-with-why.
+    **This axis produces an explicit coverage verdict per section** — a small "answered ✓ / missing ✗"
+    table over the required questions — because "does it match my style" *means* "does it answer the
+    core questions." A missing required answer is a ranked finding of its own.
+  - **3. Clarity / wordiness** — the concrete tells from the corpus survey: redundant restatement of
+    the same invariant across Scope→bullets→table (e.g. `fleetplane.mdx` states its invariants 3×;
+    one phrase appears verbatim twice), the "same thing as diagram AND as ASCII/prose" duplication,
+    throat-clearing intros ("thus I made this post", "the part that matters more than the mechanism"),
+    hedges ("a fair amount", "about half", trailing "…"), over-nested parentheticals / semicolon
+    chains packing 4 ideas into one sentence.
+  - **4. Visual leverage** — prose describing a *process/structure* that should be a mermaid flow or a
+    2-col table (real candidates found: `lebanese-house-hero.mdx` A/B/C/D arms → table;
+    "one progress model, two drivers" → mermaid; `premium-content-gating.mdx` "Why three" prose that
+    duplicates its own table). Hands to `upgrade-post` for the actual diagram insertion.
+- **The report format** — a prioritized, per-finding block: `axis · location (file:line) · quoted
+  excerpt · why · suggested rewrite/trim/generalization`. Ordered most-impactful first. **No edits
+  until the author approves each finding.**
+- **Preserve the voice** — an explicit "do NOT flatten these" list (the *good* habits from the survey:
+  question-hook openings, bold-key-term + CAPS-for-contrast texture in moderation, the "long sentence
+  then short verdict" cadence, reflective "why it's built this way" closers, physical/tactile
+  metaphors). The skill trims wordiness WITHOUT sanding off the author's style.
+- **Capture the generalization (the self-healing loop) — MANDATORY, not optional.** The audit is not
+  "done" until every accepted/rejected/reshaped finding has been triaged into exactly one of:
+  *(a) new reusable rule* → append to `STYLE-GUIDE.md` (voice/wording) or `SECTION-QUESTIONS.md`
+  (a structural question), or *(b) one-off, not generalizable* → explicitly skipped with a reason.
+  The skill's procedure ends with a **"Captured this session"** block listing what was written back,
+  so the loop is visible and can't silently no-op. This is what makes post N audited against
+  everything learned from posts 1..N-1 — the guide files are the durable, version-controlled
+  accumulator. One-in-one-place: a rule that's really a structural question goes in SECTION-QUESTIONS,
+  a voice/wording rule goes in STYLE-GUIDE.
+- **Reconcile mode (gets SHARPER with volume, not just longer).** A `refine-design-post reconcile`
+  path that periodically dedups/merges the accumulated rules: a rule that recurred across N audits is
+  promoted to a stronger, higher-priority rule; near-duplicates merge; contradictions surface for the
+  author to resolve. Without this, the guide only grows; with it, repetition across many posts
+  *strengthens* the signal. This is the mechanism that makes the skill better with time, not just
+  bigger.
+- **How to run it** — numbered procedure: read the post → run all four axes (axis 2 emits the
+  per-section question-coverage verdict) → emit the ranked report → apply approved trims → capture
+  generalizations into the guide files.
+- **The mechanical guard** — a short section pointing at the companion `validate-design-clarity.js`
+  + hook (built in Phase B below): what it catches automatically vs. what stays a judgment call for
+  the skill.
+
+## File 2 — `STYLE-GUIDE.md` (living voice/wording rules, seeded now)
+
+A running list, each rule as `**Rule.** rationale + a before/after or a real corpus example`. Seeded
+from the survey so it's useful on day one:
+- Lead with *why it matters / value / what it enables / who benefits* before mechanism (minimalist).
+- Prefer the generalizable pattern; strip employer/internal specifics (the guiding theme).
+- State a thing once — kill Scope→bullets→table→restated repetition; never render the same structure
+  as both a diagram and ASCII/prose.
+- No throat-clearing intros; no "the part that matters" importance-announcements — just state it.
+- Cut hedges ("a fair amount", "about half", trailing "…").
+- One idea per sentence; break semicolon-chains and nested parentheticals.
+- KEEP: question-hook openings, bold-key-term + CAPS-for-contrast (moderation), long-sentence→short-
+  verdict cadence, reflective closers, tactile metaphors.
+- No em-dash in the rendered post body (repo-wide reader-voice rule; the em-dash hook blocks it).
+
+A header comment states the contract: *this file is appended to as the author gives feedback; it is
+the shared guidance `author-blog-post`/`author-post` read when writing a NEW design post.*
+
+## File 3 — `SECTION-QUESTIONS.md` (the per-section question-set rubric)
+
+The minimalist structural contract — the "set of questions each section should answer." Seed with the
+author's stated openers and a first-pass per-section-type mapping, e.g.:
+- **Post opener / hook:** Why does this matter? What does it enable? Who benefits and what would they
+  do with it?
+- **Problem / motivation:** What's the pain? Who has it? Why now?
+- **Architecture / design:** What are the parts and how do they compose? Which decision is expensive to
+  get wrong (lock it), which is cheap to change?
+- **Decisions:** What did you choose, over what alternative, and *why*?
+- **Closer:** What's the reusable takeaway someone could lift into their own project?
+
+Marked as a living rubric — new question-sets get added here as the author refines what each section
+type must answer. (This is the file most directly answering the author's "capture the set of questions
+each section should answer" ask.)
+
+## Cross-linking (small edits to existing skills)
+
+So new-post authoring inherits the guidance:
+- `author-blog-post/SKILL.md` and `author-post/SKILL.md` — add a one-line `Pairs with
+  refine-design-post` pointer noting that when writing a NEW design post, read
+  `refine-design-post/STYLE-GUIDE.md` + `SECTION-QUESTIONS.md` for the author's voice + section
+  question-sets. (Reciprocal to the `Pairs with` in the new skill's description.)
+
+## Validation machinery (Phase B) — the mechanical guard
+
+Per the follow-up ("enumerate all tasks including implementing validation hooks"), we DO ship a
+warn-tier guard, following the repo's proven 4-layer pattern (`validate-post-outline.js` is the model:
+dual file-or-dir arg, `[warn:...]` stderr markers, `exit 0` always). It covers ONLY the mechanical,
+low-false-positive rules; every judgment-heavy check stays in the skill.
+
+**In scope for the validator (mechanical, greppable):**
+- Trailing "…"/`...` placeholder-thought endings.
+- A verbatim-duplicated line/sentence within one post (the "stated 3× / appears twice" tell).
+- A banned-term list of employer/proprietary/internal names (a `scripts/lib/design-leak-terms.json`
+  source-of-truth list the author seeds + grows) — the ONE genuinely mechanical leak check.
+- Optional heuristic nudges (warn-only): a `## H2` section whose body is under N words (thin section)
+  and the "mermaid block immediately followed by an ASCII/code fence redrawing it" duplication.
+
+Explicitly OUT of scope for the validator (skill-only judgment): real wordiness, hedge detection,
+question-set *coverage* (semantic), whether a passage is a leak vs. a fair generalization.
+
+Four layers (all light, cloned from existing siblings):
+- `bytesofpurpose-blog/scripts/validate-design-clarity.js` — warn-tier, scoped to `designs/`, dual
+  file/dir arg. Reads `scripts/lib/design-leak-terms.json`.
+- `.claude/hooks/validate-design-clarity-hook.sh` — clone of `validate-post-outline-hook.sh`; guards
+  on `*.mdx`/`*.md` under `*/designs/*`, greps the `[warn:...]` marker, `exit 0` (never blocks).
+- One object appended to the `PostToolUse` → `hooks` array in `.claude/settings.json`.
+- `make validate-design-clarity` target (2 lines) + name added to `.PHONY` in the root `Makefile`.
+
+**The self-healing nudge (fail-closed):**
+- `.claude/hooks/refine-capture-reminder.sh` — a `Stop` hook cloned from
+  `changelog-archive-reminder.sh`: after a session in which `refine-design-post` ran, it reminds
+  (non-blocking, exit 0) to confirm the session's lessons were captured into `STYLE-GUIDE.md` /
+  `SECTION-QUESTIONS.md`. Registered in `.claude/settings.json` under `Stop`. This is what turns the
+  "MANDATORY capture" from a hope into a guarded loop — the reason the skill actually improves over
+  time instead of decaying.
+
+## Task enumeration (execution order)
+
+**Phase A — the skill (ship first, delivers value alone):**
+1. Create `.claude/skills/refine-design-post/SKILL.md` (frontmatter + four axes + report format +
+   preserve-voice + feedback loop + how-to-run + mechanical-guard pointer).
+2. Create `.claude/skills/refine-design-post/SECTION-QUESTIONS.md` (per-section question-set rubric,
+   seeded).
+3. Create `.claude/skills/refine-design-post/STYLE-GUIDE.md` (living voice/wording rules, seeded from
+   the corpus survey).
+4. Cross-link: add the `Pairs with refine-design-post` pointer to `author-blog-post/SKILL.md` and
+   `author-post/SKILL.md` (read the guide files when writing a NEW design post).
+5. Dry-run the skill on `designs/2026-07-04-fleetplane.mdx`; confirm it catches the known
+   redundancy + visual-duplication + a question-coverage gap + a leak-risk flag, ranked, no edits,
+   and ends with a "Captured this session" block (the mandatory feedback-loop step).
+
+**Phase B — the mechanical guard:**
+6. Create `scripts/lib/design-leak-terms.json` (seed banned-term list; author confirms entries).
+7. Create `bytesofpurpose-blog/scripts/validate-design-clarity.js` (warn-tier, model on
+   `validate-post-outline.js`).
+8. Create `.claude/hooks/validate-design-clarity-hook.sh` (clone `validate-post-outline-hook.sh`).
+9. Register the hook object in `.claude/settings.json` `PostToolUse` array.
+10. Add `validate-design-clarity` target to the root `Makefile` + `.PHONY` line.
+11. Create `.claude/hooks/refine-capture-reminder.sh` (Stop hook, cloned from
+    `changelog-archive-reminder.sh`) and register it under `Stop` in `.claude/settings.json` — the
+    fail-closed nudge that keeps the self-healing loop honest.
+12. Prove the guards: run `make validate-design-clarity` over `designs/` (expect real warnings on
+    `fleetplane.mdx`), plant a banned term in a scratch copy to confirm the PostToolUse hook warns on
+    edit, and confirm the Stop reminder fires after an audit session.
+
+Tracked as tasks via TaskCreate at execution time (one per numbered item), per the repo's
+"track our work as tasks" convention. Commit → PR → ask-to-merge per the repo workflow; Phase A and
+Phase B can be one PR (skill + its guard) since B has no value without A.
+
+## Verification
+
+This is content/prose tooling, not runtime code, so verification is behavioral:
+1. **Structural check** — confirm the three files exist under `.claude/skills/refine-design-post/`,
+   frontmatter has exactly `name` (== dir) + `description`, and the skill appears in the skills list.
+2. **Dry-run the audit** — invoke the skill on one real post that the survey already flagged
+   (`designs/2026-07-04-fleetplane.mdx` — has the 3× repeated invariants + verbatim-twice phrase +
+   mermaid-AND-ASCII duplication). Confirm the report catches those *known* findings (redundancy,
+   visual duplication) AND at least one generality/leak-risk flag AND a per-section
+   question-coverage verdict (with at least one "missing ✗"), in ranked order, with no edits made.
+3. **Feedback-loop check** — give one piece of mock feedback ("always prefer 'system' over the
+   internal name") and confirm the skill appends a corresponding rule to `STYLE-GUIDE.md`.
+4. **Cross-link check** — confirm `author-blog-post`/`author-post` now point at the guide files.
+5. **Mechanical guard (Phase B)** — `make validate-design-clarity` over `designs/` exits 0 and prints
+   real `[warn:...]` findings on `fleetplane.mdx` (trailing-"…", verbatim-dup). Plant a term from
+   `design-leak-terms.json` into a scratch `.mdx` under `designs/`, Edit it, and confirm the
+   PostToolUse hook surfaces a leak-term warning to stderr without blocking (exit 0).
+
+Skill files aren't part of the site build; the only `make` step is the new `validate-design-clarity`
+target from Phase B.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-deprecated-hook.sh\"",
+            "timeout": 20
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-docs-structure-hook.sh\"",
             "timeout": 20
           },

--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -163,6 +163,12 @@ answers "why". HOW:
 - Both registered in `MDXComponents` (no import). Live demo: `/handbook/components/structural/decision-kit`.
 - ComparisonMatrix THROWS at build if a cell is keyed to an option id that is not in `options`.
   It scrolls inside its own wrapper on mobile (never pushes the page sideways).
+- JUSTIFY A RATING: a cell can be `{rating, note, footnotes}` instead of a bare string. A cell
+  with a `note` renders its mark as a clickable button (a small "why" dot hints it) that opens a
+  focus modal with the justification (any React content, incl. `<sup>` footnote refs) + a
+  `footnotes: [{id, content}]` definition list. Plain-string cells stay static; zero client JS
+  ships unless a cell has a note. E.g.
+  `cells={{sqlite: {rating:'yes', note:<>Single file, no server.<sup>1</sup></>, footnotes:[{id:'1', content:<>In-process.</>}]}}}`.
 - WHEN NOT: `OptionGrid`/`OptionTile`/`DecisionNote` show explored DESIGN directions with a
   chosen ring + WHY (a design specimen). ComparisonMatrix is the feature-by-feature decision
   TABLE. Use the matrix for "which option scores better", OptionGrid for "which mock we picked".

--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -140,7 +140,9 @@ WHAT: two components for a post that argues a CHOICE. `ComparisonMatrix` is the 
 table (options are columns, criteria rows, the `chosen` column highlighted + badged;
 `yes`/`no`/`partial` render as ●/○/◐ marks with sr-only labels, any other string as literal
 text). `Accordion` is the narrative (foldable options on native `<details>`, zero JS, each
-with a `summary`, a React `body`, an optional `verdict` pill, an optional `open`). WHEN: a
+with a `summary`, a React `body`, an optional `open`, and either `chosen: true` (a solid green
+CHOSEN pill) or a `verdict` on the rest (a quiet grey CONSIDERED pill, so only one pill draws
+the eye)). WHEN: a
 decision/comparison/critique post. The matrix answers "how do they score"; the accordion
 answers "why". HOW:
 
@@ -153,8 +155,8 @@ answers "why". HOW:
   ]}/>
 
 <Accordion label="The options" items={[
-  {summary:'Rebuild from scratch', verdict:'rejected', body:<>Slow; loses the edge cases.</>},
-  {summary:'Keep SQLite', verdict:'chosen', open:true, body:<>Zero-ops, durable, free.</>},
+  {summary:'Rebuild from scratch', verdict:'considered', body:<>Slow; loses the edge cases.</>},
+  {summary:'Keep SQLite', chosen:true, open:true, body:<>Zero-ops, durable, free.</>},
 ]}/>
 ```
 

--- a/.claude/skills/upgrade-post/SKILL.md
+++ b/.claude/skills/upgrade-post/SKILL.md
@@ -169,6 +169,9 @@ answers "why". HOW:
   `footnotes: [{id, content}]` definition list. Plain-string cells stay static; zero client JS
   ships unless a cell has a note. E.g.
   `cells={{sqlite: {rating:'yes', note:<>Single file, no server.<sup>1</sup></>, footnotes:[{id:'1', content:<>In-process.</>}]}}}`.
+- LEGEND: pass `legend` to render a small key under the table (● yes / ○ no / ◐ partial, only the
+  marks in use), plus a "clickable for the reasoning" hint when any cell has a note. Rendered from
+  the mark map so it can't drift. Off by default; opt in per matrix. (Modeled on `<PowerLegend>`.)
 - WHEN NOT: `OptionGrid`/`OptionTile`/`DecisionNote` show explored DESIGN directions with a
   chosen ring + WHY (a design specimen). ComparisonMatrix is the feature-by-feature decision
   TABLE. Use the matrix for "which option scores better", OptionGrid for "which mock we picked".

--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,12 @@ validate-idea-tags: ## Check every board (ideas/experiments) tag has a tooltip g
 	@# .claude/hooks/validate-idea-tags-hook.sh runs this on a board-post / registry edit.
 	( cd ${SITEROOT} && node scripts/validate-idea-tags.js )
 
+validate-deprecated: ## Check every deprecated:true post/doc has a deprecated_reason (+ its deprecated_for resolves)
+	@# Warn-only (always exit 0): a deprecated page's red banner needs a reason to be useful.
+	@# The warn-tier hook .claude/hooks/validate-deprecated-hook.sh runs this on a content edit
+	@# that mentions `deprecated`. See the deprecated-post mechanism (mirrors the draft path).
+	( cd ${SITEROOT} && node scripts/validate-deprecated.js )
+
 validate-hubs: ## Check the durable hubs: every kind:hub doc renders a registered <Catalog>, every hub-kind post has a valid area
 	@# Exit 2 if a kind:hub doc renders no <Catalog> / an unregistered kind, or a hub-kind post
 	@# (project/tinkering/research) has a missing/invalid `area:` (it would vanish from its hub).

--- a/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
@@ -33,12 +33,29 @@ gate throws if a cell is keyed to an option id that does not exist.
     {id: 'redis', label: 'Redis'},
   ]}
   criteria={[
-    {label: 'Zero-ops', cells: {pg: 'no', sqlite: 'yes', redis: 'partial'}},
+    {label: 'Zero-ops', cells: {
+      pg: 'no',
+      sqlite: {
+        rating: 'yes',
+        note: (
+          <>The whole database is a single file on disk. There is no server to run, no
+          daemon to keep alive, and no connection pool to tune <sup>1</sup> &mdash; the app
+          just opens the file. That is the entire operational surface.</>
+        ),
+        footnotes: [
+          {id: '1', content: <>SQLite runs in-process; "serverless" here means no separate database server, not a cloud platform.</>},
+        ],
+      },
+      redis: 'partial',
+    }},
     {label: 'Relational', cells: {pg: 'yes', sqlite: 'yes', redis: 'no'}},
     {label: 'Durable on disk', cells: {pg: 'yes', sqlite: 'yes', redis: 'partial'}},
     {label: 'Cost', cells: {pg: '$$', sqlite: 'free', redis: '$'}},
   ]}
 />
+
+Click the **Zero-ops / SQLite** mark above to see the justification modal: a cell can carry a
+`note` (why the rating was given) and optional `footnotes`, and its mark becomes clickable.
 
 ```mdx
 <ComparisonMatrix

--- a/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
@@ -27,6 +27,7 @@ gate throws if a cell is keyed to an option id that does not exist.
 <ComparisonMatrix
   title="Where to store the data"
   desc="Comparing three stores against what this project needs."
+  legend
   options={[
     {id: 'pg', label: 'Postgres'},
     {id: 'sqlite', label: 'SQLite', chosen: true},

--- a/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
@@ -69,7 +69,7 @@ while folded.
   items={[
     {
       summary: 'Rebuild the store from scratch',
-      verdict: 'rejected',
+      verdict: 'considered',
       body: (
         <>It is the cleanest design on paper, but it throws away every edge case the current
         store has already learned, and it is the slowest path to shipping.</>
@@ -77,12 +77,12 @@ while folded.
     },
     {
       summary: 'Reach for a hosted database',
-      verdict: 'rejected',
+      verdict: 'considered',
       body: <>Solves durability, but it adds an ops surface this project deliberately avoids.</>,
     },
     {
       summary: 'Keep SQLite, add only the new surface',
-      verdict: 'chosen',
+      chosen: true,
       open: true,
       body: (
         <>Zero-ops, durable on disk, relational, and free. It keeps the proven core and adds
@@ -96,8 +96,8 @@ while folded.
 <Accordion
   label="The options"
   items={[
-    {summary: 'Rebuild from scratch', verdict: 'rejected', body: <>Slow, and we lose the edge cases.</>},
-    {summary: 'Keep SQLite, add the new surface', verdict: 'chosen', open: true, body: <>Zero-ops, durable, free.</>},
+    {summary: 'Rebuild from scratch', verdict: 'considered', body: <>Slow, and we lose the edge cases.</>},
+    {summary: 'Keep SQLite, add the new surface', chosen: true, open: true, body: <>Zero-ops, durable, free.</>},
   ]}
 />
 ```

--- a/bytesofpurpose-blog/plugins/draft-docs/index.js
+++ b/bytesofpurpose-blog/plugins/draft-docs/index.js
@@ -17,8 +17,9 @@ try {
 
 /**
  * Local Docusaurus plugin: collects the permalink of every DRAFT doc
- * (`draft: true` frontmatter) and of every PREMIUM doc (`premium: true`), and
- * exposes both as global data so the swizzled sidebar can badge those entries.
+ * (`draft: true` frontmatter), every PREMIUM doc (`premium: true`), and every
+ * DEPRECATED doc (`deprecated: true`), and exposes them as global data so the
+ * swizzled sidebar can badge those entries.
  *
  * Drafts are excluded from PRODUCTION builds entirely, so the draft map is only
  * meaningful on `yarn start` — the draft sidebar badge additionally gates on
@@ -27,11 +28,21 @@ try {
  * gated client-side), so the premium map + its lock badge are meaningful in
  * prod too. (V2 of the premium-content-gating design — mirrors the draft path.)
  *
+ * DEPRECATED docs (like premium) are NOT excluded from the build — they still
+ * ship — but by DESIGN their "Dep" badge + red banner are gated to localhost +
+ * non-prod exactly like the draft badge, so the deprecation signal is a dev-only
+ * cue for now and never leaks to real readers. The deprecation REASON lives on
+ * the post's frontmatter (`deprecated_reason`, optional `deprecated_for`); the
+ * on-page banner reads it directly (via useDoc/useBlogPost), so the *Info maps
+ * here are a convenience — the permalink SET is the part the sidebar genuinely
+ * needs (sidebar items carry no frontmatter).
+ *
  * Consumed via:
- *   useGlobalData()['draft-docs-plugin'].default.draftPermalinks    // string[] — draft doc pages
- *   useGlobalData()['draft-docs-plugin'].default.premiumPermalinks  // string[] — premium doc pages
- *   useGlobalData()['draft-docs-plugin'].default.blogSidebarLabels  // {permalink: shortLabel} — blog posts with sidebar_label
- *   useGlobalData()['draft-docs-plugin'].default.docsKindEmoji      // {permalink: emoji} — docs with a `kind:` (e.g. kind: hub -> 🗂️)
+ *   useGlobalData()['draft-docs-plugin'].default.draftPermalinks       // string[] — draft doc pages
+ *   useGlobalData()['draft-docs-plugin'].default.premiumPermalinks     // string[] — premium doc pages
+ *   useGlobalData()['draft-docs-plugin'].default.deprecatedPermalinks  // string[] — deprecated doc pages
+ *   useGlobalData()['draft-docs-plugin'].default.blogSidebarLabels     // {permalink: shortLabel} — blog posts with sidebar_label
+ *   useGlobalData()['draft-docs-plugin'].default.docsKindEmoji         // {permalink: emoji} — docs with a `kind:` (e.g. kind: hub -> 🗂️)
  *
  * Only individual docs with `draft: true` are tracked — the swizzled sidebar
  * badges the LEAF link. (Category/folder badging was dropped: a fully-draft folder
@@ -69,6 +80,14 @@ module.exports = function draftDocsPlugin(context) {
     async loadContent() {
       const draftPermalinks = new Set();
       const premiumPermalinks = new Set();
+      // DEPRECATED docs/posts: shipped to prod, but their "Dep" badge + red banner
+      // are dev/localhost-gated like drafts. The set feeds the sidebar badge; the
+      // *Info maps (permalink -> {reason, replacement}) are a convenience since the
+      // banner reads the frontmatter directly on the page.
+      const deprecatedPermalinks = new Set();
+      const blogDeprecatedPermalinks = new Set();
+      const deprecatedInfo = {};
+      const blogDeprecatedInfo = {};
       const blogDraftPermalinks = new Set();
       // permalink -> short sidebar label, for blog posts that set `sidebar_label:`.
       // The blog sidebar item carries only {title, permalink}, so the swizzle looks
@@ -108,6 +127,14 @@ module.exports = function draftDocsPlugin(context) {
           if (data.premium === true) {
             premiumPermalinks.add(toPermalink(full, docsDir, data));
           }
+          if (data.deprecated === true) {
+            const p = toPermalink(full, docsDir, data);
+            deprecatedPermalinks.add(p);
+            deprecatedInfo[p] = {
+              reason: data.deprecated_reason || '',
+              replacement: data.deprecated_for || '',
+            };
+          }
           // Docs kind emoji: only when the kind is known AND its short label (sidebar_label ||
           // title) doesn't already start with an emoji (authors sometimes hand-type one).
           const kindEmoji = data.kind && BLOG_KIND_EMOJI[data.kind];
@@ -144,6 +171,13 @@ module.exports = function draftDocsPlugin(context) {
           const permalink = toBlogPermalink(entry.name, data, base);
           if (data.draft === true) {
             blogDraftPermalinks.add(permalink);
+          }
+          if (data.deprecated === true) {
+            blogDeprecatedPermalinks.add(permalink);
+            blogDeprecatedInfo[permalink] = {
+              reason: data.deprecated_reason || '',
+              replacement: data.deprecated_for || '',
+            };
           }
           // Pin to the top of the sidebar: explicit `pinned: true`, or any legend (an
           // index/keystone should sit above the year groups regardless of its date).
@@ -182,6 +216,10 @@ module.exports = function draftDocsPlugin(context) {
       return {
         draftPermalinks: [...draftPermalinks],
         premiumPermalinks: [...premiumPermalinks],
+        deprecatedPermalinks: [...deprecatedPermalinks],
+        blogDeprecatedPermalinks: [...blogDeprecatedPermalinks],
+        deprecatedInfo,
+        blogDeprecatedInfo,
         blogDraftPermalinks: [...blogDraftPermalinks],
         blogSidebarLabels,
         blogPinnedPermalinks: [...blogPinnedPermalinks],

--- a/bytesofpurpose-blog/scripts/validate-deprecated.js
+++ b/bytesofpurpose-blog/scripts/validate-deprecated.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+/**
+ * validate-deprecated.js — every deprecated post/doc should say WHY.
+ *
+ * A `deprecated: true` post/doc stays live (it ships to prod for URL stability) but
+ * shows a dev-only "Dep" badge + a red banner. The banner's whole value is the
+ * REASON, so a deprecation with no `deprecated_reason` is an unfinished deprecation:
+ * the banner renders a bare "⚠️ Deprecated" with nothing actionable. This walks the
+ * content corpus and nudges when that reason is missing.
+ *
+ * Findings (all WARN — never block; deprecation is a judgment call and a missing
+ * reason is a nudge, not a build-breaker):
+ *   - missing-reason   `deprecated: true` but no non-empty `deprecated_reason`.
+ *   - dangling-for     `deprecated_for` points at a URL that no published page
+ *                      produces (a replacement link that 404s). Best-effort.
+ *
+ * Mirrors the draft/redirect validators' shape (walk + gray-matter + the same
+ * DOCS/BLOG instance lists). Kept in lockstep with validate-redirects.js's instance
+ * lists — if you add a docs/blog instance, add it in both.
+ *
+ * Usage:  node scripts/validate-deprecated.js [--json]
+ * Exit:   0 always (warn-tier). Reserve exit 2 for a future hard rule.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const ROOT = path.join(__dirname, '..');
+
+// Kept in lockstep with validate-redirects.js. Docs instances: <dir under docs/> → routeBasePath.
+const DOCS_INSTANCES = [
+  {dir: 'docs/craft', base: '/craft'},
+  {dir: 'docs/journey', base: '/journey'},
+  {dir: 'docs/handbook', base: '/handbook'},
+  {dir: 'docs/knowledge', base: '/knowledge'},
+  {dir: 'docs/habits', base: '/habits'},
+];
+const BLOG_INSTANCES = [
+  {dir: 'blog', base: '/initiatives'},
+  {dir: 'designs', base: '/designs'},
+  {dir: 'thoughts', base: '/thoughts'},
+  {dir: 'mindset', base: '/mindset'},
+  {dir: 'questions', base: '/questions'},
+];
+
+function walk(absDir, out = []) {
+  if (!fs.existsSync(absDir)) return out;
+  for (const e of fs.readdirSync(absDir, {withFileTypes: true})) {
+    if (e.name === 'node_modules') continue;
+    const fp = path.join(absDir, e.name);
+    if (e.isDirectory()) walk(fp, out);
+    else if (/\.mdx?$/.test(e.name)) out.push(fp);
+  }
+  return out;
+}
+
+function safeMatter(fp) {
+  try {
+    return matter(fs.readFileSync(fp, 'utf8'));
+  } catch {
+    return {data: null};
+  }
+}
+
+const norm = (u) => (u && u.length > 1 ? u.replace(/\/$/, '') : u);
+
+// Best-effort published-URL set, so a deprecated_for replacement link can be sanity-checked.
+// Mirrors the docs/blog permalink derivation in validate-redirects.js (absolute slug wins).
+function collectPublished() {
+  const published = new Set();
+  for (const {dir, base} of DOCS_INSTANCES) {
+    for (const fp of walk(path.join(ROOT, dir))) {
+      const {data} = safeMatter(fp);
+      if (!data) continue;
+      let url;
+      if (typeof data.slug === 'string' && data.slug.startsWith('/')) {
+        url = data.slug === '/' ? base : base + data.slug;
+      } else {
+        const rel = path.relative(path.join(ROOT, dir), fp).replace(/\.mdx?$/, '');
+        const segs = rel.split(path.sep).filter((s) => !/^README$|^index$/i.test(s));
+        const last = typeof data.slug === 'string' ? data.slug.replace(/^\//, '') : segs.pop();
+        url = [base, ...segs, last].filter(Boolean).join('/');
+        if (/README|index/i.test(path.basename(fp)) && segs.length === 0 && !data.slug) url = base;
+      }
+      if (data.draft !== true) published.add(norm(url));
+    }
+  }
+  for (const {dir, base} of BLOG_INSTANCES) {
+    for (const fp of walk(path.join(ROOT, dir))) {
+      if (path.basename(fp).startsWith('_')) continue;
+      const {data} = safeMatter(fp);
+      if (!data) continue;
+      const fileSlug = path
+        .basename(fp)
+        .replace(/\.mdx?$/, '')
+        .replace(/^\d{4}-\d{2}-\d{2}-/, '');
+      const slug = (data.slug || fileSlug).toString().replace(/^\//, '');
+      if (data.draft !== true) published.add(norm(`${base}/${slug}`));
+    }
+  }
+  return published;
+}
+
+function collectDeprecated() {
+  const out = [];
+  const roots = [
+    ...DOCS_INSTANCES.map((i) => i.dir),
+    ...BLOG_INSTANCES.map((i) => i.dir),
+  ];
+  for (const dir of roots) {
+    for (const fp of walk(path.join(ROOT, dir))) {
+      if (path.basename(fp).startsWith('_')) continue;
+      const {data} = safeMatter(fp);
+      if (!data || data.deprecated !== true) continue;
+      out.push({
+        file: path.relative(ROOT, fp),
+        reason:
+          typeof data.deprecated_reason === 'string'
+            ? data.deprecated_reason.trim()
+            : '',
+        replacement:
+          typeof data.deprecated_for === 'string' ? data.deprecated_for.trim() : '',
+      });
+    }
+  }
+  return out;
+}
+
+function main() {
+  const json = process.argv.includes('--json');
+  const deprecated = collectDeprecated();
+  const published = collectPublished();
+  const findings = [];
+
+  for (const d of deprecated) {
+    if (!d.reason) {
+      findings.push({
+        id: 'missing-reason',
+        file: d.file,
+        detail:
+          'deprecated: true but no `deprecated_reason:` — the red banner would show a bare "⚠️ Deprecated" with nothing actionable. Add a one-line reason.',
+      });
+    }
+    if (
+      d.replacement &&
+      d.replacement.startsWith('/') &&
+      !published.has(norm(d.replacement))
+    ) {
+      findings.push({
+        id: 'dangling-for',
+        file: d.file,
+        detail: `deprecated_for: ${d.replacement} does not resolve to a published page (a replacement link that 404s). Fix the URL or drop it.`,
+      });
+    }
+  }
+
+  if (json) {
+    console.log(
+      JSON.stringify({counts: {deprecated: deprecated.length}, findings}, null, 2),
+    );
+    process.exit(0);
+  }
+
+  if (!findings.length) {
+    console.log(
+      `✅ deprecated: ${deprecated.length} deprecated page(s) checked — all have a reason.`,
+    );
+    process.exit(0);
+  }
+
+  console.warn(
+    `⚠️  deprecated: ${findings.length} advisory finding(s) across ${deprecated.length} deprecated page(s).`,
+  );
+  for (const f of findings) {
+    console.warn(`\n  [warn:deprecated-${f.id}]  ${f.file}`);
+    console.warn(`      ↳ ${f.detail}`);
+  }
+  console.warn('\n(advice only — not blocking. Run `make validate-deprecated`.)');
+  // Warn-tier: never block.
+  process.exit(0);
+}
+
+main();

--- a/bytesofpurpose-blog/scripts/validate-links.js
+++ b/bytesofpurpose-blog/scripts/validate-links.js
@@ -17,6 +17,9 @@
  *   link-to-draft    A PUBLISHED page links to a `draft: true` page (which is    [WARN]
  *                    excluded from the prod build → a build-time broken link).
  *                    A draft→draft link is allowed (they ship together later).
+ *   link-to-deprecated  A page links to a `deprecated: true` page. The target    [WARN]
+ *                    still resolves (deprecated pages ship), so it's not broken —
+ *                    but linking readers into deprecated content is a smell.
  *   test-stale-slug  A test/e2e file (`goto('/docs/…')`, README) references a     [WARN]
  *                    /docs/<slug> that resolves to no doc — an IA move changed it.
  *                    A redirect keeps users working but lands the test on the
@@ -57,6 +60,7 @@ const SEVERITY = {
   // intentionally forward-link to a page not yet published.
   'broken-internal': 'warn', // /docs/... link resolves to no published page
   'link-to-draft': 'warn',   // a PUBLISHED page links to a draft: true page
+  'link-to-deprecated': 'warn', // a link points at a deprecated: true page (still live; a smell)
   // e2e specs hardcode doc slugs in goto()/baseURL refs. When an IA move changes a
   // slug, a redirect keeps real users working but lands the test on the redirect
   // STUB (no canvas/content) → spurious timeout. Catch the stale slug here, at
@@ -148,7 +152,7 @@ function fmField(fmLines, key) {
 
 /**
  * Build the corpus slug index used by the internal-link checks.
- * Maps a normalized route ("/<slug-without-leading-slash>") → { rel, draft }.
+ * Maps a normalized route ("/<slug-without-leading-slash>") → { rel, draft, deprecated }.
  * Only docs carry author-controlled absolute slugs we link to via /docs/…, so
  * we index the docs/ tree (the only space these /docs/ links can target).
  * Returns { byRoute, hasAnyDoc }.
@@ -162,9 +166,10 @@ function buildSlugIndex(docsDir) {
     if (!slug || !slug.startsWith('/')) continue; // only absolute-slug docs are addressable
     const draftRaw = (fmField(fm, 'draft') || '').toLowerCase();
     const draft = draftRaw === 'true';
+    const deprecated = (fmField(fm, 'deprecated') || '').toLowerCase() === 'true';
     // Route the doc is served at, minus the /docs prefix, normalized (no trailing slash).
     const route = (DOCS_ROUTE_PREFIX + slug).replace(/\/+$/, '');
-    byRoute.set(route, { rel: path.relative(ROOT, f), draft });
+    byRoute.set(route, { rel: path.relative(ROOT, f), draft, deprecated });
   }
   return { byRoute, hasAnyDoc: files.length > 0 };
 }
@@ -394,6 +399,16 @@ function scanFile(file, slugIndex) {
             file: rel, line: lineNo, kind: 'link-to-draft', severity: SEVERITY['link-to-draft'],
             detail: `published page links to a draft page (${hit.rel} has draft: true)`,
             suggest: 'un-draft the target before linking from a live page, or remove/defer the link',
+          });
+        } else if (hit.deprecated) {
+          // The target resolves (deprecated pages ship), so it's not broken — but a link
+          // INTO deprecated content is a smell. Flagged for any live target (not draft:
+          // a draft→deprecated link isn't shipped yet, but the draft branch already caught
+          // draft targets, so reaching here means the target is a live deprecated page).
+          problems.push({
+            file: rel, line: lineNo, kind: 'link-to-deprecated', severity: SEVERITY['link-to-deprecated'],
+            detail: `link points at a deprecated page (${hit.rel} has deprecated: true)`,
+            suggest: 'point at the replacement (deprecated_for) instead, or drop the link',
           });
         }
       }

--- a/bytesofpurpose-blog/scripts/validate-redirects.js
+++ b/bytesofpurpose-blog/scripts/validate-redirects.js
@@ -14,6 +14,8 @@
  *                     doesn't exist, or its slug differs). [ERROR — this fails the prod build]
  *   - to-draft        a redirect `to:` a DRAFT page (excluded from prod → invalid prod build).
  *                     [ERROR]
+ *   - to-deprecated   a redirect `to:` a DEPRECATED page. It still resolves (deprecated pages
+ *                     ship), so not a build-breaker — but consider pointing at its replacement. [warn]
  *   - to-chain        a redirect `to:` (b) that is itself the `from:` of ANOTHER redirect (b→c),
  *                     i.e. a chain a→b→c. Docusaurus does NOT follow chains: a→b lands on b, which
  *                     is a redirect stub (a 404), not transitively on c. Collapse it to a→c. [ERROR]
@@ -64,10 +66,13 @@ function walk(absDir, out = []) {
 
 const norm = (u) => (u.length > 1 ? u.replace(/\/$/, '') : u); // strip trailing slash (except '/')
 
-// Build the published-URL set + the draft-URL set.
+// Build the published-URL set + the draft-URL set (+ the deprecated-URL set — a
+// deprecated page is ALSO published, so it lands in both: `published` keeps the
+// redirect valid, `deprecated` powers the advisory `to-deprecated` warning).
 function collectUrls() {
   const published = new Set();
   const draft = new Set();
+  const deprecated = new Set();
 
   // Docs: an absolute (leading-slash) slug is INSTANCE-RELATIVE → base + slug. Otherwise the
   // permalink is base + <dir path> (+ slug rename of the last segment). We resolve the common
@@ -88,6 +93,7 @@ function collectUrls() {
         if (/README|index/i.test(path.basename(fp)) && segs.length === 0 && !data.slug) url = base;
       }
       (data.draft === true ? draft : published).add(norm(url));
+      if (data.deprecated === true) deprecated.add(norm(url));
     }
   }
 
@@ -102,7 +108,9 @@ function collectUrls() {
         .replace(/\.mdx?$/, '')
         .replace(/^\d{4}-\d{2}-\d{2}-/, '');
       const slug = (data.slug || fileSlug).toString().replace(/^\//, '');
-      (data.draft === true ? draft : published).add(norm(`${base}/${slug}`));
+      const url = norm(`${base}/${slug}`);
+      (data.draft === true ? draft : published).add(url);
+      if (data.deprecated === true) deprecated.add(url);
     }
   }
 
@@ -112,7 +120,7 @@ function collectUrls() {
     for (const e of walkPages(pagesDir)) published.add(norm(e));
   }
 
-  return {published, draft};
+  return {published, draft, deprecated};
 }
 
 function walkPages(absDir, base = '', out = []) {
@@ -188,7 +196,7 @@ function wildcardTargetOf(to) {
 // ── 3. Validate ────────────────────────────────────────────────────────────
 function main() {
   const json = process.argv.includes('--json');
-  const {published, draft} = collectUrls();
+  const {published, draft, deprecated} = collectUrls();
   const redirects = loadRedirects();
   const findings = [];
 
@@ -246,6 +254,12 @@ function main() {
     if (published.has(nFrom)) {
       findings.push({tier: 'warn', id: 'from-collision', from, to, detail: `redirect FROM ${from} is also a real published page; the page wins and this redirect never fires.`});
     }
+
+    // to-deprecated: the target resolves (deprecated pages ship), so this is not a build-breaker —
+    // but sending readers to a deprecated page is a smell; point at its replacement if one exists.
+    if (deprecated.has(nTo)) {
+      findings.push({tier: 'warn', id: 'to-deprecated', from, to, detail: `redirect target ${to} is a DEPRECATED page (still live, so this resolves — but consider pointing at its replacement instead).`});
+    }
   }
 
   for (const [from, n] of froms) {
@@ -253,7 +267,7 @@ function main() {
   }
 
   if (json) {
-    console.log(JSON.stringify({counts: {redirects: redirects.length, published: published.size, draft: draft.size}, findings}, null, 2));
+    console.log(JSON.stringify({counts: {redirects: redirects.length, published: published.size, draft: draft.size, deprecated: deprecated.size}, findings}, null, 2));
     process.exit(0);
   }
 

--- a/bytesofpurpose-blog/src/components/DeprecatedBanner/index.tsx
+++ b/bytesofpurpose-blog/src/components/DeprecatedBanner/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {isLocalhost} from '@site/src/experiments';
+import styles from './styles.module.css';
+
+/**
+ * DeprecatedBanner renders a red top-of-page notice from a post's deprecation
+ * frontmatter (`deprecated: true` + `deprecated_reason` + optional
+ * `deprecated_for`). It is the on-page sibling of the dev-only "Dep" sidebar/title
+ * badge (see src/theme/DocSidebarItem/deprecatedBadge) — the reader-facing warning
+ * that a still-live page is outdated.
+ *
+ * Gated to localhost + non-prod exactly like the draft badge: deprecated pages DO
+ * ship to production, but by design the deprecation signal is a dev-only cue for
+ * now and never leaks to real readers. Renders nothing when not deprecated, in
+ * production, or off-localhost.
+ *
+ * Mounted automatically by the swizzled doc/blog item wrappers (DocItem/Content,
+ * BlogPostItem/Content) so an author never has to place it — they only set the
+ * frontmatter.
+ */
+export interface DeprecatedBannerProps {
+  deprecated?: unknown;
+  reason?: unknown;
+  replacement?: unknown;
+}
+
+function asText(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+export default function DeprecatedBanner({
+  deprecated,
+  reason,
+  replacement,
+}: DeprecatedBannerProps): React.JSX.Element | null {
+  if (deprecated !== true) return null;
+  // Dev-only, mirroring the draft/deprecated badge gate.
+  if (process.env.NODE_ENV === 'production') return null;
+  if (!isLocalhost()) return null;
+
+  const reasonText = asText(reason);
+  const replacementUrl = asText(replacement);
+
+  return (
+    <aside className={styles.banner} role="note" aria-label="Deprecated">
+      <p className={styles.title}>⚠️ Deprecated</p>
+      {reasonText && <p className={styles.reason}>{reasonText}</p>}
+      {replacementUrl && (
+        <p className={styles.replacement}>
+          <a href={replacementUrl}>See the current version →</a>
+        </p>
+      )}
+    </aside>
+  );
+}

--- a/bytesofpurpose-blog/src/components/DeprecatedBanner/styles.module.css
+++ b/bytesofpurpose-blog/src/components/DeprecatedBanner/styles.module.css
@@ -1,0 +1,38 @@
+/* DeprecatedBanner — a red top-of-page notice that a still-live page is outdated.
+   Models PostQuestions' quiet-card treatment (spacing/radius tokens) but in a red
+   danger palette. Dev-only, so it never ships to real readers; still themed for
+   light + dark so it reads correctly on localhost in either mode. */
+
+.banner {
+  margin: var(--space-4) 0 var(--space-5);
+  padding: var(--space-4) var(--space-5);
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-left: 3px solid #dc2626;
+  border-radius: var(--radius-md);
+}
+html[data-theme='dark'] .banner {
+  background: rgba(220, 38, 38, 0.1);
+  border-color: rgba(220, 38, 38, 0.4);
+  border-left-color: #ef4444;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-sans-body);
+  font-weight: 700;
+  color: #991b1b;
+}
+html[data-theme='dark'] .title {
+  color: #fca5a5;
+}
+
+.reason {
+  margin: var(--space-2) 0 0;
+  color: var(--text-body);
+  line-height: 1.55;
+}
+
+.replacement {
+  margin: var(--space-2) 0 0;
+}

--- a/bytesofpurpose-blog/src/theme/BlogPostItem/Content/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogPostItem/Content/index.tsx
@@ -4,6 +4,7 @@ import {blogPostContainerID} from '@docusaurus/utils-common';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import MDXContent from '@theme/MDXContent';
 import PostQuestions from '@site/src/components/PostQuestions';
+import DeprecatedBanner from '@site/src/components/DeprecatedBanner';
 
 // Swizzled @theme/BlogPostItem/Content: re-implements the upstream component
 // (which just wraps the MDX body) and additionally renders the "Questions this
@@ -23,6 +24,13 @@ export default function BlogPostItemContent({
       // This ID is used for the feed generation to locate the main content.
       id={isBlogPostPage ? blogPostContainerID : undefined}
       className={clsx('markdown', className)}>
+      {isBlogPostPage && (
+        <DeprecatedBanner
+          deprecated={(frontMatter as {deprecated?: unknown}).deprecated}
+          reason={(frontMatter as {deprecated_reason?: unknown}).deprecated_reason}
+          replacement={(frontMatter as {deprecated_for?: unknown}).deprecated_for}
+        />
+      )}
       {isBlogPostPage && (
         <PostQuestions questions={(frontMatter as {questions?: unknown}).questions} />
       )}

--- a/bytesofpurpose-blog/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -6,6 +6,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import ShareButton from '@site/src/components/ShareButton';
 import {isLocalhost} from '@site/src/experiments';
 import {DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
+import {DeprecatedBadge} from '@site/src/theme/DocSidebarItem/deprecatedBadge';
 import styles from './styles.module.css';
 
 // Build a vscode://file/<abs-path> URI from the post's aliased source path
@@ -40,6 +41,16 @@ function useIsDraftPost(frontMatter?: {draft?: boolean}): boolean {
   return frontMatter?.draft === true && isLocalhost();
 }
 
+// Deprecated posts ship to prod (unlike drafts), but their "Dep" badge is
+// dev/localhost-gated by design — same gate as the draft badge above.
+// `deprecated` isn't a declared field on BlogPostFrontMatter (unlike `draft`), so
+// read it through an unknown-cast the way the Content swizzles do for `questions`.
+function useIsDeprecatedPost(frontMatter?: unknown): boolean {
+  if (process.env.NODE_ENV === 'production') return false;
+  const deprecated = (frontMatter as {deprecated?: unknown} | undefined)?.deprecated;
+  return deprecated === true && isLocalhost();
+}
+
 export default function BlogPostItemHeaderTitle({
   className,
 }: {
@@ -51,6 +62,7 @@ export default function BlogPostItemHeaderTitle({
   const shareDescription =
     (frontMatter?.description as string | undefined) || metadata.description;
   const isDraft = useIsDraftPost(frontMatter);
+  const isDeprecated = useIsDeprecatedPost(frontMatter);
   const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
 
   // Dev-only: when a post is a draft, make its "D" badge a link that opens the
@@ -82,6 +94,7 @@ export default function BlogPostItemHeaderTitle({
     <TitleHeading className={clsx(styles.title, className)}>
       {isBlogPostPage ? title : <Link to={permalink}>{title}</Link>}
       {badge}
+      {isDeprecated && <DeprecatedBadge />}
     </TitleHeading>
   );
 

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Desktop/index.tsx
@@ -6,6 +6,7 @@ import {useVisibleBlogSidebarItems} from '@docusaurus/plugin-content-blog/client
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
 import {useLocation} from '@docusaurus/router';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
+import {useIsBlogDeprecated, DeprecatedBadge} from '@site/src/theme/DocSidebarItem/deprecatedBadge';
 import {
   useBlogSidebarLabel,
   usePartitionedBlogItems,
@@ -30,6 +31,7 @@ function SidebarItemLink({
   linkActiveClassName?: string;
 }) {
   const isDraft = useIsBlogDraft(item.permalink);
+  const isDeprecated = useIsBlogDeprecated(item.permalink);
   const label = useBlogSidebarLabel(item.permalink, item.title);
   return (
     <Link
@@ -40,6 +42,7 @@ function SidebarItemLink({
       title={item.title}>
       {label}
       {isDraft && <DraftBadge />}
+      {isDeprecated && <DeprecatedBadge />}
     </Link>
   );
 }

--- a/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
+++ b/bytesofpurpose-blog/src/theme/BlogSidebar/Mobile/index.tsx
@@ -6,6 +6,7 @@ import {NavbarSecondaryMenuFiller} from '@docusaurus/theme-common';
 import BlogSidebarContent from '@theme/BlogSidebar/Content';
 import {useLocation} from '@docusaurus/router';
 import {useIsBlogDraft, DraftBadge} from '@site/src/theme/DocSidebarItem/draftBadge';
+import {useIsBlogDeprecated, DeprecatedBadge} from '@site/src/theme/DocSidebarItem/deprecatedBadge';
 import {
   useBlogSidebarLabel,
   usePartitionedBlogItems,
@@ -20,6 +21,7 @@ import styles from './styles.module.css';
 
 function SidebarItemLink({item}: {item: {title: string; permalink: string}}) {
   const isDraft = useIsBlogDraft(item.permalink);
+  const isDeprecated = useIsBlogDeprecated(item.permalink);
   const label = useBlogSidebarLabel(item.permalink, item.title);
   return (
     <Link
@@ -30,6 +32,7 @@ function SidebarItemLink({item}: {item: {title: string; permalink: string}}) {
       title={item.title}>
       {label}
       {isDraft && <DraftBadge />}
+      {isDeprecated && <DeprecatedBadge />}
     </Link>
   );
 }

--- a/bytesofpurpose-blog/src/theme/DocItem/Content/index.tsx
+++ b/bytesofpurpose-blog/src/theme/DocItem/Content/index.tsx
@@ -6,6 +6,7 @@ import Heading from '@theme/Heading';
 import MDXContent from '@theme/MDXContent';
 import ShareButton from '@site/src/components/ShareButton';
 import PostQuestions from '@site/src/components/PostQuestions';
+import DeprecatedBanner from '@site/src/components/DeprecatedBanner';
 
 // Swizzled @theme/DocItem/Content: re-implements the upstream component (which
 // only renders a synthetic <h1> + the MDX body) and additionally mounts the
@@ -40,6 +41,11 @@ export default function DocItemContent({
     (frontMatter.description as string | undefined) || metadata.description;
   return (
     <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
+      <DeprecatedBanner
+        deprecated={(frontMatter as {deprecated?: unknown}).deprecated}
+        reason={(frontMatter as {deprecated_reason?: unknown}).deprecated_reason}
+        replacement={(frontMatter as {deprecated_for?: unknown}).deprecated_for}
+      />
       {syntheticTitle ? (
         // Synthetic title: keep the exact <Heading as="h1"> (preserves TOC/anchor)
         // and place the share control inline beside it.

--- a/bytesofpurpose-blog/src/theme/DocSidebarItem/Link/index.tsx
+++ b/bytesofpurpose-blog/src/theme/DocSidebarItem/Link/index.tsx
@@ -6,6 +6,7 @@ import Link from '@docusaurus/Link';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import IconExternalLink from '@theme/Icon/ExternalLink';
 import {useIsDraft, DraftBadge} from '../draftBadge';
+import {useIsDeprecated, DeprecatedBadge} from '../deprecatedBadge';
 import {useIsPremium, LockBadge} from '../lockBadge';
 import {useDocKindEmoji} from '../kindEmoji';
 import styles from './styles.module.css';
@@ -41,6 +42,7 @@ export default function DocSidebarItemLink({
   const isActive = isActiveSidebarItem(item, activePath);
   const isInternalLink = isInternalUrl(href);
   const isDraft = useIsDraft(href);
+  const isDeprecated = useIsDeprecated(href);
   const isPremium = useIsPremium(href);
   // Prepend the doc's kind emoji (e.g. 🗂️ for kind: hub) unless the label already has one.
   const kindEmoji = useDocKindEmoji(href);
@@ -73,6 +75,7 @@ export default function DocSidebarItemLink({
         {...props}>
         <LinkLabel label={displayLabel} />
         {isDraft && <DraftBadge />}
+        {isDeprecated && <DeprecatedBadge />}
         {isPremium && <LockBadge />}
         {!isInternalLink && <IconExternalLink />}
       </Link>

--- a/bytesofpurpose-blog/src/theme/DocSidebarItem/deprecatedBadge.module.css
+++ b/bytesofpurpose-blog/src/theme/DocSidebarItem/deprecatedBadge.module.css
@@ -1,0 +1,24 @@
+/* Dev/localhost-only "Dep" pill shown after a sidebar item's label. Red, to
+   distinguish it from the amber draft "D" pill (draftBadge.module.css). */
+.deprecatedBadge {
+  display: inline-block;
+  flex: none;
+  margin-left: 0.4rem;
+  padding: 0 0.32rem;
+  min-width: 1.15em;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap; /* never wrap "Dep" to its own line beside long labels */
+  vertical-align: middle;
+  color: #991b1b;
+  background: #fecaca;
+  border: 1px solid #ef4444;
+}
+html[data-theme='dark'] .deprecatedBadge {
+  color: #fecaca;
+  background: rgba(239, 68, 68, 0.18);
+  border-color: #b91c1c;
+}

--- a/bytesofpurpose-blog/src/theme/DocSidebarItem/deprecatedBadge.tsx
+++ b/bytesofpurpose-blog/src/theme/DocSidebarItem/deprecatedBadge.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {useAllPluginInstancesData} from '@docusaurus/useGlobalData';
+import {isLocalhost} from '@site/src/experiments';
+import styles from './deprecatedBadge.module.css';
+
+// Shared helper for the (dev/localhost-only) "Dep" badge on sidebar items.
+// Reads the deprecated-permalink set published by plugins/draft-docs and tells
+// the swizzled Link/BlogSidebar whether a given href is a deprecated page.
+//
+// DEPRECATED pages (unlike drafts) DO ship to production — they stay live for
+// URL stability/history. But by design their badge + banner are gated to
+// localhost + non-prod exactly like the draft badge (mirrors useIsDraft), so the
+// deprecation cue is dev-only for now and never leaks to the deployed site.
+
+function useDeprecatedPermalinks(): Set<string> {
+  const data = useAllPluginInstancesData('draft-docs-plugin') as
+    | {default?: {deprecatedPermalinks?: string[]}}
+    | undefined;
+  const list = data?.default?.deprecatedPermalinks ?? [];
+  return React.useMemo(() => new Set(list.map(normalize)), [list]);
+}
+
+function useBlogDeprecatedPermalinks(): Set<string> {
+  const data = useAllPluginInstancesData('draft-docs-plugin') as
+    | {default?: {blogDeprecatedPermalinks?: string[]}}
+    | undefined;
+  const list = data?.default?.blogDeprecatedPermalinks ?? [];
+  return React.useMemo(() => new Set(list.map(normalize)), [list]);
+}
+
+/**
+ * True when a BLOG sidebar item's permalink is a deprecated post. Used by the
+ * swizzled BlogSidebar (Initiatives/Designs), whose items carry only a permalink
+ * (no deprecated flag). Same localhost + non-prod gating as the docs badge.
+ */
+export function useIsBlogDeprecated(permalink?: string): boolean {
+  const deprecated = useBlogDeprecatedPermalinks();
+  if (process.env.NODE_ENV === 'production') return false;
+  if (!permalink || !isLocalhost()) return false;
+  return deprecated.has(normalize(permalink));
+}
+
+function normalize(href: string): string {
+  // Compare without trailing slash so '/foo' and '/foo/' match.
+  if (!href) return href;
+  return href.length > 1 ? href.replace(/\/$/, '') : href;
+}
+
+/**
+ * True when a LEAF doc link is deprecated. Gated to localhost + dev build; no-ops
+ * in production (isLocalhost() is false there). Only leaf doc links are badged;
+ * see plugins/draft-docs for why categories aren't.
+ */
+export function useIsDeprecated(href?: string): boolean {
+  const deprecated = useDeprecatedPermalinks();
+  if (process.env.NODE_ENV === 'production') return false;
+  if (!href || !isLocalhost()) return false;
+  return deprecated.has(normalize(href));
+}
+
+export function DeprecatedBadge(): React.JSX.Element {
+  // Short "Dep" so the pill never wraps next to long sidebar labels; full word
+  // is in the tooltip + aria-label.
+  return (
+    <span
+      className={styles.deprecatedBadge}
+      title="Deprecated"
+      aria-label="deprecated">
+      Dep
+    </span>
+  );
+}

--- a/packages/blog-ui/src/components/Accordion/index.tsx
+++ b/packages/blog-ui/src/components/Accordion/index.tsx
@@ -31,8 +31,13 @@ export interface AccordionItem {
   /** Fold body: any React content (prose, a list, a component). */
   body: ReactNode;
   open?: boolean;
-  /** Small pill, e.g. "chosen" / "rejected". */
+  /** Small pill. The CHOSEN option gets a solid brand pill; every other option that
+   *  carries a verdict gets a quiet grey "Considered" pill, so the decision reads at a
+   *  glance (only one green pill). Pass `chosen: true` for the winner; for the rest, set
+   *  a verdict (any truthy value, or the string 'considered') to show the muted pill. */
   verdict?: string;
+  /** Mark the winning option: renders the solid CHOSEN pill. */
+  chosen?: boolean;
 }
 
 export interface AccordionProps {
@@ -47,16 +52,28 @@ const Accordion: React.FC<AccordionProps> = ({items, label, className, style}) =
   return (
     <div className={clsx(styles.accordion, className)} style={style}>
       {label && <p className={styles.label}>{label}</p>}
-      {items.map((item, i) => (
-        <details key={i} className={styles.item} open={item.open}>
-          <summary className={styles.summary}>
-            <span className={styles.summaryText}>{item.summary}</span>
-            {item.verdict && <span className={styles.verdict}>{item.verdict}</span>}
-            <span className={styles.chevron} aria-hidden="true" />
-          </summary>
-          <div className={styles.body}>{item.body}</div>
-        </details>
-      ))}
+      {items.map((item, i) => {
+        // The winner shows a solid "chosen" pill; any other option carrying a verdict
+        // shows a quiet grey "Considered" pill (so only one pill draws the eye).
+        const showPill = item.chosen || !!item.verdict;
+        const pillLabel = item.chosen ? 'chosen' : 'considered';
+        return (
+          <details key={i} className={styles.item} open={item.open}>
+            <summary className={styles.summary}>
+              <span className={styles.summaryText}>{item.summary}</span>
+              {showPill && (
+                <span
+                  className={clsx(styles.verdict, item.chosen ? styles.verdictChosen : styles.verdictConsidered)}
+                >
+                  {pillLabel}
+                </span>
+              )}
+              <span className={styles.chevron} aria-hidden="true" />
+            </summary>
+            <div className={styles.body}>{item.body}</div>
+          </details>
+        );
+      })}
     </div>
   );
 };

--- a/packages/blog-ui/src/components/Accordion/styles.module.css
+++ b/packages/blog-ui/src/components/Accordion/styles.module.css
@@ -55,10 +55,20 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ifm-background-surface-color);
-  background: var(--ifm-color-primary);
   border-radius: var(--radius-pill);
   padding: 0.125rem var(--space-3);
+}
+/* The winner: a solid brand pill that draws the eye. */
+.verdictChosen {
+  color: var(--ifm-background-surface-color);
+  background: var(--ifm-color-primary);
+}
+/* Every other option: a quiet outlined grey pill, so it reads as "we looked at this"
+   without competing with the one chosen pill. */
+.verdictConsidered {
+  color: var(--ifm-color-content-secondary);
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
 }
 
 .chevron {

--- a/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
+++ b/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
@@ -1,22 +1,27 @@
-import React, {CSSProperties, ReactNode} from 'react';
+import React, {CSSProperties, ReactNode, useCallback, useEffect, useRef, useState} from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 
 /**
- * ComparisonMatrix : a criteria x options comparison for decision posts. Options are
+ * ComparisonMatrix: a criteria x options comparison for decision posts. Options are
  * columns, criteria are rows, each cell is a rating (a yes/no/partial mark or a short
  * value). The chosen option's column is highlighted and badged so the decision is
  * scannable at a glance. Pairs with <Accordion> (which carries the narrative); the
  * matrix carries the head-to-head.
  *
  * Rendered as a real HTML table (proper <th scope>) so a screen reader announces
- * "Consistency, Option B: partial". Zero JS; the table scrolls inside its own wrapper
- * on mobile rather than pushing the page sideways. A build-time gate throws if a cell
- * references an option id that does not exist.
+ * "Consistency, Option B: partial". The table scrolls inside its own wrapper on mobile
+ * rather than pushing the page sideways. A build-time gate throws if a cell references an
+ * option id that does not exist.
  *
- * Distinct from OptionGrid/DecisionNote (design-system specimens that show explored
- * design directions with a chosen ring + WHY); ComparisonMatrix is the head-to-head
- * feature table for a decision post.
+ * JUSTIFY A RATING: a cell can be a plain rating string OR an object carrying a `note`
+ * (why that rating was given) and optional `footnotes`. A cell with a note renders its
+ * mark as a clickable button that opens a focus modal with the justification, so the "how
+ * do they score" table can also answer "why this score" on demand, without cluttering the
+ * grid. Zero client JS ships unless at least one cell has a note.
+ *
+ * Distinct from OptionGrid/DecisionNote (design-system specimens that show explored design
+ * directions with a chosen ring + WHY); ComparisonMatrix is the head-to-head feature table.
  *
  * Usage in MDX:
  *
@@ -29,13 +34,35 @@ import styles from './styles.module.css';
  *       {id: 'c', label: 'Redis'},
  *     ]}
  *     criteria={[
- *       {label: 'Zero-ops', cells: {a: 'no', b: 'yes', c: 'partial'}},
- *       {label: 'Relational', cells: {a: 'yes', b: 'yes', c: 'no'}},
+ *       {label: 'Zero-ops', cells: {
+ *         a: 'no',
+ *         b: {rating: 'yes', note: <>A single file. No server, no daemon, no ops.</>,
+ *             footnotes: [{id: 'a', content: <>See the SQLite docs on serverless operation.</>}]},
+ *         c: 'partial',
+ *       }},
  *       {label: 'Cost', cells: {a: '$$', b: 'free', c: '$'}},
  *     ]}
  *   />
  */
 export type Rating = 'yes' | 'no' | 'partial' | string;
+
+export interface CellFootnote {
+  id: string;
+  content: ReactNode;
+}
+
+export interface CellSpec {
+  /** 'yes'|'no'|'partial' render as marks; any other string renders as literal text. */
+  rating: Rating;
+  /** Why this rating was given. When present, the cell's mark becomes clickable and this
+   *  opens in a focus modal. Any React content (prose, a list, a <sup> footnote ref). */
+  note?: ReactNode;
+  /** Optional footnotes rendered as a definition list under the note in the modal. */
+  footnotes?: CellFootnote[];
+}
+
+/** A cell is either a plain rating string or a rich spec with a justification. */
+export type Cell = Rating | CellSpec;
 
 export interface MatrixOption {
   id: string;
@@ -46,9 +73,8 @@ export interface MatrixOption {
 
 export interface MatrixCriterion {
   label: string;
-  /** One cell per option, keyed by option id. 'yes'|'no'|'partial' render as marks;
-   *  any other string renders as literal text. */
-  cells: Record<string, Rating>;
+  /** One cell per option, keyed by option id. */
+  cells: Record<string, Cell>;
 }
 
 export interface ComparisonMatrixProps {
@@ -65,6 +91,20 @@ const MARK: Record<string, {glyph: string; label: string; cls: string}> = {
   no: {glyph: '○', label: 'no', cls: 'no'}, // ○
   partial: {glyph: '◐', label: 'partial', cls: 'partial'}, // ◐
 };
+
+function isSpec(c: Cell | undefined): c is CellSpec {
+  return typeof c === 'object' && c !== null && 'rating' in c;
+}
+function cellRating(c: Cell | undefined): Rating | undefined {
+  if (c === undefined) return undefined;
+  return isSpec(c) ? c.rating : c;
+}
+function cellNote(c: Cell | undefined): ReactNode | undefined {
+  return isSpec(c) ? c.note : undefined;
+}
+function cellFootnotes(c: Cell | undefined): CellFootnote[] {
+  return isSpec(c) && c.footnotes ? c.footnotes : [];
+}
 
 function assertValid(props: ComparisonMatrixProps): string[] {
   const {title, desc, options, criteria} = props;
@@ -89,26 +129,63 @@ function assertValid(props: ComparisonMatrixProps): string[] {
   return warnings;
 }
 
+interface ActiveCell {
+  criterion: string;
+  option: string;
+  rating: Rating | undefined;
+  note: ReactNode;
+  footnotes: CellFootnote[];
+}
+
 const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
   const {title, desc, options, criteria, className, style} = props;
   // Throws (fails the build) on a cell keyed to a nonexistent option.
   const warnings = assertValid(props);
-  React.useEffect(() => {
+  useEffect(() => {
     for (const w of warnings) console.warn(`[comparison-matrix] warning: ${w}`);
   }, [warnings]);
 
-  const renderCell = (v: Rating | undefined): ReactNode => {
-    const mark = v ? MARK[v] : undefined;
+  const optionLabel = new Map(options.map((o) => [o.id, o.label]));
+  // The matrix is interactive only if at least one cell carries a note.
+  const interactive = criteria.some((c) =>
+    options.some((o) => cellNote(c.cells[o.id]) !== undefined),
+  );
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [active, setActive] = useState<ActiveCell | null>(null);
+  const openCell = useCallback(
+    (criterionLabel: string, optionId: string, cell: Cell | undefined) => {
+      setActive({
+        criterion: criterionLabel,
+        option: optionLabel.get(optionId) ?? optionId,
+        rating: cellRating(cell),
+        note: cellNote(cell),
+        footnotes: cellFootnotes(cell),
+      });
+    },
+    [optionLabel],
+  );
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (active && !dlg.open && dlg.showModal) dlg.showModal();
+    if (!active && dlg.open) dlg.close();
+  }, [active]);
+
+  const renderMark = (rating: Rating | undefined): ReactNode => {
+    const mark = rating ? MARK[rating] : undefined;
     if (mark) {
       return (
-        <span className={clsx(styles.mark, styles[`mark-${mark.cls}`])} title={mark.label}>
+        <span className={clsx(styles.mark, styles[`mark-${mark.cls}`])}>
           <span aria-hidden="true">{mark.glyph}</span>
           <span className={styles.sr}>{mark.label}</span>
         </span>
       );
     }
-    return <span className={styles.value}>{v ?? ''}</span>;
+    return <span className={styles.value}>{rating ?? ''}</span>;
   };
+
+  const activeRatingMark = active ? MARK[active.rating ?? ''] : undefined;
 
   return (
     <figure className={clsx(styles.matrix, className)} style={style}>
@@ -138,19 +215,84 @@ const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
                 <th scope="row" className={styles.criterion}>
                   {c.label}
                 </th>
-                {options.map((o) => (
-                  <td
-                    key={o.id}
-                    className={clsx(styles.cell, o.chosen && styles.cellChosen)}
-                  >
-                    {renderCell(c.cells[o.id])}
-                  </td>
-                ))}
+                {options.map((o) => {
+                  const cell = c.cells[o.id];
+                  const rating = cellRating(cell);
+                  const hasNote = cellNote(cell) !== undefined;
+                  return (
+                    <td
+                      key={o.id}
+                      className={clsx(styles.cell, o.chosen && styles.cellChosen)}
+                    >
+                      {hasNote ? (
+                        <button
+                          type="button"
+                          className={styles.cellButton}
+                          aria-haspopup="dialog"
+                          aria-label={`${c.label}, ${optionLabel.get(o.id)}: ${
+                            rating ?? ''
+                          }. Why?`}
+                          onClick={() => openCell(c.label, o.id, cell)}
+                        >
+                          {renderMark(rating)}
+                          <span className={styles.whyDot} aria-hidden="true" />
+                        </button>
+                      ) : (
+                        renderMark(rating)
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+
+      {interactive && (
+        <dialog
+          ref={dialogRef}
+          className={styles.modal}
+          aria-labelledby={`${styles.modalTitle}-h`}
+          onClose={() => setActive(null)}
+          onClick={(e) => {
+            if (e.target === dialogRef.current) setActive(null);
+          }}
+        >
+          <div className={styles.modalInner}>
+            <button
+              type="button"
+              className={styles.modalClose}
+              aria-label="Close"
+              onClick={() => setActive(null)}
+            >
+              &times;
+            </button>
+            <p className={styles.modalEyebrow}>
+              {active?.criterion} · {active?.option}
+            </p>
+            <h3 className={styles.modalTitle}>
+              {activeRatingMark ? (
+                <span className={clsx(styles.mark, styles[`mark-${activeRatingMark.cls}`])}>
+                  <span aria-hidden="true">{activeRatingMark.glyph}</span>
+                </span>
+              ) : null}
+              <span>{activeRatingMark ? activeRatingMark.label : active?.rating}</span>
+            </h3>
+            {active?.note && <div className={styles.modalNote}>{active.note}</div>}
+            {active && active.footnotes.length > 0 && (
+              <dl className={styles.modalFootnotes}>
+                {active.footnotes.map((f) => (
+                  <React.Fragment key={f.id}>
+                    <dt>{f.id}</dt>
+                    <dd>{f.content}</dd>
+                  </React.Fragment>
+                ))}
+              </dl>
+            )}
+          </div>
+        </dialog>
+      )}
     </figure>
   );
 };

--- a/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
+++ b/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
@@ -126,8 +126,8 @@ const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
                   scope="col"
                   className={clsx(styles.option, o.chosen && styles.optionChosen)}
                 >
-                  <span className={styles.optionLabel}>{o.label}</span>
                   {o.chosen && <span className={styles.chosenBadge}>chosen</span>}
+                  <span className={styles.optionLabel}>{o.label}</span>
                 </th>
               ))}
             </tr>

--- a/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
+++ b/packages/blog-ui/src/components/ComparisonMatrix/index.tsx
@@ -82,6 +82,10 @@ export interface ComparisonMatrixProps {
   desc?: string;
   options: MatrixOption[];
   criteria: MatrixCriterion[];
+  /** Show a small key explaining the marks (● yes / ○ no / ◐ partial), plus a note that a
+   *  mark with a "why" dot is clickable when any cell carries a justification. Off by
+   *  default; rendered straight from the mark map so it can never drift from the cells. */
+  legend?: boolean;
   className?: string;
   style?: CSSProperties;
 }
@@ -138,7 +142,7 @@ interface ActiveCell {
 }
 
 const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
-  const {title, desc, options, criteria, className, style} = props;
+  const {title, desc, options, criteria, legend = false, className, style} = props;
   // Throws (fails the build) on a cell keyed to a nonexistent option.
   const warnings = assertValid(props);
   useEffect(() => {
@@ -150,6 +154,18 @@ const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
   const interactive = criteria.some((c) =>
     options.some((o) => cellNote(c.cells[o.id]) !== undefined),
   );
+
+  // Which marks actually appear, so the legend only keys the ones in use (in mark order).
+  const usedMarks = (() => {
+    const present = new Set<string>();
+    for (const c of criteria)
+      for (const o of options) {
+        const r = cellRating(c.cells[o.id]);
+        if (r && MARK[r]) present.add(r);
+      }
+    return (['yes', 'no', 'partial'] as const).filter((k) => present.has(k));
+  })();
+  const showLegend = legend && usedMarks.length > 0;
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [active, setActive] = useState<ActiveCell | null>(null);
@@ -248,6 +264,30 @@ const ComparisonMatrix: React.FC<ComparisonMatrixProps> = (props) => {
           </tbody>
         </table>
       </div>
+
+      {showLegend && (
+        <dl className={styles.legend} aria-label="What the marks mean">
+          {usedMarks.map((k) => {
+            const m = MARK[k];
+            return (
+              <div className={styles.legendRow} key={k}>
+                <dt className={clsx(styles.mark, styles[`mark-${m.cls}`])} aria-hidden="true">
+                  {m.glyph}
+                </dt>
+                <dd className={styles.legendText}>{m.label}</dd>
+              </div>
+            );
+          })}
+          {interactive && (
+            <div className={styles.legendRow}>
+              <dt className={styles.legendWhy} aria-hidden="true">
+                <span className={styles.whyDot} />
+              </dt>
+              <dd className={styles.legendText}>a mark with this dot is clickable for the reasoning</dd>
+            </div>
+          )}
+        </dl>
+      )}
 
       {interactive && (
         <dialog

--- a/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
+++ b/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
@@ -262,3 +262,31 @@
     transition: none;
   }
 }
+
+/* Optional legend: a small key for the marks, rendered from the mark map (drift-free). */
+.legend {
+  margin: var(--space-3) 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-5);
+}
+.legendRow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.legend dt {
+  margin: 0;
+}
+.legendText {
+  margin: 0;
+  font-size: var(--text-body-sm);
+  color: var(--ifm-color-content-secondary);
+}
+.legendWhy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+}

--- a/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
+++ b/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
@@ -16,6 +16,11 @@
   border-collapse: collapse;
   width: 100%;
   font-size: var(--text-body-md);
+  /* The site's global markdown stylesheet gives every <table> a top/bottom margin;
+     inside the rounded scroll wrapper that pushes the table down and exposes a band of
+     page background above the header (the chosen-column tint then looks detached from
+     the top). Reset it so the header band sits flush against the wrapper's top edge. */
+  margin: 0;
 }
 
 .caption {

--- a/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
+++ b/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
@@ -49,13 +49,24 @@
   text-transform: uppercase;
   color: var(--ifm-color-content-secondary);
   background: var(--ifm-background-color);
+  /* Shrink-wrap the criterion column to its label so the option columns stretch to fill
+     the table width (width:1% is the standard table trick: the browser gives this column
+     only what its content needs, and auto-width columns take the rest). */
+  width: 1%;
+  white-space: nowrap;
 }
 
 .option {
   background: var(--ifm-background-color);
   font-weight: 600;
   vertical-align: bottom;
-  min-width: 120px;
+  /* Let the option columns absorb the width left over after the (shrink-wrapped) criterion
+     column, so the table fills its wrapper instead of sizing to content and leaving an
+     empty band on the right. `width: auto` here + `width: 1%` on the criterion column
+     (below) makes the browser stretch these equal-ish columns to fill the row. The
+     min-width keeps a mark column from collapsing too narrow. */
+  width: auto;
+  min-width: 110px;
 }
 .optionChosen {
   background: var(--accent-tint);
@@ -66,7 +77,8 @@
 }
 .chosenBadge {
   display: inline-block;
-  margin-top: var(--space-1);
+  /* The badge sits ABOVE the option label, so it reads "CHOSEN: SQLite" top-to-bottom. */
+  margin-bottom: var(--space-1);
   font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.08em;

--- a/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
+++ b/packages/blog-ui/src/components/ComparisonMatrix/styles.module.css
@@ -135,3 +135,130 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* A cell whose rating carries a justification: the mark becomes a button with a small
+   "why" indicator, and opens the focus modal on click. */
+.cellButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border: none;
+  background: transparent;
+  padding: 0.15rem 0.3rem;
+  margin: -0.15rem -0.3rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: inherit;
+  transition: background var(--duration-fast, 0.12s) var(--ease-standard, ease);
+}
+.cellButton:hover,
+.cellButton:focus-visible {
+  background: var(--accent-tint);
+  outline: none;
+}
+/* The small hollow "why" dot next to a justified mark, hinting it is clickable. */
+.whyDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  border: 1.5px solid var(--ifm-color-primary);
+  flex: none;
+  opacity: 0.6;
+}
+.cellButton:hover .whyDot,
+.cellButton:focus-visible .whyDot {
+  opacity: 1;
+  background: var(--ifm-color-primary);
+}
+
+/* Focus modal (mirrors the FlowDiagram / UseCaseDiagram modal). */
+.modal {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  max-width: min(460px, 92vw);
+  width: 100%;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  box-shadow: var(--shadow-md);
+}
+.modal::backdrop {
+  background: rgba(20, 32, 26, 0.4);
+}
+.modalInner {
+  position: relative;
+  padding: var(--space-6);
+}
+.modalClose {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  border: none;
+  background: transparent;
+  font-size: var(--text-h4);
+  line-height: 1;
+  color: var(--ifm-color-content-secondary);
+  cursor: pointer;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+}
+.modalClose:hover {
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-color);
+}
+.modalEyebrow {
+  font-size: var(--text-eyebrow);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin: 0 0 var(--space-2);
+}
+.modalTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-h4);
+  font-weight: 600;
+  margin: 0 0 var(--space-3);
+  padding-right: var(--space-6);
+  text-transform: capitalize;
+}
+.modalNote {
+  margin: 0 0 var(--space-4);
+  color: var(--text-body);
+  line-height: 1.6;
+}
+.modalNote > :first-child {
+  margin-top: 0;
+}
+.modalNote > :last-child {
+  margin-bottom: 0;
+}
+/* Footnotes as a compact definition list under the note. */
+.modalFootnotes {
+  margin: 0;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--bop-divider);
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-1) var(--space-3);
+  font-size: var(--text-body-sm);
+  color: var(--ifm-color-content-secondary);
+}
+.modalFootnotes dt {
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  font-variant-numeric: tabular-nums;
+}
+.modalFootnotes dd {
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cellButton,
+  .whyDot {
+    transition: none;
+  }
+}

--- a/packages/blog-ui/src/index.ts
+++ b/packages/blog-ui/src/index.ts
@@ -41,6 +41,9 @@ export type {
   MatrixOption,
   MatrixCriterion,
   Rating,
+  Cell,
+  CellSpec,
+  CellFootnote,
 } from './components/ComparisonMatrix';
 
 // Accordion — a foldable option list on native <details>/<summary> (zero JS). Each item has a


### PR DESCRIPTION
Two independent features developed in parallel on this branch, kept as distinct commits (rebase-merged, not squashed, so history stays attributable).

## Decision-kit (ComparisonMatrix + Accordion) polish + justifications
- `b9e0d6fdc` fix the 24px table-top-margin gap (header flush to the card)
- `b0a1ea398` full-width table, CHOSEN badge above the option label, grey "Considered" pills (not green "Rejected")
- `50662d3ec` clickable rating cells → a focus modal with a markdown justification + footnotes
- `07de1e664` an optional `legend` (● yes / ○ no / ◐ partial + a clickable-hint), drift-free from the mark map

## Deprecated-post mechanism (parallel session)
- `619ae634e` a `deprecated: true` frontmatter flag mirroring `draft:` — a red "Dep" pill + banner, dev-gated visuals but still shipped to prod for URL stability; validator + hook + redirect/link guards. Includes its plan doc.
- `66d9f85e7` the refine-design-post skill plan (skill not built yet)

Verified live per feature (decision-kit: full visual pass; deprecated: dev banner/pill + clean prod build). No content lost in the history reshape (tree verified identical to the pre-reshape backup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)