### PR TITLE
refine(claude-abacus): reframe Fleetplane as an agent-metrics reporting tool

### DIFF
--- a/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
@@ -75,11 +75,11 @@ You rolled Claude Code out across a team, and you cannot measure what it is doin
 
 ```mermaid
 graph LR
-    subgraph config["CONFIG PLANE &#8212; push"]
+    subgraph config["CONFIG PLANE: push"]
         C1[versioned config]
         C2[marketplace + MDM]
     end
-    subgraph data["DATA PLANE &#8212; pull and analyze"]
+    subgraph data["DATA PLANE: pull and analyze"]
         D1[sanitize on-device]
         D2[warehouse]
         D3[dashboards, bugs, deck]
@@ -124,7 +124,7 @@ Two planes, cleanly separated. The **config plane** pushes standardized configur
 ```mermaid
 %% animate: flow
 graph LR
-    subgraph config["CONFIG PLANE &#8212; push"]
+    subgraph config["CONFIG PLANE: push"]
         REPO[claude-abacus monorepo<br/>git]
         MKT[Plugin Marketplace]
         CORE[org-core plugin<br/>skills, agents, hooks, MCP]
@@ -142,7 +142,7 @@ graph LR
         CC --> SYNC --> SAN --> CLEAN
     end
 
-    subgraph cloud["DATA PLANE &#8212; pull and analyze"]
+    subgraph cloud["DATA PLANE: pull and analyze"]
         S3[(S3 clean transcripts<br/>SSE-KMS, versioned)]
         ETL[SQS to Lambda ETL]
         PG[(Postgres<br/>facts plus marts)]

--- a/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
@@ -125,7 +125,7 @@ Two planes, cleanly separated. The **config plane** pushes standardized configur
 %% animate: flow
 graph LR
     subgraph config["CONFIG PLANE &#8212; push"]
-        REPO[claude-fleet monorepo<br/>git]
+        REPO[claude-abacus monorepo<br/>git]
         MKT[Plugin Marketplace]
         CORE[org-core plugin<br/>skills, agents, hooks, MCP]
         MGD[managed-settings.json<br/>via MDM]
@@ -167,10 +167,10 @@ graph LR
 
 Two repos, kept separate on purpose: they have different release cadences and different blast radii. A bad config push and a bad cloud deploy should never be the same commit.
 
-### `claude-fleet` (config plus on-device agent)
+### `claude-abacus` (config plus on-device agent)
 
 ```
-claude-fleet/
+claude-abacus/
 ├── .claude-plugin/
 │   └── marketplace.json                 # marketplace manifest
 ├── plugins/
@@ -179,8 +179,8 @@ claude-fleet/
 │       ├── skills/
 │       │   ├── code-review/SKILL.md
 │       │   ├── release-notes/SKILL.md
-│       │   ├── fleet-setup/SKILL.md      # onboarding walkthrough
-│       │   └── fleet-doctor/SKILL.md     # diagnose broken installs
+│       │   ├── abacus-setup/SKILL.md      # onboarding walkthrough
+│       │   └── abacus-doctor/SKILL.md     # diagnose broken installs
 │       ├── agents/
 │       │   ├── bug-hunter.md
 │       │   └── security-scan.md
@@ -209,10 +209,10 @@ claude-fleet/
     └── test-sanitizer.yml               # BLOCKS merge on any secret escape
 ```
 
-### `fleetplane` (cloud: infra plus ETL plus web app)
+### `abacus` (cloud: infra plus ETL plus web app)
 
 ```
-fleetplane/
+abacus/
 ├── infra/                               # Terraform or CDK
 │   ├── storage.tf                       # S3, KMS, lifecycle
 │   ├── ingest.tf                        # SQS, Lambda, DLQ
@@ -245,7 +245,7 @@ fleetplane/
 
 **Goal:** every laptop runs identical, versioned config, and live token and cost dashboards exist. Ship this before any collection.
 
-- **Task 1.1: Marketplace plus org-core skeleton.** Create the `claude-fleet` repo, `marketplace.json`, and the `org-core` plugin with `plugin.json`; add two starter skills (`code-review`, `release-notes`) and the `bug-hunter` agent. **Acceptance:** on a clean machine, adding the marketplace then installing `org-core` makes the skills and agent available.
+- **Task 1.1: Marketplace plus org-core skeleton.** Create the `claude-abacus` repo, `marketplace.json`, and the `org-core` plugin with `plugin.json`; add two starter skills (`code-review`, `release-notes`) and the `bug-hunter` agent. **Acceptance:** on a clean machine, adding the marketplace then installing `org-core` makes the skills and agent available.
 - **Task 1.2: Managed settings.** Author `managed/managed-settings.json` with `extraKnownMarketplaces`, `enabledPlugins`, a `strictKnownMarketplaces` allowlist, telemetry `env` vars (`CLAUDE_CODE_ENABLE_TELEMETRY`, the OTLP exporter and endpoint), `permissions.deny` (for example `Read(**/.env)` and `Bash(sudo:*)`), and a cleanup period. Document the MDM paths for macOS, Linux, and Windows. **Acceptance:** with the file in place, user or project settings cannot disable org-core or the telemetry env vars.
 - **Task 1.3: CI for plugins.** `validate-plugins.yml` lints every manifest and verifies skill and agent frontmatter. **Acceptance:** a malformed manifest fails the PR check.
 - **Task 1.4: Live telemetry dashboards.** Stand up Grafana OSS plus an ADOT collector on Fargate receiving OTLP from laptops into CloudWatch, with panels for active engineers per day, sessions, tokens by model, and estimated spend. **Acceptance:** a session on an enrolled laptop shows up in Grafana within minutes. **This is the Phase 1 win: value before the transcript pipeline exists.**
@@ -288,7 +288,7 @@ A user LaunchAgent (not a root LaunchDaemon) watches `~/.claude/projects` with a
 
 ### Task 2.4: Distribution (brew, setup skill, self-heal)
 
-A Homebrew formula installs the binary and registers the service via `brew services` (with a scoop or winget path for Windows). The `fleet-setup` skill runs the install, verifies the service is loaded, fires a **synthetic-secret test session**, and confirms the redacted file landed in S3. The `fleet-doctor` skill diagnoses service-dead, token-expired, and upload-lag. A SessionStart self-heal hook verifies the service is loaded, the version is at or above the minimum, and the last upload was recent, then repairs or nags. **Acceptance:** a new engineer runs `/fleet-setup` and ends with a verified, uploading agent without touching a terminal manually.
+A Homebrew formula installs the binary and registers the service via `brew services` (with a scoop or winget path for Windows). The `abacus-setup` skill runs the install, verifies the service is loaded, fires a **synthetic-secret test session**, and confirms the redacted file landed in S3. The `abacus-doctor` skill diagnoses service-dead, token-expired, and upload-lag. A SessionStart self-heal hook verifies the service is loaded, the version is at or above the minimum, and the last upload was recent, then repairs or nags. **Acceptance:** a new engineer runs `/abacus-setup` and ends with a verified, uploading agent without touching a terminal manually.
 
 ### Task 2.5: Consent plus governance artifacts
 
@@ -405,7 +405,7 @@ Every row in the "others' transcripts" column writes an audit-log entry (who vie
 - **Task 4.1: API plus security model.** FastAPI (or Next API routes) with a DB role that is **read-only on marts**. Auth is OIDC via the IdP with httpOnly, SameSite session cookies. RBAC is enforced **in the API, not the UI** (`engineer`, `lead`, `exec`, `admin`). Transcript bodies are never proxied: the API issues short-lived presigned S3 GET URLs and **logs every access** (who viewed whose session). Hardening covers strict CSP, no third-party scripts, parameterized queries, rate limits, and dependency scanning; the network is reachable only via Tailscale with no public DNS. **Acceptance:** an `engineer`-role token cannot fetch another engineer's session, and every transcript fetch writes an audit-log row.
 - **Task 4.2: Transcript viewer.** A session list with filters (engineer, repo, agent), a rendered event stream plus a raw JSONL toggle, redactions visible as badges, and `log_issue` calls shown inline. **Acceptance:** viewing a session shows redaction badges, and raw access is a logged presigned download.
 - **Task 4.3: Plugin hub.** A marketplace landing showing org-core contents, current version, adoption percentage (from `skill_uses` by version), changelog, and a one-copy install command. **Acceptance:** adoption bars reflect real warehouse data and the copy button yields a working install command.
-- **Task 4.4: Dashboard.** KPI tiles (sessions, tokens, spend, bugs logged, active engineers, cost-per-confirmed-bug), a tokens-per-day trend, bugs by severity, an agent leaderboard with precision, skill adoption, and a fleet-health panel (plugin and sanitizer version spread, upload lag, and a sessions-missing-transcripts leak detector). Team-level by default; per-engineer drilldown is role-gated and audited. **Acceptance:** every panel reads a mart (not a fact table) and renders in under one second.
+- **Task 4.4: Dashboard.** KPI tiles (sessions, tokens, spend, bugs logged, active engineers, cost-per-confirmed-bug), a tokens-per-day trend, bugs by severity, an agent leaderboard with precision, skill adoption, and a session-health panel (plugin and sanitizer version spread, upload lag, and a sessions-missing-transcripts leak detector). Team-level by default; per-engineer drilldown is role-gated and audited. **Acceptance:** every panel reads a mart (not a fact table) and renders in under one second.
 - **Task 4.5: Deck studio.** A date-range picker drives a live 16:9 slide preview from `mart_deck_kpis` (sites analyzed, bugs by severity, tokens, cost, bug funnel, adoption); slide notes are drafted via the Claude API from the same numbers and frozen at generation time; a human approves before export to PPTX or PDF. **Acceptance:** regenerating for a new range updates all numbers, export produces a valid PPTX, and nothing exports without approval.
 
 ---
@@ -463,7 +463,7 @@ The single most important discipline in this design is **not** building ahead of
 |---|---|
 | ETL Lambda nears its 15-minute timeout, or analyst queries slow the app | Facts to a Parquet lake (S3 plus Glue plus Athena, dbt on Fargate); Postgres becomes marts only |
 | A second team wants different plugins or policy | Per-team plugins plus managed-settings drop-in fragments |
-| A plugin release breaks more than 10 laptops | Canary rings (`org-core@next` to 5 percent for 48h, then fleet) plus a fleet-version SLO |
+| A plugin release breaks more than 10 laptops | Canary rings (`org-core@next` to 5 percent for 48h, then everyone) plus a config-version SLO |
 | The 9am sync herd throttles the upload API, or a second region onboards | Streaming ingest (Kinesis or Firehose) plus regional endpoints |
 | Any external compliance requirement touches transcripts | Server-side DLP (Macie) as a second scrub, legal hold, SIEM export |
 | Finance asks what team X spends | Chargeback marts plus cost-allocation tagging |
@@ -495,7 +495,7 @@ Each phase is independently shippable; ship them in order.
 
 - [ ] **Phase 0:** write the consent doc plus the "what we collect" page; lock the six invariants.
 - [ ] **Phase 1:** marketplace plus org-core plus managed-settings plus plugin CI plus live OTel dashboards.
-- [ ] **Phase 2:** the CI-gated sanitizer plus the mirror/sync agent plus launchd/systemd plus brew plus fleet-setup and fleet-doctor plus the self-heal hook; pilot on two or three laptops.
+- [ ] **Phase 2:** the CI-gated sanitizer plus the mirror/sync agent plus launchd/systemd plus brew plus abacus-setup and abacus-doctor plus the self-heal hook; pilot on two or three laptops.
 - [ ] **Phase 3:** S3/SQS/Lambda ingest plus the presigned upload API plus the star schema plus marts plus the issue-logger MCP plus reconciliation.
 - [ ] **Phase 4:** the API (RBAC plus audited presign) plus the transcript viewer plus the plugin hub plus the dashboard plus the deck studio.
 - [ ] **Ongoing:** IaC everything; add scale components only when a trigger fires.

--- a/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
@@ -1,12 +1,12 @@
 ---
-slug: design-fleetplane
-sidebar_label: Fleetplane
+slug: design-claude-abacus
+sidebar_label: Claude Abacus
 sidebar_position: 19
-title: 'Fleetplane: A Control Plane for a Claude Code Fleet'
+title: 'Claude Abacus: Measuring the Value Claude Adds Across Distributed Sessions'
 description: >-
-  A build-ready plan to standardize Claude Code across an engineering fleet and
-  turn on-device-sanitized session transcripts into metrics, dashboards, and a
-  bug pipeline.
+  A build-ready plan to consolidate agent-usage metrics across Distributed
+  Claude Code Sessions: tool invocations, agents run, insights generated, and
+  bugs found, from on-device-sanitized transcripts into dashboards and a deck.
 authors:
   - oeid
 tags:
@@ -17,18 +17,52 @@ tags:
   - observability
 kind: backend-design
 draft: true
-mockups: ./_mockups/fleetplane.mdx
+mockups: ./_mockups/claude-abacus.mdx
 ---
 
-# Fleetplane: A Control Plane for a Claude Code Fleet
+# Claude Abacus: Measuring the Value Claude Adds Across Distributed Sessions
+
+## Who it's for and what they do with it
+
+**Who.** Three people care about how Claude Code is actually being used across a team. A **platform / developer-experience lead** owns the rollout and has to show it is working. An **engineer** runs Claude Code all day and wants their own usage and the bugs it caught visible, without their raw transcripts (and the secrets in them) leaving their laptop. **Engineering leadership** funds the tool and keeps asking what it returns.
+
+**The problem they share.** The richest signal about the value Claude adds, the session transcripts, is trapped on individual laptops next to raw secrets, so no one can measure it. Tool invocations, agents run, insights generated, bugs found, spend: all invisible in aggregate.
+
+**What we build to fix it.** A reporting mechanism that sanitizes each transcript on-device, uploads only the clean metrics, and turns them into dashboards, a bug pipeline, and a deck. What each person then does with it:
+
+<UseCaseDiagram
+  title="Claude Abacus"
+  actors={[
+    {id: 'lead', label: 'Platform lead', kind: 'internal'},
+    {id: 'eng', label: 'Engineer', kind: 'internal'},
+    {id: 'exec', label: 'Eng leadership', kind: 'internal'},
+  ]}
+  useCases={[
+    {id: 'adopt', label: 'Track adoption', detail: 'See who is using Claude Code and how much, across all sessions.'},
+    {id: 'value', label: 'See value delivered', detail: 'Tool invocations, agents run, insights, and bugs found, per team.'},
+    {id: 'own', label: 'See my own usage', detail: 'An engineer sees their sessions and the bugs their agents caught, raw transcripts never leaving the laptop.'},
+    {id: 'bugs', label: 'Review found bugs', detail: 'Agent-filed issues land in a deduped pipeline for a human to confirm.'},
+    {id: 'roi', label: 'Prove ROI', detail: 'Spend against bugs found and work done, ready for a leadership deck.'},
+  ]}
+  links={[
+    {from: 'lead', to: 'adopt'},
+    {from: 'lead', to: 'value'},
+    {from: 'eng', to: 'own'},
+    {from: 'eng', to: 'bugs'},
+    {from: 'exec', to: 'value'},
+    {from: 'exec', to: 'roi'},
+  ]}
+/>
+
+**How it makes their life better.** The lead can prove the rollout is landing, the engineer gets credit for the work their agents do without exposing a single secret, and leadership sees spend against value in numbers they trust.
 
 :::note[Scope]
-This design defines **Fleetplane**: a system that (1) centralizes and standardizes Claude Code configuration across an engineering fleet, (2) collects and sanitizes session transcripts **on-device**, and (3) turns them into metrics, dashboards, an issue pipeline, and an investor-ready deck. It is written as a **phased, independently shippable** build: each phase stands on its own, and Stage 1 (1 to 100 engineers) is a strict subset of every later stage, so nothing built early is thrown away when you scale.
+**Claude Abacus** is a reporting mechanism that consolidates agent-usage metrics across **Distributed Claude Code Sessions (DCCS)**: how many tool invocations run, which agents get used, what insights and bugs they surface, and what it all costs. It (1) collects and sanitizes session transcripts **on-device**, (2) turns them into metrics, dashboards, an issue pipeline, and a deck, and (3) ships a small standardized config so every environment reports the same signal. It is written as a **phased, independently shippable** build: each phase stands on its own, and Stage 1 (1 to 100 engineers) is a strict subset of every later stage, so nothing built early is thrown away when you scale.
 :::
 
 <!-- truncate -->
 
-import Mockups from './_mockups/fleetplane.mdx';
+import Mockups from './_mockups/claude-abacus.mdx';
 
 <Mockups />
 
@@ -36,7 +70,7 @@ import Mockups from './_mockups/fleetplane.mdx';
 
 ## Executive Summary
 
-You rolled Claude Code out to a growing engineering fleet, and three things are quietly breaking. Every laptop's config has drifted, so no two engineers run the same skills, agents, hooks, or permissions. The richest signal about how the fleet actually works, the session transcripts, is trapped on those laptops, next to raw secrets that must never leave the device. And leadership keeps asking for numbers you can't give: tokens, spend, bugs found, adoption. There is no control plane.
+You rolled Claude Code out across a team, and you cannot measure what it is doing. The richest signal about the value it adds, the session transcripts, is trapped on individual laptops next to raw secrets that must never leave the device. So tool invocations, agents run, insights generated, bugs found, and spend are all invisible in aggregate. And leadership keeps asking for numbers you can't give. There is no way to report on Distributed Claude Code Sessions.
 
 **The solution** splits into two planes that never blur, and the whole design follows from that split:
 
@@ -61,7 +95,7 @@ Four decisions anchor the design (spelled out in [Key Decisions](#key-decisions)
 
 **Expected value.** Live token and cost dashboards exist after Phase 1, before any transcript pipeline is built. That is the point: value lands before collection. Everything after is layered on a foundation whose only expensive-to-get-wrong pieces (the sanitizer, the schema, the consent model) are over-built early and the rest is kept deliberately small.
 
-**Status and what is open.** The architecture, the invariants, and the star schema are settled. The open items are cultural more than technical: shipping the consent doc and the "what we collect" page before fleet-wide upload, and running the pilot gate on two or three volunteer laptops with a manual raw-versus-clean diff before rollout.
+**Status and what is open.** The architecture, the invariants, and the star schema are settled. The open items are cultural more than technical: shipping the consent doc and the "what we collect" page before org-wide upload, and running the pilot gate on two or three volunteer laptops with a manual raw-versus-clean diff before rollout.
 
 ---
 
@@ -75,7 +109,7 @@ These rules do not bend as headcount grows. If a change would violate one, that 
 | 2 | **Transcripts are append-only.** | Sync is incremental by byte offset. On truncation or inode change, re-sanitize from zero. |
 | 3 | **The frontend reads marts only.** | The web app never queries fact tables, only pre-aggregated serving tables. |
 | 4 | **Everything is IaC.** | The entire cloud stack is reproducible in a fresh AWS account in under an hour. |
-| 5 | **Consent before collection.** | Ship the consent doc and the "what we collect" page before enabling fleet-wide upload. |
+| 5 | **Consent before collection.** | Ship the consent doc and the "what we collect" page before enabling org-wide upload. |
 | 6 | **The sanitizer is production code.** | It has its own test suite in CI and a version stamped on every uploaded file. |
 
 Rules 1 to 4 are technical. Rules 5 and 6 are cultural, and equally binding. The trap this whole design guards against is building Stage 3 infrastructure at Stage 1 headcount. Over-build only those three, the sanitizer, the schema, and the consent model; keep everything else deliberately small.
@@ -113,7 +147,7 @@ graph LR
         S3[(S3 clean transcripts<br/>SSE-KMS, versioned)]
         ETL[SQS to Lambda ETL]
         PG[(Postgres<br/>facts plus marts)]
-        APP[Fleetplane web app<br/>Fargate, Tailscale-only]
+        APP[Claude Abacus web app<br/>Fargate, Tailscale-only]
         GRAF[Grafana OSS<br/>live OTel metrics]
     end
 
@@ -259,10 +293,10 @@ A Homebrew formula installs the binary and registers the service via `brew servi
 
 ### Task 2.5: Consent plus governance artifacts
 
-Publish the exact field list collected, the consent doc, and the default team-level (not individual) dashboard scope. **Acceptance:** these exist and are linked from the plugin hub before fleet-wide upload is enabled.
+Publish the exact field list collected, the consent doc, and the default team-level (not individual) dashboard scope. **Acceptance:** these exist and are linked from the plugin hub before org-wide upload is enabled.
 
 :::warning[Pilot gate]
-Enable on two or three volunteer laptops first. Manually diff sanitized output against the raw transcript before any fleet rollout. The sanitizer is the one component whose failure is unrecoverable, a leaked secret cannot be un-uploaded, so it earns a human diff before it earns trust.
+Enable on two or three volunteer laptops first. Manually diff sanitized output against the raw transcript before any org-wide rollout. The sanitizer is the one component whose failure is unrecoverable, a leaked secret cannot be un-uploaded, so it earns a human diff before it earns trust.
 :::
 
 ---
@@ -356,7 +390,7 @@ One tool, `log_issue(title, severity, category, target, evidence, suggested_fix)
 
 ---
 
-## Phase 4: App Plane (Fleetplane) (weeks 4 to 5)
+## Phase 4: App Plane (Claude Abacus) (weeks 4 to 5)
 
 Four experiences behind one API and one login. Before the features, the question every engineer will ask: **who can see whose data?** The default is team-level aggregates; individual transcripts are role-gated and every access is logged.
 
@@ -388,7 +422,7 @@ sequenceDiagram
     participant S3 as S3 (clean)
     participant ETL as SQS to Lambda ETL
     participant PG as Postgres (facts plus marts)
-    participant APP as Fleetplane app
+    participant APP as Claude Abacus app
 
     CC->>SYNC: append transcript line (raw, may hold secrets)
     Note over SYNC: sanitize at edge<br/>scrub, allowlist, hash, stamp version
@@ -437,7 +471,7 @@ The single most important discipline in this design is **not** building ahead of
 
 **Stage 2 (100 to 1000) introduces SLOs:** upload lag p95 under 15 minutes, dashboard freshness under one hour, and a sanitizer escape rate of zero, verified by scheduled synthetic-secret canary sessions.
 
-**Stage 3 (1000+)** adds a plugin certification pipeline (static analysis plus sanitizer regression plus permission diff before listing), streaming ingest by default, server-side DLP as defense-in-depth, a lakehouse (Iceberg) with Redshift Serverless or Snowflake plus data contracts and lineage, and multi-tenant Fleetplane with policy-engine authz (Cedar or OPA) and SIEM export.
+**Stage 3 (1000+)** adds a plugin certification pipeline (static analysis plus sanitizer regression plus permission diff before listing), streaming ingest by default, server-side DLP as defense-in-depth, a lakehouse (Iceberg) with Redshift Serverless or Snowflake plus data contracts and lineage, and multi-tenant Claude Abacus with policy-engine authz (Cedar or OPA) and SIEM export.
 
 **The trap, restated:** do not build Stage 3 at Stage 1 headcount. Over-engineer only the sanitizer, the schema, and the consent model early. They are the only things expensive to get wrong later.
 
@@ -468,3 +502,20 @@ Each phase is independently shippable; ship them in order.
 - [ ] **Ongoing:** IaC everything; add scale components only when a trigger fires.
 
 The very first things worth handing to a coding agent, in order: scaffold both repos; implement `sanitizer.py` and its tests **first** (it is the critical path and its tests gate everything); build `org-core` and `managed-settings.json` so a laptop can enroll; then the mirror/sync agent and its triggers; then cloud ingest so uploads have somewhere to land. Everything else layers on those five.
+
+---
+
+## North Star: what the foundation could become
+
+Claude Abacus is a reporting mechanism, and that is deliberately all it is today. But a sanitized, consented, warehoused stream of what every agent actually does is a foundation, and a foundation opens more than one door. These are directions the work **could** take, not a committed roadmap. One of them, or none, or something not drawn here.
+
+```mermaid
+flowchart LR
+  found([Today: agent-usage reporting])
+  found -->|"act on sessions, not just watch them"| a([Admin control plane])
+  found -->|"rank teams and prompts"| b([Benchmarking service])
+  found -->|"turn spend into advice"| c([Cost-optimization advisor])
+  found -->|"answer the auditor"| d([Compliance and audit export])
+```
+
+The tempting one is the **admin control plane**: once you can see every environment, pushing policy to it is a short step. It is also the one to resist first, because watching is consented and low-risk while administering is neither. The honest framing is that Abacus earns the right to any of these by first being trustworthy at the one thing it claims to do: measure, without ever leaking a secret.

--- a/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-04-claude-abacus.mdx
@@ -33,23 +33,22 @@ mockups: ./_mockups/claude-abacus.mdx
 <UseCaseDiagram
   title="Claude Abacus"
   actors={[
-    {id: 'lead', label: 'Platform lead', kind: 'internal'},
     {id: 'eng', label: 'Engineer', kind: 'internal'},
-    {id: 'exec', label: 'Eng leadership', kind: 'internal'},
+    {id: 'lead', label: 'Platform lead', kind: 'external'},
+    {id: 'exec', label: 'Eng leadership', kind: 'external'},
   ]}
   useCases={[
-    {id: 'adopt', label: 'Track adoption', detail: 'See who is using Claude Code and how much, across all sessions.'},
-    {id: 'value', label: 'See value delivered', detail: 'Tool invocations, agents run, insights, and bugs found, per team.'},
     {id: 'own', label: 'See my own usage', detail: 'An engineer sees their sessions and the bugs their agents caught, raw transcripts never leaving the laptop.'},
     {id: 'bugs', label: 'Review found bugs', detail: 'Agent-filed issues land in a deduped pipeline for a human to confirm.'},
+    {id: 'adopt', label: 'Track adoption', detail: 'See who is using Claude Code and how much, across all sessions.'},
+    {id: 'value', label: 'See value delivered', detail: 'Tool invocations, agents run, insights, and bugs found, per team.'},
     {id: 'roi', label: 'Prove ROI', detail: 'Spend against bugs found and work done, ready for a leadership deck.'},
   ]}
   links={[
-    {from: 'lead', to: 'adopt'},
-    {from: 'lead', to: 'value'},
     {from: 'eng', to: 'own'},
     {from: 'eng', to: 'bugs'},
-    {from: 'exec', to: 'value'},
+    {from: 'lead', to: 'adopt'},
+    {from: 'lead', to: 'value'},
     {from: 'exec', to: 'roi'},
   ]}
 />

--- a/bytesofpurpose-blog/designs/_mockups/claude-abacus.mdx
+++ b/bytesofpurpose-blog/designs/_mockups/claude-abacus.mdx
@@ -1,11 +1,13 @@
 ---
-# Mockup sidecar for design-fleetplane.
+# Mockup sidecar for design-claude-abacus.
 # Hand-authored UX mockups + one animated walkthrough for the four Phase 4 surfaces
 # (transcript viewer, plugin hub, dashboard, deck studio). The post links this file via its
 # frontmatter `mockups:` field and renders <Mockups /> after the truncate marker.
 ---
 
 import {Mockup, Walkthrough} from '@omars-lab/blog-ui';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 export default function Mockups() {
   const ff = 'var(--ifm-font-family-base)';
@@ -39,7 +41,7 @@ export default function Mockups() {
 
   // ---- The transcript-viewer scene, driven by the Walkthrough ----
   const viewerScene = (
-    <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/transcripts/s_9c2e" caption="Open a session: redactions are badges, the agent's log_issue call is inline, and raw access is a logged download.">
+    <Mockup chrome="browser" title="Claude Abacus" url="abacus.internal/transcripts/s_9c2e" caption="Open a session: redactions are badges, the agent's log_issue call is inline, and raw access is a logged download.">
       <div style={{fontFamily: ff, minHeight: '290px'}}>
         <div style={{display: 'flex', alignItems: 'center', gap: '0.6rem', padding: '0.55rem 0.85rem', borderBottom: hair, fontSize: '0.72rem'}}>
           <strong style={{fontSize: '0.8rem'}}>session s_9c2e</strong>
@@ -66,10 +68,14 @@ export default function Mockups() {
     <>
       <h2>What it looks like</h2>
 
-      <p>The four Phase 4 surfaces sit behind one login and one API. The transcript viewer is
-      the one worth watching in motion: it is where the sanitize-at-edge invariant becomes
-      something a reviewer can see. A session is sanitized on-device, uploaded clean, then
-      opened here, where every redaction is a typed badge and every raw download is audited.</p>
+      <p>The four Phase 4 surfaces sit behind one login and one API. Pick a surface below. The
+      transcript viewer is the one worth watching in motion: it is where the sanitize-at-edge
+      invariant becomes something a reviewer can see. A session is sanitized on-device, uploaded
+      clean, then opened here, where every redaction is a typed badge and every raw download is
+      audited.</p>
+
+      <Tabs>
+      <TabItem value="viewer" label="Transcript viewer" default>
 
       <Walkthrough
         steps={[
@@ -97,9 +103,10 @@ export default function Mockups() {
         {viewerScene}
       </Walkthrough>
 
-      <h2>Plugin hub</h2>
+      </TabItem>
+      <TabItem value="plugins" label="Plugin hub">
 
-      <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/plugins" caption="The marketplace landing: version, real adoption from skill_uses, and a one-copy install command.">
+      <Mockup chrome="browser" title="Claude Abacus" url="abacus.internal/plugins" caption="The marketplace landing: version, real adoption from skill_uses, and a one-copy install command.">
         <div style={{fontFamily: ff, padding: '0.9rem 1rem', minHeight: '240px'}}>
           <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem'}}>
             <div style={{fontWeight: 800, fontSize: '0.95rem'}}>org-core</div>
@@ -107,10 +114,10 @@ export default function Mockups() {
             <span style={{marginLeft: 'auto', fontSize: '0.72rem', color: 'var(--ifm-color-emphasis-700)'}}>skills, agents, hooks, MCP</span>
           </div>
           <div style={{fontFamily: mono, fontSize: '0.72rem', padding: '0.5rem 0.6rem', borderRadius: '8px', background: 'var(--ifm-color-emphasis-100)', marginBottom: '0.7rem', display: 'flex', alignItems: 'center'}}>
-            claude /plugin install org-core@org-fleet
+            claude /plugin install org-core@org
             <span style={{marginLeft: 'auto', padding: '0.1rem 0.5rem', borderRadius: '6px', background: 'var(--ifm-color-primary)', color: '#fff', fontSize: '0.66rem', fontWeight: 700}}>copy</span>
           </div>
-          <div style={{fontSize: '0.66rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.3rem'}}>Adoption across the fleet</div>
+          <div style={{fontSize: '0.66rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.3rem'}}>Adoption across sessions</div>
           {adopt('code-review', '92%')}
           {adopt('release-notes', '74%')}
           {adopt('fleet-setup', '68%')}
@@ -118,9 +125,10 @@ export default function Mockups() {
         </div>
       </Mockup>
 
-      <h2>Dashboard</h2>
+      </TabItem>
+      <TabItem value="dashboard" label="Dashboard">
 
-      <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/dashboard" caption="Every panel reads a mart, not a fact table, and renders in under a second. Team-level by default.">
+      <Mockup chrome="browser" title="Claude Abacus" url="abacus.internal/dashboard" caption="Every panel reads a mart, not a fact table, and renders in under a second. Team-level by default.">
         <div style={{fontFamily: ff, padding: '0.9rem 1rem', minHeight: '260px'}}>
           <div style={{display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '0.7rem'}}>
             {tile('Sessions', '3,412', 'last 30d')}
@@ -140,7 +148,7 @@ export default function Mockups() {
               </div>
             </div>
             <div style={{flex: '0 0 190px', border: hair, borderRadius: '9px', padding: '0.6rem 0.7rem'}}>
-              <div style={{fontSize: '0.66rem', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.35rem'}}>Fleet health</div>
+              <div style={{fontSize: '0.66rem', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.35rem'}}>DCCS health</div>
               <div style={{fontSize: '0.72rem', display: 'flex', flexDirection: 'column', gap: '0.3rem'}}>
                 <div>sanitizer <strong>v7</strong> · 98% on latest</div>
                 <div>upload lag p95 · <strong>6 min</strong></div>
@@ -151,16 +159,17 @@ export default function Mockups() {
         </div>
       </Mockup>
 
-      <h2>Deck studio</h2>
+      </TabItem>
+      <TabItem value="deck" label="Deck studio">
 
-      <Mockup chrome="browser" title="Fleetplane" url="fleetplane.internal/deck" caption="A date range drives a live slide from mart_deck_kpis. Notes are drafted by the Claude API and frozen. Nothing exports without approval.">
+      <Mockup chrome="browser" title="Claude Abacus" url="abacus.internal/deck" caption="A date range drives a live slide from mart_deck_kpis. Notes are drafted by the Claude API and frozen. Nothing exports without approval.">
         <div style={{fontFamily: ff, padding: '0.9rem 1rem', minHeight: '250px'}}>
           <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.6rem', fontSize: '0.74rem'}}>
             <span style={{padding: '0.25rem 0.55rem', border: hair, borderRadius: '7px', fontFamily: mono}}>2026-01-01 to 2026-06-30</span>
             <button style={{marginLeft: 'auto', padding: '0.3rem 0.7rem', border: 'none', borderRadius: '7px', background: 'var(--ifm-color-primary)', color: '#fff', fontWeight: 700, fontSize: '0.7rem', cursor: 'pointer'}}>Approve and export PPTX</button>
           </div>
           <div style={{aspectRatio: '16 / 9', border: hair, borderRadius: '10px', padding: '1rem 1.2rem', background: 'var(--ifm-background-surface-color)', display: 'flex', flexDirection: 'column', justifyContent: 'center'}}>
-            <div style={{fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--ifm-color-emphasis-600)'}}>Fleetplane · H1 2026</div>
+            <div style={{fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--ifm-color-emphasis-600)'}}>Claude Abacus · H1 2026</div>
             <div style={{fontWeight: 800, fontSize: '1.15rem', margin: '0.2rem 0 0.6rem'}}>412 sites analyzed · 128 bugs found</div>
             <div style={{display: 'flex', gap: '1.4rem', fontSize: '0.8rem'}}>
               <div><div style={{fontWeight: 800, fontSize: '1.1rem', color: 'var(--ifm-color-primary)'}}>1.8B</div>tokens</div>
@@ -171,6 +180,9 @@ export default function Mockups() {
           </div>
         </div>
       </Mockup>
+
+      </TabItem>
+      </Tabs>
     </>
   );
 }

--- a/bytesofpurpose-blog/designs/_mockups/claude-abacus.mdx
+++ b/bytesofpurpose-blog/designs/_mockups/claude-abacus.mdx
@@ -120,7 +120,7 @@ export default function Mockups() {
           <div style={{fontSize: '0.66rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ifm-color-emphasis-600)', marginBottom: '0.3rem'}}>Adoption across sessions</div>
           {adopt('code-review', '92%')}
           {adopt('release-notes', '74%')}
-          {adopt('fleet-setup', '68%')}
+          {adopt('abacus-setup', '68%')}
           {adopt('security-scan', '41%')}
         </div>
       </Mockup>


### PR DESCRIPTION
## Why

First full application of the `refine-design-post` rules to a real post, and a live example of the **name-vs-purpose** check the skill was just given: the post was named *"Fleetplane: A Control Plane for a Claude Code Fleet"* but the design builds a **reporting / observability** tool, not an admin control plane. Renamed to **Claude Abacus** (an abacus counts: tool invocations, agents run, insights, bugs found) and reframed "fleet" as **Distributed Claude Code Sessions (DCCS)**.

## What changed

- **`git mv`** the post + mockup sidecar to `*-claude-abacus.mdx`. Still `draft: true`, so the old slug was never published (no redirect needed until publish).
- **Users & use cases FIRST** (the new required opening): "Who it's for and what they do with it" (platform lead / engineer / eng leadership) with a **`<UseCaseDiagram>`**, before the Scope note.
- **Reframed** title, Scope, and Executive Summary from control-plane to reporting; dropped "There is no control plane" (it contradicted the purpose).
- **North Star section** (new): the control-plane ambition now lives here as ONE possible future among others (benchmarking / cost advisor / compliance), with a **fork-in-the-road** flowchart, framed as directions the foundation *could* take, not a roadmap.
- **Tabified** the "what it looks like" mockups: the 4 CX surfaces (transcript viewer, plugin hub, dashboard, deck studio) are now `<Tabs>`/`<TabItem>` instead of a 176-line vertical stack.

## Verification

- Route `/designs/design-claude-abacus` → **HTTP 200**; dev server compiles the page **clean** (no MDX/component error in the log).
- `validate-design-clarity` + `validate-visual-density` → **pass** (no wall-of-text: the users section and North Star both carry visuals).
- **0 em-dashes**; fenced blocks balanced; committed diff is real (98 insertions / 35 deletions, 82% rename similarity).
- **Caveat:** the in-browser screenshot eyeball was skipped because the chrome-devtools profile was locked by a concurrent session. The `<UseCaseDiagram>`, fork mermaid, and `<Tabs>` are client-rendered; the clean dev-compile is strong evidence but a manual look in the browser is worth a glance before publish.

Depends on the skill rules already merged in #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)