### PR TITLE
fix(em-dash): close the &#8212; entity bypass + purge all 38 uses

### DIFF
--- a/.claude/hooks/em-dash-voice-hook.sh
+++ b/.claude/hooks/em-dash-voice-hook.sh
@@ -66,20 +66,43 @@ esac
 #     ("--port" has no leading space-or-start boundary that we treat as prose, and we
 #     explicitly skip "--" immediately followed by a letter when preceded by a non-space).
 hits=$(awk -v mode="$in_scope" '
-  BEGIN { infence=0 }
+  BEGIN { infence=0; inmermaid=0 }
   {
     line=$0
     raw=$0
 
-    # toggle fenced code blocks (``` or ~~~ at line start, allowing indentation)
+    # toggle fenced code blocks (``` or ~~~ at line start, allowing indentation). Track
+    # MERMAID fences separately: a mermaid diagram RENDERS its labels to the reader, so an
+    # em-dash (or its HTML-entity disguise) inside one is still reader-facing AI voice and
+    # must be flagged — unlike a plain code example, which is skipped.
     t=line; sub(/^[[:space:]]+/, "", t)
-    if (t ~ /^(```|~~~)/) { infence = !infence; next }
-    if (infence) next
+    if (t ~ /^(```|~~~)/) {
+      if (!infence && t ~ /^(```|~~~)[[:space:]]*mermaid/) inmermaid=1
+      else if (infence && inmermaid) inmermaid=0
+      infence = !infence
+      next
+    }
 
     flagged=0; reason=""
 
-    # 1) em-dash U+2014
-    if (index(line, "\xE2\x80\x94") > 0) { flagged=1; reason="em-dash" }
+    # 0) em-dash HTML entities — &#8212; (decimal), &#x2014; (hex), &mdash; (named). These
+    # RENDER as an em-dash, so they are the same AI-voice tell wearing an entity disguise
+    # (the mermaid-label bypass the author-mermaid skill used to recommend). Flag them
+    # EVERYWHERE, including inside a mermaid fence (labels are reader-facing).
+    if (line ~ /&#8212;|&#[xX]0*2014;|&mdash;/) {
+      flagged=1; reason="em-dash entity"
+    }
+
+    # From here on, a plain (non-mermaid) code fence is skipped: code examples are not
+    # reader-facing. A mermaid fence is NOT skipped (its labels render).
+    if (infence && !inmermaid) { if (flagged) { } else next }
+
+    # 1) em-dash U+2014 (literal char) — reader-facing everywhere, incl. mermaid labels
+    if (index(line, "\xE2\x80\x94") > 0) { flagged=1; reason=(reason=="" ? "em-dash" : reason " + em-dash") }
+
+    # Inside a mermaid fence, stop here: the "--" checks below would false-fire on mermaid
+    # edge syntax (-->, ---, --). Only the em-dash char + entities apply to mermaid.
+    if (inmermaid) { if (flagged) { printf "  L%d [%s]: %s\n", NR, reason, (length(raw)>120?substr(raw,1,117) "...":raw); } next }
 
     # 2) "--" bypass — scan a SANITIZED copy of the line
     s=line

--- a/.claude/skills/author-mermaid/SKILL.md
+++ b/.claude/skills/author-mermaid/SKILL.md
@@ -292,9 +292,10 @@ rendered."
    `docs/craft/blogging/diagramming/animated-diagrams` doc. Don't animate context/relationship
    diagrams (the dot looks random).
 3. **Em-dash hook applies inside labels.** A literal `—` (U+2014) ANYWHERE in a
-   `designs/*.mdx` (including mermaid node labels) BLOCKS the edit. In a label, use the entity
-   `&#8212;` (renders as an em-dash, the hook can't see it) or rephrase. En-dash `–` and hyphen
-   `-` are fine.
+   `designs/*.mdx` (including mermaid node labels) BLOCKS the edit. **Do NOT reach for the
+   `&#8212;` / `&mdash;` HTML entity to dodge it** — the entity RENDERS as an em-dash, reads as
+   the same AI voice, and the hook now flags it too (inside mermaid fences as well). Rephrase the
+   label instead: a colon, a comma, or two words. En-dash `–` and hyphen `-` are fine.
 4. **Nesting in docs.** When you show a ```` ```mermaid ```` block INSIDE an `mdx` code fence
    (i.e. documenting it), the OUTER fence needs **4 backticks** (` ```` `), or the inner triple
    fence closes it early and breaks the MDX build.
@@ -328,7 +329,7 @@ especially the beta types. Prove it renders:
 | `kanban` cards not under their column | indentation | cards must be INDENTED under the column line. |
 | `quadrantChart` points off-chart | coords out of range | x,y are 0–1 floats. |
 | Diagram is the wrong colors / unreadable in dark mode | hardcoded `classDef`/`style fill:` | remove them; let the theme color it. |
-| Edit blocked: em-dash in a node label | literal `—` in the label | use `&#8212;` or rephrase. |
+| Edit blocked: em-dash in a node label | literal `—` OR a `&#8212;`/`&mdash;` entity in the label | rephrase the label (colon/comma/two words). The entity is NOT a valid dodge, it renders as an em-dash and is flagged too. |
 | The mermaid example in my DOC broke the page | 3-backtick nesting | wrap the example in a 4-backtick `mdx` fence. |
 
 ## Files / references

--- a/bytesofpurpose-blog/blog/2026-06-05-what-does-gtm-mean.md
+++ b/bytesofpurpose-blog/blog/2026-06-05-what-does-gtm-mean.md
@@ -18,13 +18,13 @@ draft: false
 
 A GTM strategy is the plan for how a product reaches and wins customers. It typically covers:
 
-- **Target segment / ICP** &mdash; who the customer is
-- **Positioning & messaging** &mdash; what value prop, against what alternatives
+- **Target segment / ICP**: who the customer is
+- **Positioning & messaging**: what value prop, against what alternatives
 - **Pricing & packaging**
-- **Channels** &mdash; sales-led, self-serve, partners, marketing motions
-- **Launch sequencing** &mdash; pilot, GA, expansion, and how you ramp
-- **Cross-functional alignment** &mdash; sales, marketing, product, support all rowing together
-- **Success metrics** &mdash; adoption, revenue, retention
+- **Channels**: sales-led, self-serve, partners, marketing motions
+- **Launch sequencing**: pilot, GA, expansion, and how you ramp
+- **Cross-functional alignment**: sales, marketing, product, support all rowing together
+- **Success metrics**: adoption, revenue, retention
 
 It's fundamentally a commercial, customer-facing plan. The audience is the market.
 

--- a/bytesofpurpose-blog/designs/2026-02-27-autonomous-build-agents.mdx
+++ b/bytesofpurpose-blog/designs/2026-02-27-autonomous-build-agents.mdx
@@ -160,8 +160,8 @@ flowchart TB
         end
     end
 
-    subgraph DECISION_ZONE["Decision Zone &#8212; Where Do Build Agents Live? (D1)"]
-        subgraph IMPL["Autonomous Build Agents (This Design &#8212; Phase 2)"]
+    subgraph DECISION_ZONE["Decision Zone: Where Do Build Agents Live? (D1)"]
+        subgraph IMPL["Autonomous Build Agents (This Design: Phase 2)"]
             direction TB
             IRA["Instance Readiness<br/>Agent"]
             ADA["Auto Developer"]
@@ -422,7 +422,7 @@ flowchart LR
         ORCH["Orchestration / Workflow"]
     end
 
-    subgraph BOUNDARY_UPSTREAM["Upstream (Existing &#8212; Not In Scope)"]
+    subgraph BOUNDARY_UPSTREAM["Upstream (Existing: Not In Scope)"]
         direction TB
         WF_PLAN["Planning Workflows<br/>(Create Req Epics, Tech Design)"]
         STORY["Sprint-Ready Work-Item Record<br/>Tech Guidance + AC + Test Steps + Points"]
@@ -1199,7 +1199,7 @@ sequenceDiagram
     IRA->>CI: Check platform version, capabilities, commits
     CI-->>IRA: Instance state
     alt Incompatible
-        IRA->>S: Update status: "Blocked &#8212; [reason]"
+        IRA->>S: Update status: "Blocked: [reason]"
         Note over IRA: HALT
     else Compatible
         IRA->>S: Update status: "Pre-flight passed"
@@ -1216,7 +1216,7 @@ sequenceDiagram
     S->>ATA: Read test steps
     ATA->>CI: Query configurations (verify existence & correctness)
     CI-->>ATA: Configuration state
-    ATA->>S: Update status: "Validated" or "Failed &#8212; [details]"
+    ATA->>S: Update status: "Validated" or "Failed: [details]"
 
     S->>KTA: Read implementation log (from ADA + ATA)
     KTA->>S: Write structured implementation log

--- a/bytesofpurpose-blog/designs/2026-06-21-ecommerce-site-scanner-and-lead-generation-engine.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-21-ecommerce-site-scanner-and-lead-generation-engine.mdx
@@ -126,7 +126,7 @@ graph LR
         SEED[Operator Seed Lists]
     end
 
-    subgraph engine["Scanning & Lead Engine &#8212; THIS DESIGN"]
+    subgraph engine["Scanning & Lead Engine: THIS DESIGN"]
         DISC((Discover\n& Dedupe))
         SCAN((Scan Site))
         ENRICH((Enrich:\ntraffic + contact))
@@ -183,11 +183,11 @@ graph LR
     PV[Discovery & Enrichment Providers]:::ext
     CRM[CRM / Sequencing Tool]:::ext
 
-    OP --- OPm["wants: a ranked, insight-rich,<br/>contactable lead queue &#8212;<br/>minimal manual prospecting"]:::note
+    OP --- OPm["wants: a ranked, insight-rich,<br/>contactable lead queue<br/>minimal manual prospecting"]:::note
     BD --- BDm["wants: ready-to-send drafts<br/>that convert; low friction<br/>from approve to sent"]:::note
     AG --- AGm["goal: discover→scan→enrich→<br/>score→draft cheaply,<br/>compliantly, at volume"]:::note
-    PR --- PRm["wants: relevant outreach about<br/>real problems on their site &#8212;<br/>not to be spammed"]:::note
-    PV --- PVm["supply candidate sites,<br/>size signals, contacts &#8212;<br/>under licence/ToS terms"]:::note
+    PR --- PRm["wants: relevant outreach about<br/>real problems on their site<br/>not to be spammed"]:::note
+    PV --- PVm["supply candidate sites,<br/>size signals, contacts<br/>under licence/ToS terms"]:::note
     CRM --- CRMm["holds leads + outreach status<br/>as the system of record"]:::note
 
 ```
@@ -343,9 +343,9 @@ graph LR
         AUDIT[(Audit Log)]
     end
 
-    subgraph assumed["Assumed / Integrated &#8212; Not Built"]
+    subgraph assumed["Assumed / Integrated: Not Built"]
         PROV[Discovery & Enrichment Providers]
-        WEB[Prospect Websites &#8212; public, read-only]
+        WEB[Prospect Websites: public, read-only]
         CRM[CRM / Sequencing Tool]
         MAIL[Email / Sending Channel]
         LLM[LLM Provider]
@@ -837,8 +837,8 @@ The primary subject the engine acts on is a **candidate ecommerce site**, which 
 ```mermaid
 graph LR
     J1[Candidate<br/>discovered]:::engine
-    J2[Site scanned &#8212;<br/>signal taxonomy]:::engine
-    J3[Size estimated &#8212;<br/>tier + confidence]:::engine
+    J2[Site scanned<br/>signal taxonomy]:::engine
+    J3[Size estimated<br/>tier + confidence]:::engine
     J4{Clears<br/>ICP fit gate?}:::decision
     J5[Contact found<br/>+ verified]:::engine
     J6[Scored & ranked<br/>with reasons]:::engine

--- a/bytesofpurpose-blog/designs/2026-06-22-aide.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-aide.mdx
@@ -98,13 +98,13 @@ Aide sits between a human-run kanban board and the external systems where work p
 
 ```mermaid
 graph TB
-    subgraph EXEC["Execution Layer &#8212; cloud runtime (scheduled task)"]
+    subgraph EXEC["Execution Layer: cloud runtime (scheduled task)"]
         AGENT["Aide (agent runtime)"]
         PROMPT["Operating model<br/>tenets · queues · templates"]
         SETUP["setup script<br/>installs CLIs, env fixes, snapshots"]
     end
 
-    subgraph SKILLS["Agent Skill Layer &#8212; daily loop"]
+    subgraph SKILLS["Agent Skill Layer: daily loop"]
         SK_CI["check-in"]
         SK_INT["process-intake"]
         SK_PW["pull-work"]
@@ -381,7 +381,7 @@ sequenceDiagram
     actor H as Reviewer
     W->>J: hits a decision it can't make
     W->>J: set flag + blocked-on-human, Tier-3 question, STAY assigned
-    Note over W,J: not Blocked &#8212; this is "waiting on you", not "failed"
+    Note over W,J: not Blocked: this is "waiting on you", not "failed"
     H->>J: answers, swap blocked-on-human → was-blocked-on-human
     Note over W,J: next run
     W->>J: priority-0 Unblocked queue (before Review)
@@ -561,17 +561,17 @@ sequenceDiagram
     participant S as Metrics (MCP)
     participant G as Document store (CLI)
 
-    Note over Sched, G: Phase 1 &#8212; Check-In
+    Note over Sched, G: Phase 1: Check-In
     Sched->>W: nightly trigger
     W->>J: find/create daily subtask under check-in epic
     W->>J: pre-flight connectivity probes
     W->>J: post Check-In comment
 
-    Note over Sched, G: Phase 2 &#8212; Pull Work
+    Note over Sched, G: Phase 2: Pull Work
     W->>J: Queue 1 Review, Queue 2 Rework, Queue 3 Planning, Queue 4 Prioritized
     W->>W: build work queue in priority order
 
-    Note over Sched, G: Phase 3 &#8212; Process each item
+    Note over Sched, G: Phase 3: Process each item
     loop per item
         W->>J: Step 0 self-review own comments
         alt source = Review
@@ -595,7 +595,7 @@ sequenceDiagram
         end
     end
 
-    Note over Sched, G: Phase 4 &#8212; Check-Out
+    Note over Sched, G: Phase 4: Check-Out
     W->>J: Check-Out comment on subtask
     W->>S: insert run + item metrics
     W->>G: upload workspace archive

--- a/bytesofpurpose-blog/designs/2026-06-22-markdown-review-studio.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-markdown-review-studio.mdx
@@ -599,7 +599,7 @@ Coupled to D1. The decision is a **hybrid**: the *location* lives inline in the 
   "schemaVersion": 1,
   "threads": [
     {
-      "id": "ab12",                       // join key &#8212; matches <!--rc:* id=ab12-->
+      "id": "ab12",                       // join key: matches <!--rc:* id=ab12-->
       "anchorType": "range",              // range | block | point | doc
       "status": "open",                   // open | resolved | reopened | orphaned
       "createdBy": "reviewer",
@@ -613,7 +613,7 @@ Coupled to D1. The decision is a **hybrid**: the *location* lives inline in the 
       },
       "comments": [
         { "id": "c1", "author": "reviewer", "body": "Is this strictly stronger than fuzzy?", "createdAt": "2026-06-22T14:03:00Z" },
-        { "id": "c2", "author": "claude",   "body": "Yes &#8212; marker moves with the text; fuzzy is the fallback. Clarified in D1.", "createdAt": "2026-06-22T14:09:11Z" }
+        { "id": "c2", "author": "claude",   "body": "Yes: marker moves with the text; fuzzy is the fallback. Clarified in D1.", "createdAt": "2026-06-22T14:09:11Z" }
       ],
       "addressedInCommit": "a1b2c3d"       // set when a Claude round resolves it (D3 traceability)
     }
@@ -814,7 +814,7 @@ Invocation (per D2/D8): `claude -p --output-format json --allowedTools "Read,Edi
 ```jsonc
 {
   "replies": [
-    { "id": "ab12", "resolution": "resolved", "reply": "Clarified &#8212; marker moves with the text; fuzzy is the fallback." },
+    { "id": "ab12", "resolution": "resolved", "reply": "Clarified: marker moves with the text; fuzzy is the fallback." },
     { "id": "cd34", "resolution": "resolved", "reply": "Demoted heading to H3." },
     { "id": "ef56", "resolution": "addressed", "reply": "Added a sentence on git-revert rollback." }
   ]

--- a/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
@@ -138,7 +138,7 @@ graph LR
         CATALOG[Catalog & Content]
     end
 
-    subgraph engine["Experimentation Agent &#8212; THIS DESIGN"]
+    subgraph engine["Experimentation Agent: THIS DESIGN"]
         IDEATE((Ideate\nHypotheses))
         DESIGN((Design\nVariants))
         RUN((Run Test\non Live Traffic))
@@ -147,8 +147,8 @@ graph LR
     end
 
     subgraph people["People & Systems"]
-        OWNER[Store Owner\nDIY &#8212; primary]
-        OP[Operator\nus &#8212; supervises]
+        OWNER[Store Owner\nDIY: primary]
+        OP[Operator\nus: supervises]
         STORE[(Commerce Platform\n/ Storefront)]
         SHOPPER[Storefront Visitor]
         LEDGER[(Wins Ledger\n& Experiment Log)]
@@ -350,7 +350,7 @@ graph LR
     subgraph assumed["Assumed / Depended On"]
         SCANNER[Site Scanner\nCO-DESIGN-0002]
         COMMERCE[(Commerce Platform\n+ Analytics)]
-        SERVE[Variant-Serving\nMechanism &#8212; D1]
+        SERVE[Variant-Serving\nMechanism: D1]
         LLM[LLM Provider]
     end
 
@@ -383,8 +383,8 @@ For a typical solo/small ecommerce merchant, the current state is one of three m
 ```mermaid
 graph LR
     OWNER[DIY Store Owner] --> Q{Wants better\nconversion}
-    Q -->|most common| NOTHING((Do nothing\n&#8212; stays flat))
-    Q -->|some| GUESS((Guess & ship\nto 100% &#8212; no control))
+    Q -->|most common| NOTHING((Do nothing,\nstays flat))
+    Q -->|some| GUESS((Guess & ship\nto 100%: no control))
     Q -->|rare| TOOL((Adopt testing tool))
     TOOL --> WALL[Manual hypotheses +\nmanual variants +\nanalyst dashboards +\nweeks of waiting]
     WALL -.->|most tests| ABANDON((Abandoned or\ndecided on noise))
@@ -470,12 +470,12 @@ graph LR
         AN((Analyze +\nDecide\nD2))
     end
 
-    subgraph control["Autonomy / Guardrail Engine &#8212; D3"]
+    subgraph control["Autonomy / Guardrail Engine: D3"]
         GATE{Autonomy tier\n+ guardrails}
         ROLL[Real-time health\n+ auto-rollback]
     end
 
-    subgraph exec["Execution Layer &#8212; D1 (abstracted)"]
+    subgraph exec["Execution Layer: D1 (abstracted)"]
         SERVE[Variant Serving\n+ Bucketing]
     end
 

--- a/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
+++ b/bytesofpurpose-blog/docs/handbook/components/structural/decision-kit.mdx
@@ -40,7 +40,7 @@ gate throws if a cell is keyed to an option id that does not exist.
         rating: 'yes',
         note: (
           <>The whole database is a single file on disk. There is no server to run, no
-          daemon to keep alive, and no connection pool to tune <sup>1</sup> &mdash; the app
+          daemon to keep alive, and no connection pool to tune <sup>1</sup>. The app
           just opens the file. That is the entire operational surface.</>
         ),
         footnotes: [

--- a/bytesofpurpose-blog/scripts/validate-em-dash.js
+++ b/bytesofpurpose-blog/scripts/validate-em-dash.js
@@ -109,18 +109,26 @@ for (const file of files) {
     const isFenceToggle = /^(```|~~~)/.test(trimmed);
 
     const emCount = line.includes(EM_DASH) ? line.split(EM_DASH).length - 1 : 0;
+    // Em-dash HTML entities (&#8212; decimal, &#x2014; hex, &mdash; named) RENDER as an
+    // em-dash, so they are the same AI-voice tell in disguise. Common inside mermaid labels
+    // (the old bypass). Code-inclusive like the em-dash check.
+    const entityCount = (line.match(/&#8212;|&#[xX]0*2014;|&mdash;/g) || []).length;
     const dashBypass = !inFence && !isFenceToggle && hasDashBypass(line);
 
     if (isFenceToggle) inFence = !inFence;
 
-    if (emCount === 0 && !dashBypass) return;
+    if (emCount === 0 && entityCount === 0 && !dashBypass) return;
     let snip = line.trim();
     if (snip.length > 120) snip = snip.slice(0, 117) + '...';
-    const kind = emCount > 0 && dashBypass ? 'em-dash + "--"' : emCount > 0 ? 'em-dash' : '"--" bypass';
+    const parts = [];
+    if (emCount > 0) parts.push('em-dash');
+    if (entityCount > 0) parts.push('em-dash entity');
+    if (dashBypass) parts.push('"--"');
+    const kind = parts.join(' + ');
     findings.push({
       file: path.relative(SITE_ROOT, file),
       line: i + 1,
-      count: emCount + (dashBypass ? 1 : 0),
+      count: emCount + entityCount + (dashBypass ? 1 : 0),
       kind,
       snippet: snip,
     });


### PR DESCRIPTION
## Why

An em-dash showed up **rendered in a mermaid diagram** on the Claude Abacus post, and the em-dash hook hadn't caught it. Root cause: the guard only flagged the literal char (`—`, U+2014) and the `--` bypass, but **missed the HTML entities `&#8212;` / `&#x2014;` / `&mdash;`** — which render as an em-dash and read as the same AI voice. Worse, the hook skipped mermaid fences entirely (so even a literal `—` in a mermaid *label* shipped unflagged), and the `author-mermaid` skill actually **recommended `&#8212;` as a deliberate dodge**.

## What changed

**The guard (commit 1):**
- **`em-dash-voice-hook.sh`** — tracks mermaid fences separately from plain code fences. Now flags the em-dash char AND the entities inside a mermaid label (labels are reader-facing rendered text), keeps skipping plain code examples, and does not false-fire on mermaid edge syntax (`-->`/`---`). **Proven with a 6-case truth table**: entity-in-mermaid, char-in-mermaid, char-in-prose, `&mdash;`-in-prose all BLOCK; mermaid edges + clean content stay CLEAN.
- **`validate-em-dash.js`** — the repo-wide sweep is now entity-aware too.
- **`author-mermaid/SKILL.md`** — reversed the bad advice: do NOT use `&#8212;`/`&mdash;` to dodge the hook; rephrase the label.

**The cleanup (commit 2):**
- Purged all **38 pre-existing `&#8212;`/`&mdash;` entity bypasses** across 7 files (6 design posts, a blog post, a doc). Almost all were mermaid labels; replaced with a colon, comma, or line break per context (a 1:1 swap, 38/38, no content lost).

## Scope

- The Claude Abacus post's own 4 entities were fixed separately on the already-merged #204.
- This PR is **entity bypasses only**. The entity-aware sweep also surfaces ~183 pre-existing **literal** em-dashes across 43 files — a separate, larger cleanup tracked as a task. `validate-em-dash` is a manual, non-gating sweep, so none of these block a build/deploy.

## Verification

- `validate-em-dash` entity findings: **0** across the whole corpus.
- Confirmed I introduced **0 new literal em-dashes** in the 7 edited files (diff-scoped check).
- Fence balance intact on all 7 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)