### PR TITLE
feat(refine-design-post): users-first opening, name-vs-purpose, North Star + fork-in-the-road, tabify mockups

### DIFF
--- a/.claude/skills/author-mermaid/SKILL.md
+++ b/.claude/skills/author-mermaid/SKILL.md
@@ -26,6 +26,7 @@ This repo runs **mermaid 11.15** — all types below are verified to render here
 | Dated milestones | `timeline` | chronological events |
 | What a system TOUCHES at its boundary | `architecture-beta` (context) | hub-and-spoke; see Context diagram |
 | **Use-case diagram (UML)** | `flowchart` (no native type) | actors + oval use cases; see recipe |
+| **Fork in the road** (diverging future options) | `flowchart` | one foundation node fans out to N divergent paths; see recipe. For a North Star / vision section naming >1 direction |
 
 **Three "boundary/relationship" diagrams that are easy to confuse — pick deliberately:**
 - **Flow** (`flowchart`/`graph`): something MOVES through steps (A→B→C). Activity/data flow.
@@ -172,6 +173,25 @@ flowchart LR
 ```
 Keep actors on one side (`flowchart LR` puts them left), the use cases inside the boundary,
 and few associations per actor so the lines stay clean (visual-verify).
+
+### fork in the road (diverging future directions — for a North Star / vision section)
+When a design's closing vision names MORE THAN ONE possible future, show that the options DIVERGE
+rather than listing them: a `flowchart LR` where the current foundation is one node that fans out to
+N future-direction nodes. Each branch label is the trigger/bet that leads down that path; the
+direction nodes are stadium `([...])` ovals (a "destination" shape). Keep the paths as siblings (do
+NOT chain them) so the fork reads as *alternatives*, not a sequence. Do NOT hardcode colors — the
+theme colors it. Verified-rendering skeleton:
+```
+flowchart LR
+  found([Today: usage reporting])
+  found -->|"admin the fleet"| a([Admin control plane])
+  found -->|"compare teams"| b([Benchmarking service])
+  found -->|"cut spend"| c([Cost-optimization advisor])
+  found -->|"prove compliance"| d([Compliance export])
+```
+This is a `refine-design-post` axis-4 candidate: the skill proposes it when a North Star section names
+2+ directions. One direction needs no fork (a sentence does). Label the branches with the bet that
+opens each path, and keep the direction nodes short (they are destinations, not descriptions).
 
 ### context diagram (architecture-beta hub — what a system TOUCHES)
 Shows a system and the actors/stores/dependencies at its boundary — NOT internal flow. One

--- a/.claude/skills/author-post/homes/design.md
+++ b/.claude/skills/author-post/homes/design.md
@@ -62,8 +62,12 @@ component + a mermaid fallback). Only after that comes the `:::note[Scope]` admo
 
 A proven arc after the users/use-cases opening (see `designs/2026-07-04-fleetplane.mdx`):
 Scope → Executive Summary (problem / solution / value; lead with a relatable "you") → an animated
-architecture diagram → components / data model → a **Key Decisions** section → closing. Rich-component
-catalog: `upgrade-post`.
+architecture diagram → components / data model → a **Key Decisions** section → closing → an OPTIONAL
+**North Star / vision** section (where the foundation could go NEXT, framed as one direction among
+others, NOT the committed goal — the honest home for an ambition the name must not overclaim). When
+the North Star names more than one direction, show them diverge with a **"fork in the road"** diagram
+(a `flowchart` fanning the current foundation out to N future paths; see `author-mermaid`).
+Rich-component catalog: `upgrade-post`.
 
 - **Animate the first mermaid block**: wrap it in `<div className="mermaid-animated flow-dot">` …
   `</div>` and add `%% animate: flow` as the first line inside the fence. Dashes march; flow

--- a/.claude/skills/author-post/homes/design.md
+++ b/.claude/skills/author-post/homes/design.md
@@ -52,11 +52,18 @@ mockups: ./_mockups/<kebab>.mdx         # only if you add a mockup sidecar (belo
 
 ## Body shape (mirror the other agentic designs)
 
-Open with a `:::note[Scope]` admonition, then `<!-- truncate -->`, then the body. A proven arc
-(see `designs/2026-06-22-self-healing-storefront.mdx`, `designs/2026-07-04-fleetplane.mdx`):
-Executive Summary (problem / solution / key decisions / value) → an animated architecture diagram
-→ components / data model → a **Key Decisions** section → closing. Rich-component catalog:
-`upgrade-post`.
+**Open with USERS & USE CASES, before the Scope note.** The first section establishes the people and
+what they will do — who are we building for, what problem do they have, what will we build to fix it,
+how will they use it, how does it make their life better — and carries a **use-case diagram**
+(`<UseCaseDiagram>`: actors outside a system boundary, use-case ovals; see `author-mermaid` for the
+component + a mermaid fallback). Only after that comes the `:::note[Scope]` admonition, then
+`<!-- truncate -->`, then the body. This ordering is a REQUIRED rule enforced by `refine-design-post`
+(SECTION-QUESTIONS.md "Users & use cases"); a post that opens on the system is an ordering finding.
+
+A proven arc after the users/use-cases opening (see `designs/2026-07-04-fleetplane.mdx`):
+Scope → Executive Summary (problem / solution / value; lead with a relatable "you") → an animated
+architecture diagram → components / data model → a **Key Decisions** section → closing. Rich-component
+catalog: `upgrade-post`.
 
 - **Animate the first mermaid block**: wrap it in `<div className="mermaid-animated flow-dot">` …
   `</div>` and add `%% animate: flow` as the first line inside the fence. Dashes march; flow

--- a/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
+++ b/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
@@ -99,6 +99,26 @@ Optional:
 - Why it's built this way (the reflective coda the author favors).
 - What carried over from a prior build.
 
+## North Star / vision (OPTIONAL, closing)
+
+An optional closing section that names where the foundation built here **could** go next. It keeps
+the built thing HONEST (the design does X) while capturing the AMBITION (X is the foundation for Y, Z).
+
+Required *if the section is present*:
+- **What does the foundation enable next?** One or more possible future directions.
+- **Framed as possibilities, not the plan.** These are directions the work COULD take, explicitly ONE
+  among OTHERS — not a committed goal, not a description of what exists. (Motivating case: a fleet
+  *reporting* tool is the foundation that could later grow into an admin *control plane* — but it
+  could equally go other ways: a benchmarking service, a cost-optimization advisor, a compliance
+  export.) This is also the honest home for an ambition the NAME must not overclaim (see the
+  name-vs-purpose check in `SKILL.md`).
+
+**Visual when there are multiple directions: a "fork in the road".** When the vision names more than
+one possible path, show that the options DIVERGE with a branching diagram — a `flowchart` where the
+current foundation node fans out to N future-direction nodes (see `author-mermaid` for the "fork in
+the road" recipe). One direction needs no fork; two or more do. Propose it; `author-mermaid` /
+`upgrade-post` own the insertion.
+
 ## Recurring failure modes (from audits)
 
 - **The silent "who" drop in the opener.** The most common opener miss: it answers *why this

--- a/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
+++ b/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
@@ -9,12 +9,38 @@
 > in `STYLE-GUIDE.md`). `author-blog-post` / `author-post` read this when drafting a NEW design post,
 > so a post is born answering the right questions.
 >
-> **The spine (applies everywhere).** The author starts from **why it matters → its value → what it
-> enables → who benefits → what they'd do with it**, then mechanism. If a section reaches for
-> mechanism before establishing why the reader should care, that ordering is itself a finding.
+> **The spine (applies everywhere).** The author starts from **users and use cases → why it matters →
+> its value → what it enables → who benefits → what they'd do with it**, then mechanism. A design post
+> opens on the PEOPLE and what they will DO, not on the system. If a section reaches for mechanism or
+> CX before establishing who it is for and how they will use it, that ordering is itself a finding.
 
 Each section lists **required** questions (a missing answer = finding) and **optional** ones (nice to
 have, not gated). Not every post has every section; match by intent, not by heading text.
+
+## Users & use cases (the FIRST section — before Scope, before any CX/mechanism)
+
+**REQUIRED, and it must come first.** Every design post opens by establishing the people and what they
+will do, before the Scope note and before any architecture or CX. A post that opens on the system
+(a Scope note or Executive Summary first) is a ranked ordering finding: the reader should meet the
+users and the use cases before the machine. The five questions this section must answer:
+
+Required:
+- **Who are we building for?** Name the users / personas (roles, not "an org").
+- **What problem do they have?** The concrete pain, in their terms.
+- **What will we build to fix it?** The system, in one plain sentence (not its internals).
+- **How will they use it?** The core use cases: what each user actually does with it.
+- **How will it make their life better?** The outcome / value each user gets.
+
+**Required visual: a use-case diagram.** These questions are answered with a picture, not only prose.
+The default is the repo's `<UseCaseDiagram>` component (actors outside a system boundary, use cases as
+ovals, each with a click-to-focus `detail`) — it maps one-to-one onto who (actors) + how-they-use-it
+(use cases). A persona table or a small journey diagram can also satisfy the visual, but a use-case
+diagram is the canonical fit. Propose it here; hand the actual insertion to `upgrade-post`. A missing
+visual in this section is a finding.
+
+> Auditor note: this section subsumes and precedes the "Opener / hook" below. The opener's
+> why/value/who questions are still required, but they now live DOWNSTREAM of users-and-use-cases —
+> the post answers "who and what they do" first, then "why it matters" as the hook.
 
 ## Opener / hook (the first paragraphs, before `<!-- truncate -->`)
 

--- a/.claude/skills/refine-design-post/SKILL.md
+++ b/.claude/skills/refine-design-post/SKILL.md
@@ -43,6 +43,19 @@ The rewrite keeps the LESSON and strips the INSTANCE: "at $EMPLOYER we ran 40k R
 Foobar service" → "a high-throughput service under sustained load". If a passage has no
 generalizable lesson once the specifics are gone, that is itself a finding (cut it).
 
+**Name vs purpose — does the title describe what the tech actually DOES?** A separate accuracy check
+(same axis because both are "does the post misrepresent itself"): read the title and the system name,
+then read what the design actually builds, and ask *do they match?* A name that OVERCLAIMS or
+mislabels is a ranked finding — it sets a false expectation the body then contradicts. The motivating
+case: a system named "**A Control Plane for a Claude Code Fleet**" implies an ADMIN control plane (you
+push commands, you administer the fleet), but the design actually builds a **reporting / observability
+mechanism** (it consolidates usage metrics across sessions; it does not administer anything). The fix
+is a name that matches the built purpose (e.g. a "fleet reporting / observability" framing), and the
+control-plane ambition moves to an optional North Star section (see `SECTION-QUESTIONS.md`) as a
+possible FUTURE direction, not a description of what exists. Distinct from `name-post` (title VOICE —
+does an idea read as a question, an initiative as done): this is title ACCURACY — does the name tell
+the truth about the purpose. Propose the corrected name; the author decides.
+
 ### 2. Minimalism / question-set coverage — does each section answer its core questions?
 
 The author is a minimalist who leads with *users and use cases → why this matters → its value → what
@@ -96,9 +109,18 @@ Flag prose that describes a **process or structure** that a reader would grasp f
   the "one progress model, two drivers" section).
 - Prose that just re-explains a table already on the page → cut the prose, keep the table (real: the
   "Why three" paragraph in `premium-content-gating.mdx`).
+- The **users + use cases** opening → a **`<UseCaseDiagram>`** (required, per axis 2).
+- **Multiple future directions** in a North Star / vision section → a **"fork in the road"** diagram:
+  a `flowchart` where the current foundation fans out to N divergent future-direction nodes, so the
+  reader sees the options DIVERGE rather than reading them as a list. Two or more directions warrant
+  the fork; one does not. See the "fork in the road" recipe in `author-mermaid`.
+- A **long vertical stack of CX mockups** ("what it looks like") → wrap in **`<Tabs>`/`<TabItem>`**,
+  one tab per self-contained surface, so the reader PICKS a surface instead of scrolling past every
+  one. A mockups sidecar with N (~3+) stacked `<Mockup>`/`<Walkthrough>` blocks is a wall of visuals
+  (the visual analogue of axis-5 bombardment). One or two mocks can stay stacked; a big stack tabs.
 
-Note the candidate and hand the actual insertion to `upgrade-post` (owns the mermaid/table/component
-snippets). Do not add the diagram in this skill; propose it.
+Note the candidate and hand the actual insertion to `upgrade-post` / `author-mermaid` (which own the
+mermaid/table/component snippets). Do not add the diagram in this skill; propose it.
 
 ### 5. Reader's first read — can a newcomer actually follow this?
 

--- a/.claude/skills/refine-design-post/SKILL.md
+++ b/.claude/skills/refine-design-post/SKILL.md
@@ -45,20 +45,28 @@ generalizable lesson once the specifics are gone, that is itself a finding (cut 
 
 ### 2. Minimalism / question-set coverage — does each section answer its core questions?
 
-The author is a minimalist who leads with *why this matters → its value → what it enables → who
-benefits → what they'd do with it*. Auditing for "my style" **means** checking a section answers
-its core questions. Run every section against `SECTION-QUESTIONS.md` and emit an explicit
-**coverage verdict** — a small table per section over its required questions:
+The author is a minimalist who leads with *users and use cases → why this matters → its value → what
+it enables → who benefits → what they'd do with it*. Auditing for "my style" **means** checking a
+section answers its core questions. Run every section against `SECTION-QUESTIONS.md` and emit an
+explicit **coverage verdict** — a small table per section over its required questions:
 
 | Section | Required question | Answered? |
 |---|---|---|
+| Users & use cases (FIRST) | Who are we building for? | ✓ |
+| Users & use cases (FIRST) | How will they use it (use cases)? | ✗ missing |
+| Users & use cases (FIRST) | Use-case diagram present? | ✗ missing |
 | Opener | Why does this matter? | ✓ |
-| Opener | Who benefits + what would they do with it? | ✗ missing |
+
+**The one hard structural rule: a design post MUST open with users & use cases before Scope/CX.** The
+first section answers who / what problem / what we build / how they use it / how it improves their
+life, and carries a **use-case visual** (default `<UseCaseDiagram>`). A post that opens on the system
+(a Scope note or Executive Summary first, with no users/use-cases section ahead of it) is a ranked
+**ordering finding**, and a missing use-case visual in that section is its own finding.
 
 A **missing** required answer is a ranked finding of its own (the section is thin — add the answer).
 A section that answers its questions **and then keeps going** is padded (the surplus is a clarity
-finding for axis 3). Start-with-why: if a section explains mechanism before it establishes why the
-reader should care, flag the ordering.
+finding for axis 3). Start-with-users: if a section explains mechanism or CX before it establishes who
+the post is for and how they use it, flag the ordering.
 
 ### 3. Clarity / wordiness — the concrete tells
 

--- a/.claude/skills/refine-design-post/STYLE-GUIDE.md
+++ b/.claude/skills/refine-design-post/STYLE-GUIDE.md
@@ -27,6 +27,11 @@
 
 ## Rules to APPLY (trim toward these)
 
+- **Name the tech for what it DOES, not what it aspires to.** The title + system name must match the
+  built purpose. A name that overclaims sets a false expectation the body contradicts. *(Real:
+  "A Control Plane for a Claude Code Fleet" implies an admin control plane, but the design builds a
+  reporting/observability tool — the control-plane idea belongs in an optional North Star section as a
+  future direction, not the name.)* Accuracy-to-purpose; distinct from `name-post` (title voice).
 - **State a thing once.** Kill the Scope-note → bullets → table → "restated" repetition of the same
   invariant. State it once, reference it after. *(Real: `fleetplane.mdx` states its invariants 3×.)*
 - **Never render the same structure twice.** A mermaid diagram AND an ASCII/prose redraw of the same
@@ -42,6 +47,10 @@
 - **Prefer a table/diagram for parallel structure.** Parallel arms/options/mappings, or an
   input→transform→output flow, read faster as a table or a mermaid flow than as paragraphs. (Propose
   it; `upgrade-post` inserts it.)
+- **Tab a long mockups / "what it looks like" stack.** When the CX section stacks several
+  self-contained mockups vertically, wrap them in `<Tabs>`/`<TabItem>` (one tab per surface) so the
+  reader picks a screen instead of scrolling past all of them. A big vertical mock stack is the visual
+  analogue of a wall of text. *(Real: fleetplane's 4 browser mocks + a walkthrough, 176-line sidecar.)*
 - **No em-dash in the rendered body.** Repo-wide reader-voice rule — a literal `—` reads as AI voice
   and the `em-dash-voice-hook.sh` BLOCKS it. Use a period, a colon, or a parenthesis. (This rule is
   about the POST body, not this guide file.)

--- a/.claude/skills/refine-design-post/STYLE-GUIDE.md
+++ b/.claude/skills/refine-design-post/STYLE-GUIDE.md
@@ -11,9 +11,15 @@
 
 ## Guiding themes
 
-- **Minimalism — get to the core value.** Lead with *why it matters, its value, what it enables, who
-  benefits, what they'd do with it*, then mechanism. Cut anything that doesn't advance a core
-  question (see `SECTION-QUESTIONS.md`). Less, but load-bearing.
+- **Lead with users and use cases — before Scope, before CX, before the system.** A design post opens
+  on the PEOPLE and what they will DO: who are we building for, what problem do they have, what will we
+  build to fix it, how will they use it, how does it make their life better. Only then the mechanism.
+  This opening carries a **use-case diagram** (the repo's `<UseCaseDiagram>`), not just prose. Opening
+  on a Scope note or an Executive Summary (the system first) is the ordering mistake this rule exists
+  to catch. See the "Users & use cases" section in `SECTION-QUESTIONS.md`.
+- **Minimalism — get to the core value.** After users/use-cases, lead with *why it matters, its value,
+  what it enables, who benefits, what they'd do with it*, then mechanism. Cut anything that doesn't
+  advance a core question (see `SECTION-QUESTIONS.md`). Less, but load-bearing.
 - **Generality over specifics.** Prefer the reusable PATTERN to the private instance. Strip
   employer/proprietary/internal names, real internal numbers, and one-off internal process. Keep the
   lesson, drop the instance. This is the guiding theme of the whole `/designs` blog: the value is in


### PR DESCRIPTION
## Why

A batch of structural + accuracy rules for the `refine-design-post` skill, all surfaced while auditing `fleetplane`. They make design posts open on the reader and stay honest about what the tech is.

## What changed (skill contract)

**1. Users & use cases FIRST (required).** Every design post must open on the PEOPLE and what they'll DO — who / what problem / what we build / how they use it / how it improves their life — before the Scope note, carried by a **`<UseCaseDiagram>`**. Opening on the system is a ranked ordering finding. (`SECTION-QUESTIONS.md` new required first section, `SKILL.md` axis 2, `STYLE-GUIDE.md` guiding theme, `author-post/homes/design.md` body-shape.)

**2. Name vs purpose (axis 1).** Does the title/system-name describe what the tech actually DOES, or overclaim? A mislabeled name sets a false expectation the body contradicts. Motivating case: "A Control Plane for a Claude Code Fleet" implies an admin control plane, but the design builds a **reporting/observability** tool. Distinct from `name-post` (voice) — this is accuracy-to-purpose.

**3. North Star / vision (optional closing section).** Name where the foundation could go NEXT, framed as one direction among others, NOT the committed goal — the honest home for an ambition the name must not overclaim.

**4. Fork in the road (visual).** When the North Star names 2+ directions, show they DIVERGE with a branching flowchart (foundation fans out to N future paths), not a list. Wired across `SECTION-QUESTIONS`, `SKILL.md` axis 4, `author-post/homes/design.md`, and a new **verified recipe + table row in `author-mermaid`**.

**5. Tabify a big mockups stack (axis 4 / reader-first).** A long vertical stack of self-contained CX mockups is a wall of visuals; wrap in `<Tabs>`/`<TabItem>`, one tab per surface. (fleetplane: 4 browser mocks + a walkthrough, 176-line sidecar.)

## Notes

- `<UseCaseDiagram>` and `<Tabs>` both already exist + are registered; the fork-in-the-road recipe uses only standard `flowchart LR` primitives (same as the verified use-case recipe).
- **Applying all of these to `fleetplane` is a separate pass (task #19)** — this PR is the rule-encoding only.
- Markdown fences balanced; no reader-facing content touched (skill files are em-dash-exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)