### PR TITLE
scan-blog-worthy: tech blog posts batch (learning plans + explainers)

### DIFF
--- a/bytesofpurpose-blog/blog/2020-01-06-a-learning-plan-for-graphql.mdx
+++ b/bytesofpurpose-blog/blog/2020-01-06-a-learning-plan-for-graphql.mdx
@@ -1,0 +1,62 @@
+---
+slug: a-learning-plan-for-graphql
+title: "A Learning Plan for GraphQL"
+description: "What to know when you're picking up GraphQL — why you'd reach for it over REST, and a curated set of docs, tutorials, and tools to learn it from."
+authors: [oeid]
+tags: [backend, software-engineering, learning-plan]
+date: 2020-01-06
+draft: true
+---
+
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+When I set out to learn GraphQL, the question that actually mattered wasn't "how do
+I write a query" — it was **"why would I reach for this instead of REST?"** GraphQL
+lets a client ask for exactly the fields it needs in one round trip, instead of
+stitching together several REST endpoints and throwing away the parts it didn't
+want. That's the whole pitch: the client describes the shape of the data, the server
+resolves it. Everything else is detail you can pick up once that clicks.
+
+This is the learning plan I kept — the resources worth starting from, grouped by how
+I actually used them.
+
+<!-- truncate -->
+
+## How to approach it
+
+A good way in, in order:
+
+[Step 1] Read **one "why GraphQL / thinking in graphs"** piece so the mental model
+lands before the syntax. The goal is to be able to say *when* GraphQL helps and when
+it doesn't.
+
+[Step 2] Work through **one core-concepts tutorial** end to end — schema, types,
+queries, resolvers — rather than skimming several.
+
+[Step 3] **Tinker with a real engine.** Stand up a GraphQL layer over a database
+(Hasura over Postgres is the fastest path) and run a stress test against the
+equivalent REST calls, so the performance trade-offs stop being abstract.
+
+The cards below are the specific resources I collected for each of those, and they
+grow over time.
+
+## Concepts and best practices
+
+Start here to build the model: what GraphQL is for, how to think in graphs, and the
+practices that keep a schema sane as it grows.
+
+<CategoryCarousel topic="learn-about-graphql" category="Learn about GraphQL" />
+
+## Tinkering: GraphQL over a real database
+
+Once the concepts land, the fastest way to internalize them is to put a GraphQL API
+in front of actual data and poke at it. These are the engines, tutorials, and schema
+tools I used to do that — Hasura over Postgres especially.
+
+<CategoryCarousel topic="learn-about-graphql" category="Tinker with GraphQL and Postgres ..." />
+
+---
+
+> This roadmap is curated from my own running notes on GraphQL. The resource lists
+> are a living collection — they're maintained as data, so the list grows without the
+> post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-01-06-questions-for-understanding-design-patterns.md
+++ b/bytesofpurpose-blog/blog/2020-01-06-questions-for-understanding-design-patterns.md
@@ -1,0 +1,85 @@
+---
+slug: questions-for-understanding-design-patterns
+title: "Questions for Understanding Design Patterns"
+description: "A reader's question-set for working through the classic Gang of Four Design Patterns book — the questions that actually unlock object-oriented design."
+authors: [oeid]
+tags: [software-engineering, design-patterns, question-set, best-practices]
+date: 2020-01-06
+draft: true
+---
+
+When I first sat down with *Design Patterns: Elements of Reusable Object-Oriented Software* (Gamma, Helm, Johnson, and Vlissides — the "Gang of Four"), I didn't take notes the usual way. Instead of summarizing what the book said, I wrote down the **questions** each section was answering. A pattern only sticks once you can state the problem it solves, so a good question is worth more than a tidy summary.
+
+What follows is that question-set: the questions I'd want a reader to be able to answer after a careful first pass through the book's introduction. Use them as a study guide, a self-quiz, or a checklist for whether a chapter actually landed.
+
+<!-- truncate -->
+
+## What design patterns are for
+
+- How is the quality of an object-oriented system measured?
+- How can developers leverage the expertise of other skilled architects and developers?
+- How does one design reusable object-oriented software — and what constraints must the design meet to do so?
+- How can a design be tested to ensure it is reusable?
+- What do experienced designers know that beginners don't? What traps do they avoid, and how do they steer clear of design déjà vu — solving the same problem the same wrong way again?
+- What activities do design patterns facilitate?
+- What are the essential elements of a design pattern?
+
+## Reading and organizing the catalog
+
+- How can a developer's point of view change how they understand a pattern? What makes one person see a pattern where another just sees a building block?
+- How can the choice of programming language change how a pattern is interpreted? Are all patterns applicable to every language? How do patterns translate between declarative and imperative languages?
+- How do we describe a design pattern in detail?
+- What is the *intent* of each pattern?
+- How are the patterns organized, and what are the relationships between them?
+
+## Solving design problems
+
+- How do patterns help solve design problems?
+- How do you decompose a problem into a relevant set of objects and the interactions between them?
+  - What is the description of an object, and how do programming languages commonly interact with objects?
+  - What is dynamic binding?
+  - How do you decide what should be an object at all?
+- How do patterns help you design interfaces, and how do they establish relationships between interfaces?
+
+## Modeling classes and relationships
+
+- How are object implementations (classes) represented in UML?
+- How do you represent an abstract class in a UML diagram — and how do you tell that a class *is* abstract? What is an abstract class?
+- How do you represent inheritance in a UML diagram? What is inheritance?
+- What is the difference between a class and a type?
+- What is the difference between class inheritance and interface inheritance?
+- Why is it important to program to an interface, not an implementation?
+- How does a class reference another class in UML?
+- How is *acquaintance* modeled in UML, and what is an acquaintance?
+- How is *aggregation* modeled in UML, and what is aggregation?
+
+## Reuse: inheritance vs. composition
+
+- How can functionality be reused in object-oriented systems?
+- How does reuse through inheritance differ from reuse through composition?
+  - What is white-box reuse? What is black-box reuse?
+  - Why is "favor object composition over class inheritance" considered a principle of object-oriented design?
+  - How can delegation make composition functionally equivalent to inheritance?
+  - How can parameterized types be used to reuse functionality? In which languages are parameterized types available?
+  - How does the runtime performance of composition compare to inheritance?
+- What is the runtime versus compile-time structure of each pattern?
+
+## Designing for change
+
+- What must you consider when designing a system for change?
+- How do design patterns help you design systems for change?
+- How do patterns fit into the different ways a software application can be distributed?
+  - What are the different ways a program can be distributed?
+  - How do patterns benefit an *application*? What is an application?
+  - How do patterns benefit a *toolkit*? What is a toolkit?
+  - What is a *framework*? What is inversion of control? What are the pros and cons of using a framework, and what risks do you incur? How do patterns help you build good frameworks — and how do patterns differ from frameworks?
+  - Which is harder to design: applications, toolkits, or frameworks?
+
+## Actually using them
+
+- How do you select which design pattern to use?
+- How do you use a design pattern once you've chosen it?
+
+---
+
+> These questions follow the introduction of *Design Patterns: Elements of Reusable Object-Oriented Software* by Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides (Addison-Wesley, 1994). The questions are mine; the book is theirs — go read it.

--- a/bytesofpurpose-blog/blog/2020-02-23-a-learning-plan-for-nlp.mdx
+++ b/bytesofpurpose-blog/blog/2020-02-23-a-learning-plan-for-nlp.mdx
@@ -1,0 +1,35 @@
+---
+slug: a-learning-plan-for-nlp
+title: "A Learning Plan for NLP"
+description: "A short, honest starting point for natural language processing — how to approach a first NLP project and a few resources to learn from."
+authors: [oeid]
+tags: [ai-engineering, llm, learning-plan]
+date: 2020-02-23
+draft: true
+---
+
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+When I started looking into NLP, the thing that moved me forward wasn't reading more about it. It was building one real thing end to end. Picking a single concrete project (a word2vec experiment, a topic model over a pile of documents, or a small text pipeline that goes from raw input to a useful output) forced me to learn the core ideas in the order I actually needed them, instead of collecting concepts that never connected to anything.
+
+This is an early, small set of notes, so I want to be candid about that. There are only a few resources here. It is a starting point, not a survey.
+
+<!-- truncate -->
+
+## How to approach it
+
+[Step 1] Pick **one end-to-end tutorial** and follow it the whole way through, rather than skimming several. The goal is to get from raw text to a working result once, so the shape of an NLP project is no longer abstract.
+
+[Step 2] **Build a small project** of your own with the same structure. Something narrow and real is enough: a topic model over documents you care about, or word vectors trained on a corpus you can poke at.
+
+[Step 3] **Learn the core ideas as you hit them** along the way. Text processing, topic modeling, and word vectors all land better when a project you're building actually needs them.
+
+## Resources
+
+These are the few resources I started from. The list is maintained as data, so it can grow over time.
+
+<CategoryCarousel topic="learn-about-nlp" category="Resources" />
+
+---
+
+> This roadmap is curated from my own running notes on NLP. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-02-27-a-learning-plan-for-machine-learning.mdx
+++ b/bytesofpurpose-blog/blog/2020-02-27-a-learning-plan-for-machine-learning.mdx
@@ -1,0 +1,64 @@
+---
+slug: a-learning-plan-for-machine-learning
+title: "A Learning Plan for Machine Learning"
+description: "What to know when you're getting into machine learning — how to approach it, and a curated set of concepts, courses, and techniques to learn from."
+authors: [oeid]
+tags: [ai-engineering, llm, learning-plan]
+date: 2020-02-27
+draft: true
+---
+
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+When I started learning machine learning, the trap I kept falling into was reaching for
+a framework before I understood what the model was actually doing. The thing that
+finally made it click was treating ML as one idea: you have data, you want a function
+that maps inputs to outputs, and you let the data shape that function instead of writing
+the rules yourself. Once that framing landed, the rest stopped feeling like magic and
+started feeling like a toolbox.
+
+This is the learning plan I have kept and added to over the years. The resources are
+grouped by how I actually reached for them, and the lists keep growing.
+
+<!-- truncate -->
+
+## How to approach it
+
+A good way in, in order:
+
+[Step 1] Build the mental model first. Get clear on what ML is, the split between
+supervised and unsupervised learning, and the basics of regression and classification.
+The goal is to be able to look at a problem and name what kind of problem it is.
+
+[Step 2] Work through one comprehensive course end to end. Pick a single structured
+path rather than skimming a dozen, and follow it all the way so the concepts connect
+instead of staying as isolated facts.
+
+[Step 3] Learn specific techniques as you hit them. When a course or project surfaces
+something like gradient descent or how to split your data, go deep on that one piece in
+the moment. The technique sticks better when you have a problem that needs it.
+
+## Concepts & fundamentals
+
+Start here to build the model: what ML actually is, and the basics of supervised
+learning, regression, and classification that everything else builds on.
+
+<CategoryCarousel topic="learn-about-ml" category="Concepts & fundamentals" />
+
+## Courses & comprehensive resources
+
+When you are ready to go from scattered concepts to a real foundation, pick one of
+these structured courses or resource hubs and follow it through.
+
+<CategoryCarousel topic="learn-about-ml" category="Courses & comprehensive resources" />
+
+## Specific techniques
+
+Reach for these when a particular mechanism comes up and you want to understand it on
+its own: gradient descent, the train/test split, distance measures, and AutoML.
+
+<CategoryCarousel topic="learn-about-ml" category="Specific techniques" />
+
+---
+
+> This roadmap is curated from my own running notes on machine learning. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-03-15-a-learning-plan-for-kubernetes.mdx
+++ b/bytesofpurpose-blog/blog/2020-03-15-a-learning-plan-for-kubernetes.mdx
@@ -1,0 +1,60 @@
+---
+slug: a-learning-plan-for-kubernetes
+title: "A Learning Plan for Kubernetes"
+description: "What to know when picking up Kubernetes — the core building blocks, then the patterns, scaling, and cloud specifics, with curated resources."
+authors: [oeid]
+tags: [backend, software-engineering, cloud, learning-plan]
+date: 2020-03-15
+draft: true
+---
+
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+When I picked up Kubernetes, the thing that kept me from drowning was treating it as
+two passes instead of one. The first pass is the core building blocks: the objects you
+declare, the `kubectl` muscle memory, `helm` for packaging, operators for the things
+that need a controller, and the surrounding ecosystem tooling. Get comfortable there
+and most of the cluster stops feeling like magic.
+
+The second pass is operational: how you scale workloads, how autoscaling actually
+behaves under load, and how a managed offering on a specific cloud changes the setup.
+This is the learning plan I kept as running notes — the resources worth starting from,
+grouped by which pass I used them in.
+
+<!-- truncate -->
+
+## How to approach it
+
+A good way in, in order:
+
+[Step 1] Learn the **core objects and tooling** first — declare pods, deployments, and
+services, get fluent with `kubectl`, package with `helm`, and understand when an
+operator is the right pattern.
+
+[Step 2] Study **real-world patterns and autoscaling** so you know how workloads behave
+under load and which patterns keep a cluster healthy as it grows.
+
+[Step 3] **Go deep on one cloud's managed offering** rather than staying generic. Pick a
+single managed Kubernetes service and learn its specifics end to end.
+
+The cards below are the specific resources I collected for each pass, and they grow over
+time.
+
+## Core Kubernetes
+
+Start here to build the foundation: the core objects you declare and the tooling you
+drive the cluster with day to day.
+
+<CategoryCarousel topic="learn-about-kubernetes" category="Core Kubernetes" />
+
+## Patterns, scaling & cloud
+
+Once the building blocks land, this is where the operational knowledge lives — the
+patterns that keep workloads healthy, how autoscaling behaves, and the cloud-specific
+managed setups.
+
+<CategoryCarousel topic="learn-about-kubernetes" category="Patterns, scaling & cloud" />
+
+---
+
+> This roadmap is curated from my own running notes on Kubernetes. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-03-23-how-oauth-lets-an-app-act-on-your-behalf.md
+++ b/bytesofpurpose-blog/blog/2020-03-23-how-oauth-lets-an-app-act-on-your-behalf.md
@@ -1,0 +1,50 @@
+---
+slug: how-oauth-lets-an-app-act-on-your-behalf
+title: "How OAuth Lets an App Act on Your Behalf"
+description: "A plain-language walkthrough of the OAuth handshake — how a third-party app gets access to your data without ever seeing your password."
+authors: [oeid]
+tags: [backend, software-engineering, best-practices]
+date: 2020-03-23
+draft: true
+---
+
+The thing that finally made OAuth click for me was framing it around a single question: *how does an app get to act on my behalf without me ever handing it my password?* Once you trace the handshake from that angle, the moving parts — request tokens, access tokens, the redirect dance — stop being jargon and start being obvious.
+
+Here's the walkthrough I wrote for myself, using Jira as the concrete example of the system that owns the data.
+
+<!-- truncate -->
+
+## The cast of characters
+
+Say I have data in **Jira** — issues, projects, comments. I own these resources, which makes me the **resource owner**: I'm the one who decides whether that information is kept, shared, or deleted.
+
+Now I start using **another app** that integrates with Jira. At some point I take an action in that app that requires data *from* Jira. The app needs access — but I do **not** want to give it my Jira username and password. That's the whole problem OAuth exists to solve.
+
+## The handshake
+
+Here's the sequence that lets the app reach my Jira data without ever learning my credentials:
+
+1. The app requests a **request token** from Jira.
+2. The app **redirects me to Jira** to authorize that request token. It also tells Jira where to send me back afterward.
+3. On Jira's own site, I enter my username and password — **into Jira, never into the app** — and approve the request.
+4. Jira sends me back to the app, now carrying an **authorized request token**.
+5. The app exchanges that authorized request token for an **access token**, and uses the access token to call Jira's API for my data.
+
+The key move is step 3: my credentials only ever touch Jira. The app walks away with tokens, not with my password — and I can revoke those tokens later without changing my password everywhere.
+
+## Why two tokens instead of one
+
+It's reasonable to ask why the flow bothers with a *request* token and *then* an *access* token, rather than just handing the app one credential. The separation is what makes the authorization step meaningful: the request token represents "an app is *asking*," and only after I approve it on the resource owner's site does it become something that can be exchanged for real access. The access token is then the thing that's scoped, refreshable, and revocable — independent of my login.
+
+That word **scope** matters: an access token is granted for a limited set of permissions, not blanket access to everything I own. The app gets exactly what I approved and no more.
+
+## Where to go deeper
+
+When I wrote these notes I lined up the canonical references worth reading next:
+
+- [Refreshing access tokens](https://www.oauth.com/oauth2-servers/access-tokens/refreshing-access-tokens/) — how an access token is renewed without sending the user back through the flow.
+- [Why OAuth has both a request token and an access token](https://stackoverflow.com/questions/3584718/why-is-oauth-designed-to-have-request-token-and-access-token) — the design rationale for the two-token split.
+- [OAuth scopes](https://oauth.net/2/scope/) — the mechanism that limits what an access token is allowed to do.
+- [Jira's REST API OAuth authentication](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-oauth-authentication/) — the concrete provider flow this walkthrough is modeled on.
+
+The mental model is the durable part: **an app acts on your behalf by holding a scoped, revocable token that it earned through your explicit approval — not by holding your password.** Everything else is detail.

--- a/bytesofpurpose-blog/blog/2020-05-11-a-learning-plan-for-agile.mdx
+++ b/bytesofpurpose-blog/blog/2020-05-11-a-learning-plan-for-agile.mdx
@@ -1,0 +1,35 @@
+---
+slug: a-learning-plan-for-agile
+title: "A Learning Plan for Agile"
+description: "A starting point for learning Agile, Scrum, and Kanban — how to approach it and a curated set of guides and books."
+authors: [oeid]
+tags: [software-engineering, best-practices, learning-plan]
+date: 2020-05-11
+draft: true
+---
+
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+I picked up most of what I knew about Agile by osmosis: standups, sprints, a board with sticky notes. It worked well enough that I never stopped to ask what the model actually was. When I finally did sit down to learn it deliberately, the questions that mattered weren't about ceremonies. They were about roles. Who are the actors, what is each one responsible for, and what happens when those responsibilities blur. Scrum and Kanban both answer that, and they answer it differently.
+
+These are my running notes on learning Agile properly: the order I'd read things in, and the resources I kept coming back to.
+
+<!-- truncate -->
+
+## How to approach it
+
+[Step 1] Read the **Scrum Guide** first. It's short, it's the canonical source, and it defines the roles and events precisely. Everything else is commentary on this.
+
+[Step 2] Read **one practical book** to see how the model survives contact with a real team. The guide tells you the rules; a book shows you where they bend.
+
+[Step 3] **Run it on something small.** Put a one-person project on a board, set a short cadence, and feel the friction firsthand. The trade-offs stop being theoretical once you're the product owner, the team, and the scrum master all at once.
+
+## Scrum, Kanban & getting started
+
+The canonical guide, the practical books, and the starting points for actually running it.
+
+<CategoryCarousel topic="learn-about-agile" category="Scrum, Kanban & getting started" />
+
+---
+
+> This roadmap is curated from my own running notes on Agile. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-06-16-questions-for-productionizing-a-machine-learning-system.md
+++ b/bytesofpurpose-blog/blog/2020-06-16-questions-for-productionizing-a-machine-learning-system.md
@@ -1,0 +1,68 @@
+---
+slug: questions-for-productionizing-a-machine-learning-system
+title: "Questions for Productionizing a Machine Learning System"
+description: "The operational questions that decide how an ML system actually runs in production — when to predict, how to rank, how often to train, and how to stay explainable."
+authors: [oeid]
+tags: [ai-engineering, llm, question-set]
+date: 2020-06-16
+draft: true
+---
+
+The hard part of machine learning in production usually isn't the model. It's the
+operational shape around it: *when* do you compute predictions, *how* do you serve a
+ranking, *how often* do you retrain, and can you explain any of it to the person
+relying on the result. These are the questions I keep coming back to when thinking
+through an ML system's design, grouped by the concern they belong to.
+
+<!-- truncate -->
+
+## Feedback and prediction cadence
+
+- What problem are ML engineers generally concerned with here in the first place?
+- How do you ingest feedback — can it be batched up, or does it need to be handled as
+  it arrives?
+- How often are predictions actually generated? Is this a bulk job, an online
+  request, or both?
+- For online prediction: when a user shows up, you have to rank the current set of
+  facts for them right now. But if the underlying facts change (say, at midnight),
+  you may need to recompute the top results. How do you reconcile "fresh per request"
+  with "the world changed underneath you"?
+- Without online-learning capability, the best you can do may be recomputing once a
+  day — and the model itself might take a while to run. Does your latency budget allow
+  that?
+
+## Ranking
+
+- How hard is it to rank for a single user? (On its own: not very.)
+- But ideally you want to use data from the *entire population* to make good
+  recommendations even for that one user. How do you bring population-level signal
+  into a single user's ranking?
+
+## Training
+
+- How frequently do you retrain?
+- When you're doing online training, when do you take a snapshot of the model?
+- Where do heuristics fit — what can you lean on them for while the learned system
+  catches up?
+
+## Consumption
+
+- What does the usage behavior of the user actually look like? Do they open the app
+  once a day, constantly, rarely? The answer changes how often prediction and
+  training are even worth doing.
+
+## Explainability
+
+- An explainable system is trying to balance two things at once: giving the user
+  visibility into *why* they're seeing something, and giving them a genuinely good
+  recommendation.
+- What algorithm can balance these? You want a good recommendation service in the
+  long run — but optimizing purely for that can mean recommending bad things in the
+  short run while the system explores. How much short-run cost will you accept for
+  long-run quality?
+
+---
+
+> These are my own working questions on running ML systems in production, not a
+> checklist from any one source. They're the things I'd want answered before
+> committing to an architecture.

--- a/bytesofpurpose-blog/blog/2020-07-14-a-learning-plan-for-postgresql.mdx
+++ b/bytesofpurpose-blog/blog/2020-07-14-a-learning-plan-for-postgresql.mdx
@@ -1,0 +1,44 @@
+---
+slug: a-learning-plan-for-postgresql
+title: "A Learning Plan for PostgreSQL"
+description: "What to know to get good with PostgreSQL — practical query recipes, schema-design best practices, and tooling, with curated resources."
+authors: [oeid]
+tags: [data-engineering, databases, learning-plan]
+date: 2020-07-14
+draft: true
+---
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+When I sat down to actually get good with PostgreSQL, I realized the syntax was never the hard part. What mattered was building a toolbox of query recipes I could reach for without thinking, and developing schema-design habits that age well as a project grows. These are my running notes from that effort.
+
+I've organized them around two muscles: the everyday querying patterns I lean on constantly, and the design decisions that quietly determine whether a schema stays pleasant to work with or turns into a maintenance tax.
+
+<!-- truncate -->
+
+## How to approach it
+
+[Step 1] Build a recipe toolbox for everyday querying. Joins, aggregation, date handling, and null wrangling come up in nearly every query I write, so the goal is to make them reflexive rather than something you look up each time.
+
+[Step 2] Learn the schema-design best practices. A few habits pay for themselves repeatedly: every table should have a primary key, and you should make liberal use of views to hide table structure behind stable interfaces so you can refactor underneath them. Lean on constraints to let the database enforce invariants, and reach for partitioning when tables get large. One sharp edge worth remembering early: materialized views must be refreshed manually, so they're a caching tool, not a live one.
+
+[Step 3] Get comfortable with the tooling. Knowing your way around psql, a GUI like DBeaver, and a SQL linter removes friction so you can focus on the actual problem.
+
+## Querying recipes
+
+These are the patterns I reach for daily — joins, aggregation, date math, and handling nulls cleanly.
+
+<CategoryCarousel topic="learn-about-postgresql" category="Querying recipes" />
+
+## Schema design & best practices
+
+Design choices set the ceiling on how maintainable a database stays. These resources cover primary keys, constraints, views, materialized views, and partitioning.
+
+<CategoryCarousel topic="learn-about-postgresql" category="Schema design & best practices" />
+
+## Tooling
+
+A small set of tools handles most day-to-day work: psql for the terminal, DBeaver for browsing, and linting to keep SQL consistent.
+
+<CategoryCarousel topic="learn-about-postgresql" category="Tooling" />
+
+> This roadmap is curated from my own running notes on PostgreSQL. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2021-07-05-answering-leadership-principle-interview-questions.md
+++ b/bytesofpurpose-blog/blog/2021-07-05-answering-leadership-principle-interview-questions.md
@@ -1,0 +1,183 @@
+---
+slug: answering-leadership-principle-interview-questions
+title: "Answering Leadership-Principle Interview Questions"
+description: "A map of the leadership principles behavioral interviews probe for, the questions that surface each one, and the STAR method for answering them with stories that land."
+authors: [oeid]
+tags: [best-practices, productivity]
+date: 2021-07-05
+draft: true
+---
+
+Behavioral interviews at a lot of companies — Amazon most famously — are built around
+a published set of **leadership principles**. The questions feel open-ended ("tell me
+about a time…"), but each one is really probing for a specific principle. If you know
+which principle a question maps to and you have a crisp story ready, the whole format
+gets a lot less intimidating.
+
+This is the prep map I built for myself: each principle, the kind of question that
+surfaces it, and the method for answering. The stories are mine, anonymized — the
+point here is the *structure*, which transfers to any company that interviews this
+way.
+
+<!-- truncate -->
+
+## The method: answer in STAR
+
+Answer every behavioral question in the **STAR** format. It forces a complete story
+and keeps you from rambling:
+
+- **Situation** — the problem and its context (who, what, where, when). Keep it brief.
+- **Task** — what *you* specifically had to do, and the constraints (deadlines, costs,
+  technical limits).
+- **Action** — the specific actions you took. Choose actions that *demonstrate*
+  desirable traits (initiative, leadership, judgment) without you having to name them.
+- **Result** — how it turned out. Quantify if you can, then add what you learned and
+  what you'd do differently.
+
+A useful variant interviewers use to evaluate the answer is **SBI** — Situation,
+Behavior, Impact — which is just STAR viewed from the listener's side. If your story
+has a clear situation, a behavior that was yours, and a measurable impact, it works
+under either lens.
+
+## The principles, and the questions that surface them
+
+For each principle: the definition (paraphrased from the canonical wording), and a
+representative question. Have one or two stories ready per principle.
+
+### Customer Obsession
+*Leaders start with the customer and work backwards. They earn and keep customer
+trust, and obsess over customers rather than competitors.*
+
+> Tell me about a time you worked backwards from a customer problem. How did you solve
+> it?
+
+### Ownership
+*Leaders are owners. They think long term, act on behalf of the whole company beyond
+their own team, and never say "that's not my job."*
+
+> When did you last sacrifice a long-term value to complete a short-term task?
+
+### Invent and Simplify
+*Leaders expect invention from their teams and always find ways to simplify. They are
+externally aware and not limited by "not invented here."*
+
+> Give a specific example where you drove adoption of your vision, and explain how you
+> knew it had been adopted by others.
+
+### Are Right, A Lot
+*Leaders have strong judgment and good instincts. They seek diverse perspectives and
+work to disconfirm their own beliefs.*
+
+> Tell me about a strategic decision you had to make without clear data or benchmarks.
+
+### Learn and Be Curious
+*Leaders are never done learning and always seek to improve. They are curious about
+new possibilities and act to explore them.*
+
+> Tell me about a time you had to run a project that was heavily opposed.
+
+### Hire and Develop the Best
+*Leaders raise the performance bar with every hire, recognize exceptional talent, and
+take coaching others seriously.*
+
+> Tell me about someone you developed. What did you do, and where did they end up?
+
+### Insist on the Highest Standards
+*Leaders have relentlessly high standards, continually raise the bar, and ensure
+defects don't get sent down the line.*
+
+> Tell me about a time you had to choose between standards and delivery.
+
+### Think Big
+*Thinking small is a self-fulfilling prophecy. Leaders create and communicate a bold
+direction that inspires results.*
+
+> Tell me about the most ambitious thing you've proposed. How did you get others
+> behind it?
+
+### Bias for Action
+*Speed matters. Many decisions are reversible and don't need extensive study; calculated
+risk-taking is valued.*
+
+> Tell me about a time you acted quickly on incomplete information.
+
+### Frugality
+*Accomplish more with less. Constraints breed resourcefulness and invention; there are
+no extra points for headcount or budget.*
+
+> Tell me about a time you delivered something valuable with very limited resources.
+
+### Have Backbone; Disagree and Commit
+*Leaders respectfully challenge decisions they disagree with, even when uncomfortable.
+Once a decision is made, they commit wholly.*
+
+> Describe a time you disagreed with your manager.
+
+The trick on this one: show that you *both* pushed back with conviction *and* committed
+fully once the call was made. Tie the disagreement back to a concrete action that
+could be taken right away.
+
+### Deliver Results
+*Leaders focus on the key inputs and deliver them with the right quality, on time.
+Despite setbacks, they never settle.*
+
+> Give me an example of delivering an important project under a tight deadline.
+
+### Dive Deep
+*Leaders operate at all levels, stay connected to the details, audit frequently, and
+are skeptical when metrics and anecdote disagree. No task is beneath them.*
+
+> Tell me about a time the data and the story disagreed. What did you find when you dug
+> in?
+
+### Earn Trust
+*Leaders listen attentively, speak candidly, and treat others respectfully. They are
+vocally self-critical and benchmark against the best.*
+
+> Tell me about a time you were given poor feedback. / Tell me about a time you didn't
+> work well with someone.
+
+## Two stories, in shape
+
+The principles are the index; the stories are what you're actually graded on. Two of
+mine, anonymized, to show how a story maps onto STAR.
+
+### A turnaround story (Earn Trust / Dive Deep / Deliver Results)
+
+- **Situation** — I was brought in to lead a team fixing the performance of a complex
+  GPU-based ML system that processed images. It was supposed to handle 600 images per
+  second; it was managing about 50. The customer was frustrated — at that rate their
+  backlog would take a year instead of a month, and they were losing faith we could
+  deliver.
+- **Task** — Decompose the architecture, find the strategic improvements that would
+  raise throughput in time, and explain each change to the customer so they understood
+  *why* it mattered.
+- **Action** — I broke the architecture down, diagrammed it, and mapped every
+  bottleneck. I documented each proposed enhancement with its rationale, and ran daily
+  standups to keep everyone aligned on progress.
+- **Result** — Within a month we took it from ~50 to ~680 images per second. The
+  methodical, transparent approach rebuilt the customer's trust, cleared their backlog,
+  and opened the door to several follow-on projects.
+
+That one story credibly covers three principles — which is the goal. Strong stories
+are reusable across principles; you reframe the emphasis to fit the question.
+
+### A reuse story (Invent and Simplify / Ownership)
+
+- **Situation** — Across many projects I kept solving the same underlying problem: the
+  same pattern of insights, feedback, and evolving profiles, re-implemented each time.
+- **Task** — Take ownership of the recurring problem and convince leadership to
+  dedicate resources to solving it once, properly.
+- **Action** — Built proof-of-concepts that showed technical leaders where the reuse
+  potential was, and quantified the time and code that a standardized approach would
+  save.
+- **Result** — The standardized components ended up used across teams, and the effort
+  pinned down the definition of a previously ambiguous, overloaded term inside the org.
+
+## Putting it together
+
+Prep is mostly indexing: build a small library of strong stories, then tag each one
+with the two or three principles it can answer. Walk into the interview knowing which
+story you'll reach for when you hear "tell me about a time you disagreed" versus "a
+time you delivered under pressure." The principles are public; the only homework is
+making your own stories land in STAR shape.

--- a/bytesofpurpose-blog/blog/2021-10-04-a-learning-plan-for-java.mdx
+++ b/bytesofpurpose-blog/blog/2021-10-04-a-learning-plan-for-java.mdx
@@ -1,0 +1,69 @@
+---
+slug: a-learning-plan-for-java
+title: "A Learning Plan for Java"
+description: "What to know to be effective in Java beyond the language itself — the libraries, concurrency model, and Spring ecosystem worth learning, with curated resources."
+authors: [oeid]
+tags: [backend, software-engineering, java, learning-plan]
+date: 2021-10-04
+draft: true
+---
+
+import CategoryCarousel from '@site/src/components/CategoryCarousel';
+
+When I picked up Java seriously, the part that surprised me was how little the
+language itself mattered. The syntax, the type system, the object model: I had most
+of that down in a weekend. Being *effective* in Java turned out to be a different
+skill, and it lived almost entirely outside the language. It was knowing which
+everyday libraries to reach for, understanding how threads and the JVM actually
+behave under load, and learning Spring, since that's how the overwhelming majority of
+real Java applications are wired together.
+
+These are my running notes on that ecosystem: the things I keep coming back to,
+grouped by how I actually learned them. The cards under each section are the resources
+I collected, and they grow over time.
+
+<!-- truncate -->
+
+## How to approach it
+
+A good order to work through it:
+
+[Step 1] Get fluent with the **everyday libraries and tooling** first: the collections
+and utilities you'll use daily, plus the build and test tools (Maven or Gradle, JUnit)
+that every project assumes you already know.
+
+[Step 2] Build a real understanding of **concurrency and the JVM**: threads,
+executors, the memory model, garbage collection, and how to monitor and profile a
+running process. This is where Java rewards depth and where most production problems
+hide.
+
+[Step 3] Learn **Spring**, because it's the de facto way most Java services are built.
+Understanding dependency injection, Spring Boot, and the surrounding framework will do
+more for your day-to-day productivity than almost anything else.
+
+## Language, libraries & build tools
+
+Start here to get productive quickly: the standard-library pieces worth knowing well,
+plus the build and test tooling that every Java project takes for granted.
+
+<CategoryCarousel topic="learn-about-java" category="Language, libraries & build tools" />
+
+## Concurrency & the JVM
+
+This is the heart of being effective in Java. These cover threads and executors, the
+memory model, garbage collection, and the tools for monitoring and profiling what your
+process is actually doing at runtime.
+
+<CategoryCarousel topic="learn-about-java" category="Concurrency & the JVM" />
+
+## Spring & frameworks
+
+Most real Java apps run on Spring, so it's worth learning deliberately. These resources
+cover dependency injection, Spring Boot, and the wider framework ecosystem you'll meet
+on the job.
+
+<CategoryCarousel topic="learn-about-java" category="Spring & frameworks" />
+
+---
+
+> This roadmap is curated from my own running notes on Java. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2026-01-28-what-makes-something-a-process.md
+++ b/bytesofpurpose-blog/blog/2026-01-28-what-makes-something-a-process.md
@@ -1,0 +1,91 @@
+---
+slug: what-makes-something-a-process
+title: "What Makes Something a Process"
+description: "A small framework for thinking about personal and software processes — what a process actually is, the elements every one shares, and how it differs from a workflow or a technique."
+authors: [oeid]
+tags: [software-engineering, best-practices]
+date: 2026-01-28
+draft: true
+---
+
+I kept using the word "process" for very different things — a checklist, a habit, a
+build pipeline — until I sat down and tried to define it precisely. It turned out to
+be a useful exercise: once you can say what makes something *a process* (as opposed
+to a one-off task or a vague intention), you can tell when you actually have one,
+when you're missing one, and when two of them are quietly fighting each other.
+
+This is the small framework I landed on.
+
+<!-- truncate -->
+
+## What a process is
+
+A process is **the context in which you use your tools**. A tool is a hammer; a
+process is "framing a wall." More precisely, a process **orchestrates multiple
+activities to accomplish an end goal** — and that goal can be either the creation of
+an artifact or the fulfillment of an inner state. Processes generally exist to help
+you make or repeat a **big decision** without re-deriving it from scratch every time.
+
+## The elements every process shares
+
+When I write a process down, these are the slots I fill in. If I can't fill them, I
+don't really have a process yet.
+
+- **Purpose** — what goal does it accomplish?
+- **Trigger** — when does the process apply? When do you *enter* it?
+- **Inputs** — what goes into it?
+- **Outputs** — what comes out?
+- **Major questions** — what primary concerns does it address?
+- **Activities** — what steps are involved?
+- **Metrics** — how do you know it's meeting its purpose?
+
+## The attributes that distinguish a process
+
+A real process, as opposed to a task or an intention, has four properties. It must:
+
+1. **Accomplish a certain goal**
+2. **Be repetitive** — you run it more than once
+3. **Be measurable** — you can tell whether it's working
+4. **Be acted on continuously** — it's a living thing, not a one-time event
+
+That second and fourth point are what separate a *process* from a *project*. A
+project ends; a process recurs.
+
+## Process vs. workflow vs. technique
+
+These three get used interchangeably, but the distinctions are useful:
+
+- A **technique** is the most tangible and specific — a single concrete way of doing
+  one thing.
+- A **process** is higher level: it orchestrates several activities (which may each
+  use techniques) toward a goal.
+- A **workflow** is the orchestration mechanism — the order, triggers, and handoffs
+  by which a process's activities actually run.
+
+So a process is *what* you're trying to accomplish and the activities involved; a
+workflow is *how* those activities are wired together; a technique is a specific move
+inside one of them.
+
+## Where processes fight: conflict at the handoffs
+
+The most useful insight I got from this was about where processes *break*. Conflicts
+don't usually happen inside an activity — they happen at the **handoffs between
+them**:
+
+- If the **inputs and outputs aren't clear** at a boundary, you get conflict.
+- If the two sides have **different expectations** at the boundary, you get conflict.
+
+This is exactly **impedance mismatch** in code — the friction when one function hands
+data to another that expected a different shape. Designing a process well is largely
+about making its internal handoffs explicit: each activity's outputs should be
+precisely what the next activity expects as input. When you find a process that keeps
+producing friction, look at the seams, not the steps.
+
+## How to know you're done
+
+A process also needs a **definition of done** — when do you know you've completed a
+run, and how do you determine completeness? Without it, a process either never ends
+or ends arbitrarily. Pair that with the *breadth vs. depth* question when you're
+designing one: **breadth** asks whether you've covered all the different activities;
+**depth** asks whether you've covered all the possibilities within each. A good
+process is honest about which of the two it's optimizing for.

--- a/bytesofpurpose-blog/src/data/references/index.ts
+++ b/bytesofpurpose-blog/src/data/references/index.ts
@@ -14,6 +14,12 @@ import type { CarouselItem } from '@site/src/components/Carousel';
 
 import learningResources from './learning-resources.json';
 import learnAboutGraphql from './learn-about-graphql.json';
+import learnAboutMl from './learn-about-ml.json';
+import learnAboutNlp from './learn-about-nlp.json';
+import learnAboutJava from './learn-about-java.json';
+import learnAboutAgile from './learn-about-agile.json';
+import learnAboutKubernetes from './learn-about-kubernetes.json';
+import learnAboutPostgresql from './learn-about-postgresql.json';
 
 export type ReferenceItem = CarouselItem;
 
@@ -36,6 +42,12 @@ export interface ReferenceTopic {
 export const references: Record<string, ReferenceTopic> = {
   'learning-resources': learningResources as unknown as ReferenceTopic,
   'learn-about-graphql': learnAboutGraphql as unknown as ReferenceTopic,
+  'learn-about-ml': learnAboutMl as unknown as ReferenceTopic,
+  'learn-about-nlp': learnAboutNlp as unknown as ReferenceTopic,
+  'learn-about-java': learnAboutJava as unknown as ReferenceTopic,
+  'learn-about-agile': learnAboutAgile as unknown as ReferenceTopic,
+  'learn-about-kubernetes': learnAboutKubernetes as unknown as ReferenceTopic,
+  'learn-about-postgresql': learnAboutPostgresql as unknown as ReferenceTopic,
 };
 
 // Look up one category's items for a topic. Returns [] if absent so a post

--- a/bytesofpurpose-blog/src/data/references/index.ts
+++ b/bytesofpurpose-blog/src/data/references/index.ts
@@ -13,6 +13,7 @@
 import type { CarouselItem } from '@site/src/components/Carousel';
 
 import learningResources from './learning-resources.json';
+import learnAboutGraphql from './learn-about-graphql.json';
 
 export type ReferenceItem = CarouselItem;
 
@@ -34,6 +35,7 @@ export interface ReferenceTopic {
 // The registry: topic key -> its data. Add a line here when you add a topic.
 export const references: Record<string, ReferenceTopic> = {
   'learning-resources': learningResources as unknown as ReferenceTopic,
+  'learn-about-graphql': learnAboutGraphql as unknown as ReferenceTopic,
 };
 
 // Look up one category's items for a topic. Returns [] if absent so a post

--- a/bytesofpurpose-blog/src/data/references/learn-about-agile.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-agile.json
@@ -1,0 +1,89 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The Software Backend Developer/Learning Topics/Agile Development/Learn about Agile.md",
+    "source_commit": "40186c4ab6c35ffd1dc537982237f6d4b4810091",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Scrum, Kanban & getting started": [
+    {
+      "title": "What Is Agile?",
+      "href": "https://www.forbes.com/sites/stevedenning/2016/08/13/what-is-agile/#1535b51a26e3",
+      "description": "The Learning Consortium comes to the Drucker Forum.",
+      "meta": "forbes.com"
+    },
+    {
+      "title": "What is Agile? | Atlassian",
+      "href": "https://www.atlassian.com/agile",
+      "description": "The Agile methodology is an approach that divides work into phases, emphasizing continuous delivery and improvement.",
+      "meta": "atlassian.com"
+    },
+    {
+      "title": "What are agile retrospectives? | Atlassian",
+      "href": "https://www.atlassian.com/agile/scrum/retrospectives",
+      "description": "A retrospective helps teams perform better over time. See what the agile community is saying and learn how to run your own retrospective meetings.",
+      "meta": "atlassian.com"
+    },
+    {
+      "title": "Product Management | Atlassian",
+      "href": "https://www.atlassian.com/agile/product-management",
+      "description": "Product management is an organizational function that aims to maximize the value of a product by optimizing every step of the product lifecycle.",
+      "meta": "atlassian.com"
+    },
+    {
+      "title": "9 Books on Agile Project Management Worth Reading in 2021 | Hygger.io",
+      "href": "https://hygger.io/blog/9-books-agile-project-management-worth-reading/",
+      "description": "✅9 Books on Agile Project Management Worth Reading in 2021 - Read Article by Autor Pavel Kukhnavets. ➤See also other materials in Agile category at Hygger.io Blog.",
+      "meta": "hygger.io"
+    },
+    {
+      "title": "Reddit - The heart of the internet",
+      "href": "https://www.reddit.com/r/scrum/comments/hg7lzn/who_is_truly_responsible_for_defining_epics/?utm_source=share&utm_medium=ios_app&utm_name=iossmf",
+      "description": "I was voluntold to be the SM for the team and we have been struggling and truly never producing anything of value. We have no real defined epics/features/themes, everyone on the team writes User Stories and most of them have no details in…",
+      "meta": "reddit.com"
+    }
+  ],
+  "_dead": [
+    {
+      "url": "https://www.amazon.com/Learning-Agile-Understanding-Scrum-Kanban/dp/1449331920/ref=sr_1_3?keywords=agile&qid=1568382862&s=books&sr=1-3",
+      "status": 500,
+      "error": null,
+      "section": "Learn about Agile",
+      "context": "- [ ] https://www.amazon.com/Learning-Agile-Understanding-Scrum-Kanban/dp/1449331920/ref=sr_1_3?keywords=agile&qid=1568382862&s=books&sr=1-3"
+    },
+    {
+      "url": "https://www.scrum.org/resources/blog/30-books-scrum-masters",
+      "status": 403,
+      "error": null,
+      "section": "Learn about Agile",
+      "context": "- [ ] https://www.scrum.org/resources/blog/30-books-scrum-masters"
+    },
+    {
+      "url": "https://hbr-org.cdn.ampproject.org/c/s/hbr.org/amp/2016/05/embracing-agile",
+      "status": 200,
+      "error": "page.evaluate: Execution context was destroyed, most likely because of a navigation",
+      "section": "Learn about Agile",
+      "context": "* [ ] [Embracing Agile](https://hbr-org.cdn.ampproject.org/c/s/hbr.org/amp/2016/05/embracing-agile)"
+    },
+    {
+      "url": "https://www.noteplan.co/blog/how-to-scrum-for-one-man-operations/",
+      "status": 404,
+      "error": null,
+      "section": "Learn about Agile",
+      "context": "- [ ] https://www.noteplan.co/blog/how-to-scrum-for-one-man-operations/"
+    },
+    {
+      "url": "https://www.scrumguides.org/scrum-guide.html",
+      "status": null,
+      "error": "page.goto: Timeout 20000ms exceeded.",
+      "section": "Learn about Agile",
+      "context": "- https://www.scrumguides.org/scrum-guide.html"
+    },
+    {
+      "url": "https://www.reddit.com/r/scrum/comments/hgztwx/zero_knowledge_about_scrum/?utm_source=share&utm_medium=ios_app&utm_name=iossmf",
+      "status": 200,
+      "error": "page.evaluate: Execution context was destroyed, most likely because of a navigation",
+      "section": "Learn about Agile",
+      "context": "- https://www.reddit.com/r/scrum/comments/hgztwx/zero_knowledge_about_scrum/?utm_source=share&utm_medium=ios_app&utm_name=iossmf"
+    }
+  ]
+}

--- a/bytesofpurpose-blog/src/data/references/learn-about-graphql.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-graphql.json
@@ -1,0 +1,144 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The Software Backend Developer/Learning Topics/API Development/Learn about GraphQL.md",
+    "source_commit": "9011569b3bd01ce835e1134110fcb3c89eb6d9e7",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Learn about GraphQL": [
+    {
+      "title": "What is GraphQL and why it matters for headless CMS",
+      "href": "https://www.brightspot.com/cms-architecture/headless-cms/what-is-graphql-and-why-it-matters-for-headless-cms",
+      "description": "Discover why GraphQL is a game changer for API-based CMS and how it compares to REST.",
+      "meta": "brightspot.com"
+    },
+    {
+      "title": "GitHub - hasura/graphql-engine: Blazing fast, instant realtime GraphQL APIs on all your data with fine grained access c…",
+      "href": "https://github.com/hasura/graphql-engine",
+      "description": "Blazing fast, instant realtime GraphQL APIs on all your data with fine grained access control, also trigger webhooks on database events. - hasura/graphql-engine",
+      "meta": "github.com"
+    },
+    {
+      "title": "GraphQL Best Practices | GraphQL",
+      "href": "https://graphql.org/learn/best-practices/",
+      "description": "The GraphQL specification is intentionally silent on a handful of important issues facing APIs such as dealing with the network, authorization, and pagination. This doesn’t mean that there aren’t solutions for these issues when using Graph…",
+      "meta": "graphql.org"
+    },
+    {
+      "title": "Thinking in Graphs | GraphQL",
+      "href": "https://graphql.org/learn/thinking-in-graphs/",
+      "description": "Graphs are powerful tools for modeling many real-world phenomena because they resemble our natural mental models and verbal descriptions of the underlying process. With GraphQL, you model your business domain as a graph by defining a schem…",
+      "meta": "graphql.org"
+    },
+    {
+      "title": "Remote Joins: A GraphQL API to join a database & other data-sources",
+      "href": "https://hasura.io/blog/remote-joins-a-graphql-api-to-join-database-and-other-data-sources",
+      "description": "Remote Joins in Hasura extend the concept of joining data across tables, to being able to join data across tables and remote data sources.",
+      "meta": "hasura.io"
+    },
+    {
+      "title": "GraphQL Tutorials",
+      "href": "https://graphql.com/tutorials/",
+      "description": "Learn the fundamentals of schemas and queries, then implement some apps with hands-on step-by-step tutorials.",
+      "meta": "graphql.com"
+    },
+    {
+      "title": "Course Introduction | GraphQL ReasonML React Apollo Tutorial",
+      "href": "https://hasura.io/learn/graphql/reason-react-apollo/introduction/",
+      "description": "A powerful and concise tutorial that will introduce you to GraphQL and integrating GraphQL into your ReasonReact app with Apollo, in the shortest amount of time possible.",
+      "meta": "hasura.io"
+    },
+    {
+      "title": "Course Introduction | GraphQL React Apollo Typescript Tutorial",
+      "href": "https://hasura.io/learn/graphql/typescript-react-apollo/introduction/",
+      "description": "A powerful and concise tutorial that will introduce you to GraphQL and integrating GraphQL and Typescript into your React app with Apollo, in the shortest amount of time possible.",
+      "meta": "hasura.io"
+    }
+  ],
+  "Tinker with GraphQL and Postgres ...": [
+    {
+      "title": "hasura/graphql-engine - Docker Image",
+      "href": "https://hub.docker.com/r/hasura/graphql-engine",
+      "description": "Blazing fast, instant GraphQL APIs on Postgres with fine grained access control (https://hasura.io)",
+      "meta": "hub.docker.com"
+    },
+    {
+      "title": "GitHub - hasura/learn-graphql: Real world GraphQL tutorials for frontend developers with deadlines!",
+      "href": "https://github.com/hasura/learn-graphql",
+      "description": "Real world GraphQL tutorials for frontend developers with deadlines! - hasura/learn-graphql",
+      "meta": "github.com"
+    },
+    {
+      "title": "GitHub - walmartlabs/json-to-simple-graphql-schema: Transforms JSON input into a GraphQL schema",
+      "href": "https://github.com/walmartlabs/json-to-simple-graphql-schema",
+      "description": "Transforms JSON input into a GraphQL schema. Contribute to walmartlabs/json-to-simple-graphql-schema development by creating an account on GitHub.",
+      "meta": "github.com"
+    },
+    {
+      "title": "GraphQL Core Concepts Tutorial",
+      "href": "https://www.howtographql.com/basics/2-core-concepts/",
+      "description": "GraphQL Core Concepts Tutorial",
+      "meta": "howtographql.com"
+    },
+    {
+      "title": "Understanding GraphQL (finally)",
+      "href": "https://medium.com/@erinfoox/understanding-graphql-finally-a75986d8df0a",
+      "description": "Understanding GraphQL (finally) 💡 I get it!I understand GraphQL and most of the magical powers it is capable of. It took a lot of research, tutorials, youtube videos and questions to wrap my head …",
+      "meta": "medium.com"
+    },
+    {
+      "title": "Documentation",
+      "href": "https://www.apollographql.com/docs/#new-to-apollo-or-graphql",
+      "description": "Develop anything.",
+      "meta": "apollographql.com"
+    },
+    {
+      "title": "Documentation",
+      "href": "https://www.apollographql.com/docs/",
+      "description": "Develop anything.",
+      "meta": "apollographql.com"
+    },
+    {
+      "title": "Schemas and Types | GraphQL",
+      "href": "https://graphql.org/learn/schema/",
+      "description": "Learn about the different elements of the GraphQL type system",
+      "meta": "graphql.org"
+    }
+  ],
+  "_dead": [
+    {
+      "url": "https://github.com/sassoftware/restaf-graphql-server",
+      "status": 404,
+      "error": null,
+      "section": "Learn about GraphQL",
+      "context": "- https://github.com/sassoftware/restaf-graphql-server"
+    },
+    {
+      "url": "https://hasura.io/docs/1.0/graphql/manual/getting-started/index.html#get-started-from-scratch",
+      "status": 404,
+      "error": null,
+      "section": "Tinker with GraphQL and Postgres ...",
+      "context": "- https://hasura.io/docs/1.0/graphql/manual/getting-started/index.html#get-started-from-scratch"
+    },
+    {
+      "url": "https://www.apollographql.com/blog/graphql-explained-5844742f195e/",
+      "status": 404,
+      "error": null,
+      "section": "Tinker with GraphQL and Postgres ...",
+      "context": "https://www.apollographql.com/blog/graphql-explained-5844742f195e/"
+    },
+    {
+      "url": "https://developer.github.com/v4/explorer/",
+      "status": 404,
+      "error": null,
+      "section": "Tinker with GraphQL and Postgres ...",
+      "context": "https://developer.github.com/v4/explorer/"
+    },
+    {
+      "url": "https://www.apollographql.com/blog/the-anatomy-of-a-graphql-query-6dffa9e9e747/",
+      "status": 404,
+      "error": null,
+      "section": "Tinker with GraphQL and Postgres ...",
+      "context": "https://www.apollographql.com/blog/the-anatomy-of-a-graphql-query-6dffa9e9e747/"
+    }
+  ]
+}

--- a/bytesofpurpose-blog/src/data/references/learn-about-java.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-java.json
@@ -1,0 +1,235 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The Software Backend Developer/Learning Topics/Backend Languages/Learn about Java.md",
+    "source_commit": "40186c4ab6c35ffd1dc537982237f6d4b4810091",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Language, libraries & build tools": [
+    {
+      "title": "What is Java Database Connectivity (JDBC)? | Definition from TechTarget",
+      "href": "https://www.theserverside.com/definition/Java-Database-Connectivity-JDBC",
+      "description": "Java Database Connectivity (JDBC)is an application program interface (API) specification for connecting programs written in Java to the data in popular databases.",
+      "meta": "theserverside.com"
+    },
+    {
+      "title": "Apache Ant Command Line Example - Examples Java Code Geeks - 2026",
+      "href": "https://examples.javacodegeeks.com/apache-ant-command-line-arguments-example/",
+      "description": "1. Introduction In this example, we will explain Apache Ant Command Line Arguments. In software development, the term building usually means the",
+      "meta": "examples.javacodegeeks.com"
+    },
+    {
+      "title": "Introducing new Code With Me Series - Build a book tracker app (Spring Boot + Cassandra)",
+      "href": "https://www.youtube.com/watch?v=LxVGFBRpEFM",
+      "description": "Click here to register for a free account on DataStax (Required for following along the series):https://dtsx.io/3sxR2NlGitHub Link: https://github.com/koushi...",
+      "meta": "youtube.com"
+    },
+    {
+      "title": "How to Write Doc Comments for the Javadoc Tool",
+      "href": "https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html",
+      "description": "This document describes the style guide, tag and image conventions we use in documentation comments for Java programs written at Java Software, Oracle. It does not rehash related material covered elsewhere:",
+      "meta": "oracle.com"
+    },
+    {
+      "title": "Project Lombok",
+      "href": "https://projectlombok.org/",
+      "description": "Project Lombok is a java library that automatically plugs into your editor and build tools, spicing up your java. Never write another getter or equals method again, with one annotation your class has a fully featured builder, Automate your…",
+      "meta": "projectlombok.org"
+    },
+    {
+      "title": "Stable",
+      "href": "https://projectlombok.org/features/",
+      "description": "or: How I learned to stop worrying and love the NullPointerException.",
+      "meta": "projectlombok.org"
+    },
+    {
+      "title": "Configuration file :: Apache Log4j",
+      "href": "https://logging.apache.org/log4j/2.x/manual/configuration.html#XML",
+      "description": "Using a configuration file is the most popular and recommended approach for configuring Log4j Core. In this page we will examine the composition of a configuration file and how Log4j Core uses it.",
+      "meta": "logging.apache.org"
+    },
+    {
+      "title": "Asserting exceptions in JUnit | Cássio Molin",
+      "href": "https://cassiomolin.com/archive/asserting-exceptions-in-junit/",
+      "description": "This post explores some techniques for asserting exceptions in Java with JUnit.",
+      "meta": "cassiomolin.com"
+    },
+    {
+      "title": "Mockito framework site",
+      "href": "https://site.mockito.org/",
+      "description": "A landing page for information about Mockito framework, a mocking framework for unit tests written in Java.",
+      "meta": "site.mockito.org"
+    }
+  ],
+  "Concurrency & the JVM": [
+    {
+      "title": "GitHub - resilience4j/resilience4j: Resilience4j is a fault tolerance library designed for Java8 and functional program…",
+      "href": "https://github.com/resilience4j/resilience4j",
+      "description": "Resilience4j is a fault tolerance library designed for Java8 and functional programming - resilience4j/resilience4j",
+      "meta": "github.com"
+    },
+    {
+      "title": "Be Aware of ForkJoinPool#commonPool()",
+      "href": "https://dzone.com/articles/be-aware-of-forkjoinpoolcommonpool",
+      "description": "Sometimes, we don't want to specify our thread-pool and just use the default for the current library. This article demonstrates how this is handled in the JDK.",
+      "meta": "dzone.com"
+    },
+    {
+      "title": "non-blocking IO vs async IO and implementation in Java",
+      "href": "https://stackoverflow.com/questions/25099640/non-blocking-io-vs-async-io-and-implementation-in-java",
+      "description": "Trying to summarize for myself the difference between these 2 concepts (because I'm really confused when I see people are using both of them in one sentence, like \"non-blocking async IO\" which I'm ...",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "An Introduction to ThreadLocal in Java | Baeldung",
+      "href": "https://www.baeldung.com/java-threadlocal",
+      "description": "A quick and practical guide to using ThreadLocal for storing thread-specific data in Java.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "What Is Thread-Safety and How to Achieve It? | Baeldung",
+      "href": "https://www.baeldung.com/java-thread-safety",
+      "description": "Learn about the different use cases for thread-safety and concurrent access.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "Guide to Java String Pool | Baeldung",
+      "href": "https://www.baeldung.com/java-string-pool",
+      "description": "Learn how the JVM optimizes the amount of memory allocated to String storage in the Java String Pool.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "What Is Thread-Safety and How to Achieve It? | Baeldung",
+      "href": "https://www.baeldung.com/java-thread-safety#volatile-fields",
+      "description": "Learn about the different use cases for thread-safety and concurrent access.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "A Guide to the Java ExecutorService | Baeldung",
+      "href": "https://www.baeldung.com/java-executor-service-tutorial",
+      "description": "An intro and guide to the ExecutorService framework provided by the JDK - which simplifies the execution of tasks in asynchronous mode.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "Java Management Extensions (JMX)",
+      "href": "https://www.oracle.com/java/technologies/javase/javamanagement.html",
+      "description": "The JMX technology provides the tools for building distributed, Web-based, modular and dynamic solutions for managing and monitoring devices, applications, and service-driven networks. By design, this standard is suitable for adapting lega…",
+      "meta": "oracle.com"
+    },
+    {
+      "title": "Client Configuration - AWS SDK for Java 1.x",
+      "href": "https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/section-client-configuration.html",
+      "description": "How to change proxy configuration, HTTP transport configuration, and TCP socket buffer size hints by using the AWS SDK for Java.",
+      "meta": "docs.aws.amazon.com"
+    },
+    {
+      "title": "Set the JVM TTL for DNS name lookups - AWS SDK for Java 1.x",
+      "href": "https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/jvm-ttl-dns.html",
+      "description": "Learn how to set Java virtual machine (JVM) for DNS name lookups using the AWS SDK for Java.",
+      "meta": "docs.aws.amazon.com"
+    },
+    {
+      "title": "The Security Manager (The Java™ Tutorials > Essential Java Classes > The Platform Environment)",
+      "href": "https://docs.oracle.com/javase/tutorial/essential/environment/security.html",
+      "description": "This Java tutorial describes exceptions, basic input/output, concurrency, regular expressions, and the platform environment",
+      "meta": "docs.oracle.com"
+    },
+    {
+      "title": "Java TreeMap vs HashMap | Baeldung",
+      "href": "https://www.baeldung.com/java-treemap-vs-hashmap",
+      "description": "Learn about the differences and similarities between TreeMap and HashMap.",
+      "meta": "baeldung.com"
+    }
+  ],
+  "Spring & frameworks": [
+    {
+      "title": "Intro to AspectJ | Baeldung",
+      "href": "https://www.baeldung.com/aspectj",
+      "description": "This article is a quick and practical introduction to AspectJ.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "GitHub - OpenFeign/feign: Feign makes writing java http clients easier",
+      "href": "https://github.com/OpenFeign/feign",
+      "description": "Feign makes writing java http clients easier. Contribute to OpenFeign/feign development by creating an account on GitHub.",
+      "meta": "github.com"
+    },
+    {
+      "title": "Spring @Qualifier Annotation",
+      "href": "https://www.baeldung.com/spring-qualifier-annotation",
+      "description": "@Autowired alone isn't sometimes enough to disambiguate dependencies. You can wire more exactly using the @Qualifier annotation. @Primary can also help.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "Difference between vs | Baeldung",
+      "href": "https://www.baeldung.com/spring-contextannotation-contextcomponentscan",
+      "description": "Explore the differences between context:annotation-config and context:component-scan XML elements.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "Spring Tutorial 10 - Bean Autowiring",
+      "href": "https://www.youtube.com/watch?v=suiEGbKf21g&list=PLC97BDEFDCDD169D7&index=10",
+      "description": "We'll now look at a configuration feature provided by Spring to wire dependencies automatically: Bean Autowiring. We'll learn about different types of autowi...",
+      "meta": "youtube.com"
+    },
+    {
+      "title": "What Is a Spring Bean? | Baeldung",
+      "href": "https://www.baeldung.com/spring-bean",
+      "description": "A quick and practical explanation of what a Spring Bean is.",
+      "meta": "baeldung.com"
+    },
+    {
+      "title": "Introduction to the Spring IoC Container and Beans :: Spring Framework",
+      "href": "https://docs.spring.io/spring-framework/reference/core/beans/introduction.html",
+      "description": "This chapter covers the Spring Framework implementation of the Inversion of Control (IoC) principle. Dependency injection (DI) is a specialized form of IoC, whereby objects define their dependencies (that is, the other objects they work wi…",
+      "meta": "docs.spring.io"
+    },
+    {
+      "title": "What does this do: @RunWith(SpringJUnit4ClassRunner.class)",
+      "href": "https://stackoverflow.com/questions/25317009/what-does-this-do-runwithspringjunit4classrunner-class",
+      "description": "What does this annotation do? When would I want to use it? When would I not want to use it? @RunWith(SpringJUnit4ClassRunner.class) I can find more usages of this when I Google and do not find ...",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "Spring Tutorial 16 - Writing a BeanFactoryPostProcessor",
+      "href": "https://www.youtube.com/watch?v=szNWTBlewQI&list=PLC97BDEFDCDD169D7&index=16",
+      "description": "In this tutorial, we'll learn about and write our own BeanFactoryPostProcessor. We'll also try out a handy BeanFactoryPostProcessor that comes with Spring: t...",
+      "meta": "youtube.com"
+    },
+    {
+      "title": "Using @Value annotation with static final variable in Spring Framework",
+      "href": "https://stackoverflow.com/questions/14439171/using-value-annotation-with-static-final-variable-in-spring-framework",
+      "description": "I want to make the Request Mappings in my Spring application dynamic. So that my url can not be understandable. And I can show anything meaningless to the user and still mapping purpose will be res...",
+      "meta": "stackoverflow.com"
+    }
+  ],
+  "_dead": [
+    {
+      "url": "https://testng.org/doc/",
+      "status": 404,
+      "error": null,
+      "section": "Test NG",
+      "context": "- https://testng.org/doc/"
+    },
+    {
+      "url": "http://www.javapractices.com/topic/TopicAction.do?Id=171",
+      "status": 503,
+      "error": null,
+      "section": "Throwing Exceptions",
+      "context": "- http://www.javapractices.com/topic/TopicAction.do?Id=171"
+    },
+    {
+      "url": "http://www.amazon.com/exec/obidos/ASIN/0471941484",
+      "status": 503,
+      "error": null,
+      "section": "Monitoring",
+      "context": "- [Garbage Collection: Algorithms for Automatic Dynamic Memory Management: Jones, Richard, Lins, Rafael D: 9780471941484: Amazon.com: Books](http://www.amazon.c"
+    },
+    {
+      "url": "https://dinocajic.medium.com/when-does-garbage-collection-run-in-java-9b48837c4f1f",
+      "status": 410,
+      "error": null,
+      "section": "Monitoring",
+      "context": "https://dinocajic.medium.com/when-does-garbage-collection-run-in-java-9b48837c4f1f"
+    }
+  ]
+}

--- a/bytesofpurpose-blog/src/data/references/learn-about-kubernetes.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-kubernetes.json
@@ -1,0 +1,119 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The Software Backend Developer/Learning Topics/DevOps Concepts/Learn about Kubernetes.md",
+    "source_commit": "40186c4ab6c35ffd1dc537982237f6d4b4810091",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Core Kubernetes": [
+    {
+      "title": "Home",
+      "href": "https://thenewstack.io/",
+      "description": "The latest news and resources on cloud native technologies, distributed systems and data architectures with emphasis on DevOps and open source projects.",
+      "meta": "thenewstack.io"
+    },
+    {
+      "title": "GitHub - GoogleContainerTools/skaffold: Easy and Repeatable Kubernetes Development",
+      "href": "https://github.com/GoogleContainerTools/skaffold",
+      "description": "Easy and Repeatable Kubernetes Development. Contribute to GoogleContainerTools/skaffold development by creating an account on GitHub.",
+      "meta": "github.com"
+    },
+    {
+      "title": "Operators: A Journey from Helm to Golang to Deliver on Cloud-native Applications' Day-2 Operations - VMblog",
+      "href": "https://vmblog.com/bylines/operators-a-journey-from-helm-to-golang-to-deliver-on-cloud-native-applications-day-2-operations/#.XpiJd1NKjUJ",
+      "description": "By Joe Leslie, Senior Product Manager at NuoDB For several years now, containers and containerization have dominated application development and software delivery conversations, along with process enablers such as CI/CD pipelines. While in…",
+      "meta": "vmblog.com"
+    },
+    {
+      "title": "GitHub - operator-framework/operator-sdk: SDK for building Kubernetes applications. Provides high level APIs, useful ab…",
+      "href": "https://github.com/operator-framework/operator-sdk",
+      "description": "SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding. - operator-framework/operator-sdk",
+      "meta": "github.com"
+    }
+  ],
+  "Patterns, scaling & cloud": [
+    {
+      "title": "Kubernetes Production Patterns and Anti-Patterns",
+      "href": "https://goteleport.com/blog/kubernetes-production-patterns/",
+      "description": "We explore helpful techniques to improve resiliency and high availability of Kubernetes deployments and take a look at some common mistakes to avoid when working with Docker and Kubernetes.",
+      "meta": "goteleport.com"
+    },
+    {
+      "title": "Kubernetes autoscaling with Istio metrics",
+      "href": "https://medium.com/google-cloud/kubernetes-autoscaling-with-istio-metrics-76442253a45a",
+      "description": "Kubernetes autoscaling with Istio metrics Autoscaling is an approach to automatically scale up or down workloads based on the resource usage. Autoscaling in Kubernetes has two dimensions: the Cluster …",
+      "meta": "medium.com"
+    },
+    {
+      "title": "Azure Kubernetes Service (AKS) documentation",
+      "href": "https://learn.microsoft.com/en-us/azure/aks/",
+      "description": "AKS allows you to quickly deploy a production ready Kubernetes cluster in Azure. Learn how to use AKS with these quickstarts, tutorials, and samples.",
+      "meta": "learn.microsoft.com"
+    },
+    {
+      "title": "Azure Kubernetes Service (AKS) Core Concepts - Azure Kubernetes Service",
+      "href": "https://learn.microsoft.com/en-us/azure/aks/core-aks-concepts",
+      "description": "Learn about the core concepts of Azure Kubernetes Service (AKS).",
+      "meta": "learn.microsoft.com"
+    },
+    {
+      "title": "Best Practices for Azure Kubernetes Service (AKS) - Azure Kubernetes Service",
+      "href": "https://learn.microsoft.com/en-us/azure/aks/best-practices",
+      "description": "Collection of cluster operator and developer best practices to build and manage applications in Azure Kubernetes Service (AKS), including guidance for AKS Automatic and AKS Standard.",
+      "meta": "learn.microsoft.com"
+    },
+    {
+      "title": "Jsonnet - Jsonnet Configuration Language",
+      "href": "https://jsonnet.org/",
+      "description": "A powerful DSL for elegant description of JSON data.",
+      "meta": "jsonnet.org"
+    },
+    {
+      "title": "GitHub - jsonnet-bundler/jsonnet-bundler: A jsonnet package manager.",
+      "href": "https://github.com/jsonnet-bundler/jsonnet-bundler#install",
+      "description": "A jsonnet package manager. Contribute to jsonnet-bundler/jsonnet-bundler development by creating an account on GitHub.",
+      "meta": "github.com"
+    },
+    {
+      "title": "Install Tools",
+      "href": "https://kubernetes.io/docs/tasks/tools/",
+      "description": "Set up Kubernetes tools on your computer.",
+      "meta": "kubernetes.io"
+    },
+    {
+      "title": "GitHub - derailed/k9s: 🐶 Kubernetes CLI To Manage Your Clusters In Style!",
+      "href": "https://github.com/derailed/k9s",
+      "description": "🐶 Kubernetes CLI To Manage Your Clusters In Style! - derailed/k9s",
+      "meta": "github.com"
+    },
+    {
+      "title": "Helm",
+      "href": "https://helm.sh/",
+      "description": "The package manager for Kubernetes",
+      "meta": "helm.sh"
+    },
+    {
+      "title": "Red Hat OpenShift",
+      "href": "https://www.redhat.com/en/technologies/cloud-computing/openshift",
+      "description": "A unified application development platform that lets you build, modernize, and deploy applications at scale on your choice of hybrid cloud infrastructure.",
+      "meta": "redhat.com"
+    },
+    {
+      "title": "GitHub - prometheus-operator/kube-prometheus: Use Prometheus to monitor Kubernetes and applications running on Kubernet…",
+      "href": "https://github.com/prometheus-operator/kube-prometheus",
+      "description": "Use Prometheus to monitor Kubernetes and applications running on Kubernetes - prometheus-operator/kube-prometheus",
+      "meta": "github.com"
+    },
+    {
+      "title": "cluster-monitoring-operator/jsonnet/grafana.jsonnet at 1cff58efb310c00d67ea48135136fc2e2242d945 · openshift/cluster-mon…",
+      "href": "https://github.com/openshift/cluster-monitoring-operator/blob/1cff58efb310c00d67ea48135136fc2e2242d945/jsonnet/grafana.jsonnet#L49",
+      "description": "Manage the OpenShift monitoring stack. Contribute to openshift/cluster-monitoring-operator development by creating an account on GitHub.",
+      "meta": "github.com"
+    },
+    {
+      "title": "GitHub - brancz/kubernetes-grafana: The future of Grafana on Kubernetes with Prometheus.",
+      "href": "https://github.com/brancz/kubernetes-grafana",
+      "description": "The future of Grafana on Kubernetes with Prometheus. - brancz/kubernetes-grafana",
+      "meta": "github.com"
+    }
+  ]
+}

--- a/bytesofpurpose-blog/src/data/references/learn-about-ml.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-ml.json
@@ -1,0 +1,205 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The AI Engineer/Learning Topics/Machine Learning/Learn about ML.md",
+    "source_commit": "40186c4ab6c35ffd1dc537982237f6d4b4810091",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Concepts & fundamentals": [
+    {
+      "title": "Game of Zones Season 6 FULL Season Binge (Every Episode)",
+      "href": "https://www.youtube.com/watch?t=1235&v=N66uHLwbr8o&feature=youtu.be",
+      "description": "Watch all of Game of Zones season 6.X-Mas Day Special - The King's LAnding - 0:00EP 1 - The Dire Wolf - 4:53EP 2 - Journeymen - 8:15EP 3 - The North Remember...",
+      "meta": "youtube.com"
+    },
+    {
+      "title": "Machine Learning for Everyone | Vipul Patel | 32 comments",
+      "href": "https://www.linkedin.com/posts/vipulppatel_machine-learning-for-everyone-activity-6589526851092381697-v7QF",
+      "description": "Machine Learning for Everyone - Awesome Notes (35 Pages) - Vasily Zubarev Other Great Articles: (downloadable) 📌 A Non-Technical Introduction to LDA Topic Models https://lnkd.in/gTD_jrb 📌 Cheat Sheets for AI: Neural Networks, Machine Lea…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "Google Colab",
+      "href": "https://colab.research.google.com/drive/1SvVTDYD_QH_V67juSmWkNHa9N99oah-r",
+      "meta": "colab.research.google.com"
+    },
+    {
+      "title": "Gemini Enterprise Agent Platform | Google Cloud Documentation",
+      "href": "https://docs.cloud.google.com/gemini-enterprise-agent-platform",
+      "description": "Build, scale, govern, and optimize autonomous agents with Gemini Enterprise Agent Platform.",
+      "meta": "docs.cloud.google.com"
+    },
+    {
+      "title": "Introducing Feast: an open source feature store for machine learning | Google Cloud Blog",
+      "href": "https://cloud.google.com/blog/products/ai-machine-learning/introducing-feast-an-open-source-feature-store-for-machine-learning",
+      "description": "Learn from GO-JEK and Google how Feast can help you store and keep tabs on various features relevant to your business, so that data scientists can collaborate to improve their models.",
+      "meta": "cloud.google.com"
+    },
+    {
+      "title": "OpenAI API, Community Examples | Notion",
+      "href": "https://brookechan.notion.site/OpenAI-API-Community-Examples-ce088785e541498698c1895798e67664",
+      "description": "Hosted by Notion Sites — The easiest way to get a website up and running.",
+      "meta": "brookechan.notion.site"
+    },
+    {
+      "title": "Cover Letter Generator | Notion",
+      "href": "https://brookechan.notion.site/Cover-Letter-Generator-8ac55d1145dc4243ae0dc97345e3661f",
+      "description": "Company: Spotify Job Description: We want someone to help build a new data pipeline for Spotify Unwrapped team using Apache Kafka and D3.js Resume: - Worked as a Developer Advocate at Algolia, writing blog posts and speaking on behalf of t…",
+      "meta": "brookechan.notion.site"
+    },
+    {
+      "title": "Metacademy: a package manager for knowledge – Machine Learning (Theory)",
+      "href": "https://hunch.net/?p=2714",
+      "description": "In recent years, there’s been an explosion of free educational resources that make high-level knowledge and skills accessible to an ever-wider group of people. In your own field, you probably have a good idea of where to look for the answe…",
+      "meta": "hunch.net"
+    },
+    {
+      "title": "2020 Machine Learning Roadmap (87% valid for 2024)",
+      "href": "https://www.youtube.com/watch?v=pHiMN_gy9mk",
+      "description": "Getting into machine learning is quite the adventure. And as any adventurer knows, sometimes it can be helpful to have a compass to figure out if you're head...",
+      "meta": "youtube.com"
+    },
+    {
+      "title": "Machine Learning for Designers",
+      "href": "https://www.oreilly.com/radar/machine-learning-for-designers/",
+      "description": "This report introduces contemporary machine learning systems, but also provides a conceptual framework to help you integrate machine-learning capabilities into your user-facing designs.",
+      "meta": "oreilly.com"
+    },
+    {
+      "title": "MIT 6.S191 (2020): Introduction to Deep Learning",
+      "href": "https://www.youtube.com/watch?v=njKP3FqW3Sk",
+      "description": "MIT Introduction to Deep Learning 6.S191: Lecture 1Foundations of Deep LearningLecturer: Alexander AminiJanuary 2020For all lectures, slides, and lab materia...",
+      "meta": "youtube.com"
+    },
+    {
+      "title": "Contextual Bandits — VowpalWabbit latest documentation",
+      "href": "https://vowpalwabbit.org/docs/vowpal_wabbit/python/latest/tutorials/python_Contextual_bandits_and_Vowpal_Wabbit.html",
+      "description": "This tutorial includes an overview of the contextual bandits approach to reinforcement learning and describes how to approach a contextual bandit problem using Vowpal Wabbit. You will learn how to use Vowpal Wabbit in a contextual bandit s…",
+      "meta": "vowpalwabbit.org"
+    }
+  ],
+  "Courses & comprehensive resources": [
+    {
+      "title": "Start Here with Machine Learning",
+      "href": "https://machinelearningmastery.com/start-here/#process",
+      "description": "Your guide to getting started and getting good at applied machine learning with Machine Learning Mastery.",
+      "meta": "machinelearningmastery.com"
+    },
+    {
+      "title": "Homepage",
+      "href": "https://end-to-end-machine-learning.teachable.com/",
+      "meta": "end-to-end-machine-learning.teachable.com"
+    },
+    {
+      "title": "Free resources to Supercharge your Data Science Career | Vipul Patel | 15 comments",
+      "href": "https://www.linkedin.com/posts/vipulppatel_free-resources-to-supercharge-your-data-science-activity-6591198674523566080-qi6I",
+      "description": "Free resources to Supercharge your Data Science Career - EliteDataScience Other Great Articles: (downloadable) 📌 Essential Notes - Coursera Deep Learning Course by Andrew Ng https://lnkd.in/dPizzVe 📌 Advantages Drawbacks Applications of…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "The Ultimate guide to AI, Data Science & Machine Learning, Articles, Cheatsheets and Tutorials ALL in one place",
+      "href": "https://www.linkedin.com/pulse/all-cheatsheets-one-place-vipul-patel/",
+      "description": "Last updated 10/29/21 This is a carefully curated compendium of articles & tutorials covering all things AI, Data Science & Machine Learning for the beginner to advanced practitioner. I will be periodically updating this document with popu…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "Learn Python, Data Viz, Pandas & More | Tutorials | Kaggle",
+      "href": "https://www.kaggle.com/learn",
+      "description": "Practical data skills you can apply immediately: that's what you'll learn in these no-cost courses. They're the fastest (and most fun) way to become a data scientist or improve your current skills.",
+      "meta": "kaggle.com"
+    },
+    {
+      "title": "Machine Learning Algorithms Cheatsheet [Python/R] | Kaggle",
+      "href": "https://www.kaggle.com/discussions/getting-started/156497",
+      "description": "Download - Machine Learning Algorithms Cheatsheet [Python/R]",
+      "meta": "kaggle.com"
+    },
+    {
+      "title": "numpy | Kaggle",
+      "href": "https://www.kaggle.com/discussions/getting-started/154965",
+      "description": "Discover what actually works in AI. Join millions of builders, researchers, and labs evaluating agents, models, and frontier technology through crowdsourced benchmarks, competitions, and hackathons.",
+      "meta": "kaggle.com"
+    },
+    {
+      "title": "huggingface.co",
+      "href": "https://huggingface.co/docs/transformers/summary",
+      "meta": "huggingface.co"
+    },
+    {
+      "title": "huggingface.co",
+      "href": "https://huggingface.co/docs/transformers/examples#the-big-table-of-tasks",
+      "meta": "huggingface.co"
+    },
+    {
+      "title": "Creating Neural Networks with Computational Graphs | Vipul Patel",
+      "href": "https://www.linkedin.com/feed/update/urn:li:activity:6551453166750187520",
+      "description": "Understanding & Creating Neural Networks with Computational Graphs from Scratch -Rafay Khan Other Great Articles: (downloadable) Google Data Engineering Cheatsheet (9 pages) https://lnkd.in/dbYMBGg Machine Learning Cheatsheets (16 Pages) h…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "#machinelearning #artificialintelligence #datascience #ml #ai #deeplearning #technology #python | Vipul Patel",
+      "href": "https://www.linkedin.com/feed/update/urn:li:activity:6551014767471927296",
+      "description": "Neural Networks & Deep Learning with Python ANN,CNN,RNN ✍ Visual Explanation of Deep Learning (21 pages) https://lnkd.in/eiiCB9w ✍ Walkthrough how to use Deep Learning to solve a problem with Python - (13 pages) https://lnkd.in/eBmbaJq ✍ A…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "Math of Deep Learning Neural Networks – Simplified | Vipul Patel",
+      "href": "https://www.linkedin.com/feed/update/urn:li:activity:6550852574898077696",
+      "description": "Math of Deep Learning Neural Networks Simplified (9 pages) - Roopam Upadhyay Other Great Articles: (downloadable) Detailed Guide to Build Better Predictive Models using Segmentation https://lnkd.in/dy9mFk5 20 Data Science Business Use Case…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "Guide to Build Better Predictive Models using Segmentation | Vipul Patel",
+      "href": "https://www.linkedin.com/feed/update/urn:li:activity:6550576226271010816",
+      "description": "Detailed Guide to Build Better Predictive Models using Segmentation Other Great Articles: (downloadable) 20 Data Science Business Use Cases https://lnkd.in/duHBfRr Architecting a Machine Learning Pipeline https://lnkd.in/djmkDek Being a Da…",
+      "meta": "linkedin.com"
+    }
+  ],
+  "Specific techniques": [
+    {
+      "title": "tensorflow_constrained_optimization/README.md at master · google-research/tensorflow_constrained_optimization",
+      "href": "https://github.com/google-research/tensorflow_constrained_optimization/blob/master/README.md",
+      "description": "Contribute to google-research/tensorflow_constrained_optimization development by creating an account on GitHub.",
+      "meta": "github.com"
+    },
+    {
+      "title": "What is Stratified Cross-Validation in Machine Learning? | Towards Data Science",
+      "href": "https://towardsdatascience.com/what-is-stratified-cross-validation-in-machine-learning-8844f3e7ae8e/",
+      "description": "This article explains stratified cross-validation and it's implementation in Python using Scikit-Learn. This article assumes the reader to...",
+      "meta": "towardsdatascience.com"
+    },
+    {
+      "title": "What is Hamming Distance?",
+      "href": "https://www.tutorialspoint.com/article/what-is-hamming-distance",
+      "description": "Hamming distance is a metric for comparing two binary data strings of equal length. It measures the number of bit positions in which the two bits are different, providing a quantitative way to assess how \"close\" or \"far apart\" two binary s…",
+      "meta": "tutorialspoint.com"
+    },
+    {
+      "title": "Euclidean distance - Wikipedia",
+      "href": "https://en.wikipedia.org/wiki/Euclidean_distance",
+      "description": "In mathematics, the Euclidean distance between two points in a Euclidean space is the length of the line segment between them. It can be calculated from the Cartesian coordinates of the points using the Pythagorean theorem, and therefore i…",
+      "meta": "en.wikipedia.org"
+    },
+    {
+      "title": "GitHub - microsoft/nni: An open source AutoML toolkit for automate machine learning lifecycle, including feature engine…",
+      "href": "https://github.com/microsoft/nni",
+      "description": "An open source AutoML toolkit for automate machine learning lifecycle, including feature engineering, neural architecture search, model compression and hyper-parameter tuning. - microsoft/nni",
+      "meta": "github.com"
+    }
+  ],
+  "_dead": [
+    {
+      "url": "https://www.reddit.com/r/learnmachinelearning/comments/fdwiex/gradient_descent_from_scratch_in_pure_python/?utm_source=share&utm_medium=ios_app&utm_name=iossmf",
+      "status": 200,
+      "error": "page.evaluate: Execution context was destroyed, most likely because of a navigation",
+      "section": "Gradient Descent",
+      "context": "* [ ] https://www.reddit.com/r/learnmachinelearning/comments/fdwiex/gradient_descent_from_scratch_in_pure_python/?utm_source=share&utm_medium=ios_app&utm_name=i"
+    },
+    {
+      "url": "https://towardsdatascience.com/image-clustering-using-transfer-learning-df5862779571",
+      "status": 404,
+      "error": null,
+      "section": "Backlog",
+      "context": "- https://towardsdatascience.com/image-clustering-using-transfer-learning-df5862779571"
+    }
+  ]
+}

--- a/bytesofpurpose-blog/src/data/references/learn-about-nlp.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-nlp.json
@@ -1,0 +1,64 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The AI Engineer/Learning Topics/Natural Language Processing/Learn about NLP.md",
+    "source_commit": "40186c4ab6c35ffd1dc537982237f6d4b4810091",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Resources": [
+    {
+      "title": "LinkedIn",
+      "href": "https://lnkd.in/grxZtz3",
+      "description": "This link will take you to a page that’s not on LinkedIn",
+      "meta": "lnkd.in"
+    },
+    {
+      "title": "#javascrip #java #datascienc #businessintelligence #dataanalytics #database #operatingsystems #programming #web #networ…",
+      "href": "https://www.linkedin.com/feed/update/urn:li:activity:6541520171213946880",
+      "description": "All the Interview Questions You Need in One Place : ✅ #JavaScrip #Java interviews https://lnkd.in/g9A2qMp ✅ #DataScienc #BusinessIntelligence #DataAnalytics interviews https://lnkd.in/gPi-KiB ✅#Database interviews https://lnkd.in/gSwkbNA ✅…",
+      "meta": "linkedin.com"
+    },
+    {
+      "title": "#handbooks #datascience #interview #onlinecourses #cheatsheets #customeranalytics #python #nlp | Steve Nouri | 30 comme…",
+      "href": "https://www.linkedin.com/feed/update/urn:li:activity:6541916192939085824",
+      "description": "Feature Engineering/Dimensionality Reduction for Machine Learning: ✅ Feature engineering for numeric data: filtering, binning, scaling, log transforms, and power transforms ✅ Natural text techniques: bag-of-words, n-grams, and phrase detec…",
+      "meta": "linkedin.com"
+    }
+  ],
+  "_dead": [
+    {
+      "url": "https://lnkd.in/gKYqpfV",
+      "status": 404,
+      "error": null,
+      "section": "Resources ...",
+      "context": "https://lnkd.in/gKYqpfV"
+    },
+    {
+      "url": "https://lnkd.in/gMkf7gD",
+      "status": 404,
+      "error": null,
+      "section": "Resources ...",
+      "context": "https://lnkd.in/gMkf7gD"
+    },
+    {
+      "url": "https://lnkd.in/gGHKSdN",
+      "status": 404,
+      "error": null,
+      "section": "Resources ...",
+      "context": "https://lnkd.in/gGHKSdN"
+    },
+    {
+      "url": "https://lnkd.in/gZvMffe",
+      "status": 404,
+      "error": null,
+      "section": "Resources ...",
+      "context": "https://lnkd.in/gZvMffe"
+    },
+    {
+      "url": "https://lnkd.in/gFFDFMg",
+      "status": 404,
+      "error": null,
+      "section": "Resources ...",
+      "context": "https://lnkd.in/gFFDFMg"
+    }
+  ]
+}

--- a/bytesofpurpose-blog/src/data/references/learn-about-postgresql.json
+++ b/bytesofpurpose-blog/src/data/references/learn-about-postgresql.json
@@ -1,0 +1,229 @@
+{
+  "_provenance": {
+    "source": "roles-software-development/The Data Engineer/Learning Topics/Relational Databases/Learn about Postgresql.md",
+    "source_commit": "40186c4ab6c35ffd1dc537982237f6d4b4810091",
+    "note": "Public links abstracted from the source note's link log; dead links pruned. Refresh by re-running the link pipeline and re-stamping source_commit."
+  },
+  "Querying recipes": [
+    {
+      "title": "How to Group By “Nothing” in SQL",
+      "href": "https://blog.jooq.org/how-to-group-by-nothing-in-sql/",
+      "description": "The SQL standard knows a lesser known feature called GROUPING SETS. One particular side-effect of that feature is that we can group by \"nothing\" in SQL. E.g. when querying the Sakila database: SELECT count(*) FROM film GROUP BY () This wil…",
+      "meta": "blog.jooq.org"
+    },
+    {
+      "title": "https://www.google.com/search?q=fill+left+vs+left+join&rlz=1C5CHFA_enUS815US815&oq=fill+left+vs+left+join&aqs=chrome..6…",
+      "href": "https://www.google.com/sorry/index?continue=https://www.google.com/search%3Fq%3Dfill%2Bleft%2Bvs%2Bleft%2Bjoin%26rlz%3D1C5CHFA_enUS815US815%26oq%3Dfill%2Bleft%2Bvs%2Bleft%2Bjoin%26aqs%3Dchrome..69i57j69i64l3.6080j0j1%26sourceid%3Dchrome%26ie%3DUTF-8%26sei%3D6SMoapqBH_-4qtsP4OWw-Q8&q=EhAmABcCTxyOALgMSXO11jPmGOnHoNEGIjDAbs5_ITnaS54eYHcHSs5EmRqQHPCxrJ2DhZ8dT754a0ETHSluGeVtAX1oxn6yFrwyAVJaAUM",
+      "meta": "google.com"
+    },
+    {
+      "title": "PostgreSQL LEFT JOIN or LEFT OUTER JOIN - w3resource",
+      "href": "https://www.w3resource.com/PostgreSQL/postgresql-left-join.php",
+      "description": "The PostgreSQL LEFT JOIN, joins two tables and fetches rows based on a condition, which are matching in both the tables, and the unmatched rows will also be available from the table written before the JOIN clause.",
+      "meta": "w3resource.com"
+    },
+    {
+      "title": "Postgresql - select something where date = \"01/01/11\"",
+      "href": "https://stackoverflow.com/questions/5875712/postgresql-select-something-where-date-01-01-11",
+      "description": "I have a datetime field in my Postgresql, named \"dt\". I'd like to do something like SELECT * FROM myTable WHERE extract (date from dt) = '01/01/11' What is the right syntax to do that? Thanks!",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "Aggregate Functions",
+      "href": "https://www.postgresql.org/docs/9.5/functions-aggregate.html",
+      "description": "Aggregate functions compute a single result from a set of input values. The built-in normal aggregate functions are listed in Table 9-49 and Table 9-50. The built-in ordered-set aggregate functions are listed in Table 9-51 and Table 9-52.…",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "Postgres returns [null] instead of [] for array_agg of join table",
+      "href": "https://stackoverflow.com/questions/31108946/postgres-returns-null-instead-of-for-array-agg-of-join-table",
+      "description": "I'm selecting some objects and their tags in Postgres. The schema is fairly simple, three tables: objects id taggings id | object_id | tag_id tags id | tag I'm joining the tables like this, using",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "pandas.date_range — pandas 3.0.3 documentation",
+      "href": "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.date_range.html",
+      "description": "Returns the range of equally spaced time points (where the difference between any two adjacent points is specified by the given frequency) such that they fall in the range [start, end] , where the first one and the last one are, resp., the…",
+      "meta": "pandas.pydata.org"
+    },
+    {
+      "title": "How to replace nulls with zeros in postgresql crosstabs",
+      "href": "https://stackoverflow.com/questions/6355177/how-to-replace-nulls-with-zeros-in-postgresql-crosstabs",
+      "description": "I've a product table with product_id and 100+ attributes. The product_id is text whereas the attribute columns are integer, i.e. 1 if the attribute exists. When the Postgresql crosstab is run, non-",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "Preserve order from subquery (with GROUP BY and ORDER BY)",
+      "href": "https://stackoverflow.com/questions/35923762/preserve-order-from-subquery-with-group-by-and-order-by",
+      "description": "I am using a smartphone to collect data from the accelerometer and then saving it in a postgresql database, in a server. Basically, each time I read the accelerometer, I save the latitude/longitude...",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "https://www.google.com/search?q=date+from+timestamp+postgres&rlz=1C5CHFA_enUS815US815&oq=date+from+timestamp+post&aqs=c…",
+      "href": "https://www.google.com/sorry/index?continue=https://www.google.com/search%3Fq%3Ddate%2Bfrom%2Btimestamp%2Bpostgres%26rlz%3D1C5CHFA_enUS815US815%26oq%3Ddate%2Bfrom%2Btimestamp%2Bpost%26aqs%3Dchrome.0.0j69i57j0l2j69i60j69i64l3.6217j0j4%26sourceid%3Dchrome%26ie%3DUTF-8%26sei%3DAyQoasajG_SzmtkPl6XSoQw&q=EhAmABcCTxyOALgMSXO11jPmGIPIoNEGIjBKsruBKiPOsNgxeT6ehTNGGbbsmY8eBkO8zEhtWEEflJg_Z_evyg4zphjs4s-jetAyAVJaAUM",
+      "meta": "google.com"
+    },
+    {
+      "title": "Declare a variable in a PostgreSQL query",
+      "href": "https://stackoverflow.com/questions/1490942/declare-a-variable-in-a-postgresql-query",
+      "description": "How do I declare a variable for use in a PostgreSQL 8.3 query? In MS SQL Server I can do this: DECLARE @myvar INT; SET @myvar = 5/ SELECT * FROM somewhere WHERE something = @myvar; How do I d...",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "WITH Queries (Common Table Expressions)",
+      "href": "https://www.postgresql.org/docs/9.1/queries-with.html",
+      "description": "WITH provides a way to write auxiliary statements for use in a larger query. These statements, which are often referred to as Common Table Expressions or CTEs, can be thought of as defining temporary tables that exist just for one query. E…",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "PostgreSQL UNNEST() function - w3resource",
+      "href": "https://w3resource.com/PostgreSQL/postgresql_unnest-function.php",
+      "description": "PostgreSQL UNNEST() function with Example : This function is used to expand an array to a set of rows.",
+      "meta": "w3resource.com"
+    }
+  ],
+  "Schema design & best practices": [
+    {
+      "title": "5.1. Table Basics",
+      "href": "https://www.postgresql.org/docs/12/ddl-basics.html",
+      "description": "5.1.&nbsp;Table Basics A table in a relational database is much like a table on paper: It consists of rows and …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.4. Constraints",
+      "href": "https://www.postgresql.org/docs/12/ddl-constraints.html",
+      "description": "5.4.&nbsp;Constraints 5.4.1. Check Constraints 5.4.2. Not-Null Constraints 5.4.3. Unique Constraints 5.4.4. Primary Keys 5.4.5. Foreign Keys 5.4.6. Exclusion Constraints Data …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.2. Default Values",
+      "href": "https://www.postgresql.org/docs/12/ddl-default.html",
+      "description": "5.2.&nbsp;Default Values A column can be assigned a default value. When a new row is created and no values are …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.3. Generated Columns",
+      "href": "https://www.postgresql.org/docs/12/ddl-generated-columns.html",
+      "description": "5.3.&nbsp;Generated Columns A generated column is a special column that is always computed from other columns. Thus, it is for …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.5. System Columns",
+      "href": "https://www.postgresql.org/docs/12/ddl-system-columns.html",
+      "description": "5.5.&nbsp;System Columns Every table has several system columns that are implicitly defined by the system. Therefore, these names cannot be …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.6. Modifying Tables",
+      "href": "https://www.postgresql.org/docs/12/ddl-alter.html#id-1.5.4.8.10",
+      "description": "5.6.&nbsp;Modifying Tables 5.6.1. Adding a Column 5.6.2. Removing a Column 5.6.3. Adding a Constraint 5.6.4. Removing a Constraint 5.6.5. Changing …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.8. Row Security Policies",
+      "href": "https://www.postgresql.org/docs/12/ddl-rowsecurity.html",
+      "description": "5.8.&nbsp;Row Security Policies In addition to the SQL-standard privilege system available through GRANT, tables can have row security policies that …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.9. Schemas",
+      "href": "https://www.postgresql.org/docs/12/ddl-schemas.html",
+      "description": "5.9.&nbsp;Schemas 5.9.1. Creating a Schema 5.9.2. The Public Schema 5.9.3. The Schema Search Path 5.9.4. Schemas and Privileges 5.9.5. The …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "5.11. Table Partitioning",
+      "href": "https://www.postgresql.org/docs/12/ddl-partitioning.html",
+      "description": "5.11.&nbsp;Table Partitioning 5.11.1. Overview 5.11.2. Declarative Partitioning 5.11.3. Partitioning Using Inheritance 5.11.4. Partition Pruning 5.11.5. Partitioning and Constraint Exclusion 5.11.6. …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "Chapter 14. Performance Tips",
+      "href": "https://www.postgresql.org/docs/12/performance-tips.html",
+      "description": "Chapter&nbsp;14.&nbsp;Performance Tips Table of Contents 14.1. Using EXPLAIN 14.1.1. EXPLAIN Basics 14.1.2. EXPLAIN ANALYZE 14.1.3. Caveats 14.2. Statistics Used by …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "40.3. Materialized Views",
+      "href": "https://www.postgresql.org/docs/12/rules-materializedviews.html",
+      "description": "40.3.&nbsp;Materialized Views Materialized views in PostgreSQL use the rule system like views do, but persist the results in a table-like …",
+      "meta": "postgresql.org"
+    },
+    {
+      "title": "Date/Time Functions and Operators",
+      "href": "https://www.postgresql.org/docs/9.2/functions-datetime.html",
+      "description": "Table 9-28 shows the available functions for date/time value processing, with details appearing in the following subsections. Table 9-27 illustrates the behaviors of the basic arithmetic operators (+, *, etc.). For formatting functions, re…",
+      "meta": "postgresql.org"
+    }
+  ],
+  "Tooling": [
+    {
+      "title": "Data transfer | DBeaver Documentation",
+      "href": "https://dbeaver.com/docs/dbeaver/Data-transfer/",
+      "description": "Learn how to import and export data in many formats including csv, copy data from one database to another, and move data between tables.",
+      "meta": "dbeaver.com"
+    },
+    {
+      "title": "EverSQL | Your Database, Just Faster",
+      "href": "https://www.eversql.com/sql-syntax-check-validator/",
+      "description": "EverSQL is an AI-powered PostgreSQL & MySQL database and SQL optimizer. 100,000+ engineers use EverSQL to monitor and optimize SQL queries online, and get ongoing database performance insights, quickly and easily.",
+      "meta": "eversql.com"
+    },
+    {
+      "title": "PostgreSQL syntax check without running the query",
+      "href": "https://stackoverflow.com/questions/8271606/postgresql-syntax-check-without-running-the-query",
+      "description": "I want to verify the syntax of files containing sql queries before they can be committed in my CVS project. In order to do that, I have a commitinfo script, but I have trouble finding out if the sql",
+      "meta": "stackoverflow.com"
+    },
+    {
+      "title": "Performance implications of MySQL VARCHAR sizes",
+      "href": "https://dba.stackexchange.com/questions/424/performance-implications-of-mysql-varchar-sizes/1915#1915",
+      "description": "Is there a performance difference in MySQL between varchar sizes? For example, varchar(25) and varchar(64000). If not, is there a reason not to declare all varchars with the max size just to ensu...",
+      "meta": "dba.stackexchange.com"
+    }
+  ],
+  "_dead": [
+    {
+      "url": "https://www.postgresqltutorial.com/postgresql-cross-join/",
+      "status": null,
+      "error": "page.goto: Timeout 20000ms exceeded.",
+      "section": "Cross Join to repeat rows across two tables",
+      "context": "https://www.postgresqltutorial.com/postgresql-cross-join/"
+    },
+    {
+      "url": "https://www.postgresqltutorial.com/plpgsql-variables/",
+      "status": 522,
+      "error": null,
+      "section": "Declaring Query Variables",
+      "context": "https://www.postgresqltutorial.com/plpgsql-variables/"
+    },
+    {
+      "url": "https://kb.objectrocket.com/postgresql/declare-row-variable-for-postgresql-825",
+      "status": 404,
+      "error": null,
+      "section": "Declaring Query Variables",
+      "context": "https://kb.objectrocket.com/postgresql/declare-row-variable-for-postgresql-825"
+    },
+    {
+      "url": "https://www.postgresqltutorial.com/postgresql-alias/",
+      "status": 522,
+      "error": null,
+      "section": "Declaring Query Variables",
+      "context": "https://www.postgresqltutorial.com/postgresql-alias/"
+    },
+    {
+      "url": "https://docs.teradata.com/reader/kmuOwjp1zEYg98JsB8fu_A/FTrSJJOjpjqIZ6ue5YuiCQ",
+      "status": 404,
+      "error": null,
+      "section": "Grouping on Arrays",
+      "context": "https://docs.teradata.com/reader/kmuOwjp1zEYg98JsB8fu_A/FTrSJJOjpjqIZ6ue5YuiCQ"
+    },
+    {
+      "url": "https://www.amazon.com/dp/0672327651",
+      "status": 500,
+      "error": null,
+      "section": "Common Non-SQL, Postgres Specific Commands",
+      "context": "- https://www.amazon.com/dp/0672327651"
+    }
+  ]
+}


### PR DESCRIPTION
Publishes the technical blog-post batch drafted via scan-blog-worthy:

- Learning plans: GraphQL, ML, NLP, Java, Agile, Kubernetes, PostgreSQL
- Answering Leadership-Principle Interview Questions
- Questions for Productionizing a Machine Learning System
- What Makes Something a Process
- Design Patterns question-set + OAuth explainer (batch 1)
- Plus src/data/references/*.json for the learning-plan carousels

These are the posts the personalbook `blog_published_as` markers point at
(a-learning-plan-for-*, answering-leadership-principle-interview-questions).
Merging makes `make validate-blog` in personalbook pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)