### PR TITLE
refine(premium-gating): dogfood the audit on an already-strong post

### DIFF
--- a/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
+++ b/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
@@ -127,6 +127,11 @@ the road" recipe). One direction needs no fork; two or more do. Propose it; `aut
   person the reader can picture. Fix = one clause naming concrete beneficiaries and their payoff (a
   resident, a would-be tenant, a reporter), not an abstract "users". This also closes the
   Problem/motivation "who has it?" row — they are the same gap. — [local-guide-skill.mdx]
+- **Even a mature, diagram-rich post usually lacks the users & use-cases opening.** The strongest
+  posts (great hook, honest trade-offs, threat-model tables) still tend to open on the Problem or the
+  system, skipping the required "who + use cases + a `<UseCaseDiagram>`" section. Auditing a GOOD post
+  is mostly: add that opening, break the one wall-of-text, and confirm the KEEP list. Don't manufacture
+  findings on a strong post; the new structural rules are usually the real gaps. — [premium-content-gating.mdx]
 
 ## Notes for the auditor
 

--- a/.claude/skills/refine-design-post/STYLE-GUIDE.md
+++ b/.claude/skills/refine-design-post/STYLE-GUIDE.md
@@ -93,3 +93,12 @@ taught it]`. Empty until the first audit adds to it.)_
   employer/internal name or a real internal number is. Generalize the INSTANCE, keep the coined name
   and the round figure. (Author's call: "Fleetplane" + "roughly 50 to 150 USD/month" both stayed.)
   The generality axis targets what only made sense inside one org, not every proper noun. — [fleetplane.mdx]
+- **An FAQ that re-explains an earlier section is redundancy, not an FAQ.** When a Q&A answer restates
+  a full section almost verbatim, cut it to a one-line VERDICT plus a link up to the section. The
+  detail belongs in one home; the FAQ points to it. (Real: the "Does this work on localhost?" FAQ
+  fully restated the Dev/prod parity section → trimmed to "Yes, identical except auth; see Dev/prod
+  parity".) — [premium-content-gating.mdx]
+- **Strip an incidental internal ID even in a post openly about your own system.** A post can name its
+  own real domain/repo (public, and it's ABOUT that system) yet still carry a leak-flavored internal
+  number with no reader value (a project ID, an org-internal counter). Drop the number, keep the name.
+  (Real: "PostHog project 448205" → "PostHog"; the blog's own domain + repo stayed.) — [premium-content-gating.mdx]

--- a/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-02-premium-content-gating.mdx
@@ -14,6 +14,38 @@ and without ever making a reader type a password on the page?
 
 <!-- truncate -->
 
+## Who it's for and what they do with it
+
+**Who.** Three people meet this gate. The **author** (me) wants some posts to drive a LinkedIn connection before they open, without giving up the static, crawlable, free-by-default site. A **reader** hits a locked post and wants to read it without inventing yet another password. An **internal tester** (also me, in dev) needs the exact production gate to work locally so what I test is what ships.
+
+**The problem they share.** A static site has no server to check who's asking, so the usual "gate it behind a login" move is off the table. Yet a React-component gate is cosmetic: the premium text still ships in the page source. There is no honest way to lock content on a static host without a trick.
+
+**What we build to fix it.** Ship the premium body **encrypted**, and hand the key to a tiny Cloudflare Worker that releases it only to a signed-in reader. What each person then does:
+
+<UseCaseDiagram
+  title="Premium Content Gating"
+  desc="Who meets the premium gate and what they do with it."
+  actors={[
+    {id: 'author', label: 'Author', kind: 'internal'},
+    {id: 'reader', label: 'Reader', kind: 'external'},
+    {id: 'tester', label: 'Internal tester', kind: 'external'},
+  ]}
+  useCases={[
+    {id: 'mark', label: 'Mark a post premium', detail: 'Add premium: true frontmatter; the build encrypts the body.'},
+    {id: 'free', label: 'Read free content', detail: 'The whole site stays anonymous-readable and crawlable.'},
+    {id: 'unlock', label: 'Unlock by signing in', detail: 'Sign in with LinkedIn; the browser fetches the key and decrypts, no password typed.'},
+    {id: 'parity', label: 'Test the real gate locally', detail: 'Dev encrypts and unlocks through the same Worker as prod.'},
+  ]}
+  links={[
+    {from: 'author', to: 'mark'},
+    {from: 'reader', to: 'free'},
+    {from: 'reader', to: 'unlock'},
+    {from: 'tester', to: 'parity'},
+  ]}
+/>
+
+**How it makes their life better.** The author gets a real gate that still ranks in search and costs nothing to serve; the reader unlocks with one LinkedIn click and never types a passphrase; the tester runs the production gate on `localhost`, so there is no "works in dev, breaks in prod" gap.
+
 ## Problem
 
 The blog is a static Docusaurus build deployed to GitHub Pages. "Gating" content
@@ -57,7 +89,7 @@ flowchart TB
         Worker["Worker /api/*<br/>/api/me · /api/unlock-key"]
     end
     LinkedIn["🔗 LinkedIn<br/>Sign in w/ OIDC"]
-    PostHog["📊 PostHog<br/>project 448205"]
+    PostHog["📊 PostHog<br/>analytics"]
 
     Browser -->|loads| Bundle
     Nav -->|sign in| Access --> LinkedIn
@@ -287,30 +319,12 @@ the design treats the **V5 verifier (`scripts/verify-premium-encrypted.js`) as t
 guarantee** and the encrypt plugin as merely the thing that should make V5 pass. Four
 principles, hardened after an adversarial code review of the implementation:
 
-1. **Fail closed when safety is *unprovable*, not just when a leak is *seen*.** V5 proves
-   absence by grepping the whole build for distinctive tokens of each premium body. If a
-   premium doc yields **no** distinctive tokens, the verifier cannot prove the body is
-   absent, so it now **errors and aborts the deploy** rather than warning and passing.
-   "Can't prove safe" is treated as "unsafe." (The earlier version logged a warning and
-   continued, which is fail-*open* for exactly the docs hardest to fingerprint.)
-
-2. **Layered fingerprints so every body is checkable.** A body of only short, common words
-   produces no long single token. Rather than leave it un-fingerprinted, `bodyFingerprints()`
-   falls back from **long single tokens → 4-word phrases** (text runs survive HTML
-   serialization without entity-escaping, so they're still greppable). Only a genuinely
-   empty body reaches principle 1's hard error.
-
-3. **One source of truth for "what is premium."** The set of premium docs is computed in
-   exactly one place, `collectPremiumDocs()` (YAML-parsed `premium === true`), and every
-   consumer (the encrypt plugin, the V5 verifier, **and** the deploy's fail-closed abort)
-   reads from it. Shell gates do **not** re-derive the set with a parallel `grep` that could
-   silently disagree (`premium:true` vs `premium: true`, quoted, etc.). A gate that
-   disagrees with the encryptor about which docs to encrypt is a leak waiting to happen.
-
-4. **The passphrase is itself contraband in the build.** V5 also asserts the
-   `STATICRYPT_PASSPHRASE` value appears **nowhere** in the built output, if the key ever
-   leaked into a bundle, every premium body would be offline-decryptable, so its absence is
-   gated with the same severity as the bodies.
+| Principle | What it guards against | Fail-closed behavior |
+|---|---|---|
+| **Fail closed when safety is *unprovable*** | A body so hard to fingerprint that absence can't be proven | A premium doc yielding **no** distinctive tokens now **errors and aborts the deploy** ("can't prove safe" = "unsafe"). The earlier warn-and-continue was fail-*open* for exactly those docs. |
+| **Layered fingerprints** | A body of only short, common words producing no long token | `bodyFingerprints()` falls back from **long single tokens → 4-word phrases** (text runs survive HTML serialization, still greppable). Only a genuinely empty body reaches the hard error above. |
+| **One source of truth for "what is premium"** | A shell gate's parallel `grep` silently disagreeing with the encryptor (`premium:true` vs `premium: true`) | The premium set is computed once in `collectPremiumDocs()` (YAML-parsed), and every consumer (encrypt plugin, V5, the deploy abort) reads from it. No re-derivation. |
+| **The passphrase is contraband too** | The decryption key leaking into a bundle (every body becomes offline-decryptable) | V5 asserts `STATICRYPT_PASSPHRASE` appears **nowhere** in the built output, gated with the same severity as the bodies. |
 
 > **Known nuance (residual, by design): the post-deploy V5 in `make deploy` is
 > detection, not prevention.** `docusaurus deploy` rebuilds *and pushes* in one step, so
@@ -462,17 +476,26 @@ repo (see *Trade-offs*). Within that scope, this is the attack surface and what 
 
 ### Does this work on localhost?
 
-**Yes, local dev is designed to behave identically to production** (see *Dev/prod
-parity* above). `yarn start` encrypts premium bodies the same way the prod build does,
-and the dev server **proxies `/api/*` to the deployed Worker**, so `localhost` unlocks
-premium through the exact same `/api/unlock-key` path as prod. The encryption, client
-code, and key source are identical; the **only** difference is authentication, dev
-uses a CF Access **service token** (headers injected by the proxy, no browser login)
-rather than a LinkedIn cookie, because an `HttpOnly` domain-scoped cookie can't cross to
-`localhost` and the login nonce is origin-bound (see *The one real difference* above).
-There is no dev-only key and no "it no-ops locally" caveat. The `?internal=1` analytics
-opt-in also works in dev. *(Parity requires the Worker to be deployed **and** the dev
-service token configured; until then `/api/unlock-key` can't vend locally.)*
+**Yes, identical to prod except for how the unlock request authenticates.** The full
+mechanics (dev encrypts too, proxies `/api/*` to the real Worker, and uses a CF Access
+service token instead of a LinkedIn cookie because a domain-scoped `HttpOnly` cookie
+can't reach `localhost`) are in *Dev/prod parity* above. Parity requires the Worker
+deployed **and** the dev service token configured.
+
+## North Star: where the gate could go next
+
+Today the gate answers one question: "is this a signed-in LinkedIn user?" One global key, one binary check. That is deliberately the whole of it. But the same "ship ciphertext, vend the key to an authenticated request" foundation could grow in more than one direction. These are possibilities, not a plan.
+
+```mermaid
+flowchart LR
+  found([Today: one key, one sign-in check])
+  found -->|"lock posts independently"| a([Per-doc keys])
+  found -->|"charge, not just gate"| b([Real membership tiers])
+  found -->|"gate by who, not just whether"| c([Audience-segment gating])
+  found -->|"let others reuse it"| d([Drop-in gate for any static site])
+```
+
+The one I would resist first is **membership tiers**: the moment money changes hands, "a nudge to say hi on LinkedIn" becomes a product with support, refunds, and a much higher bar for the honest trade-off below. The gate earns any of these by staying trustworthy at the one thing it does now: encrypt at compile time, never leak, and be honest that it is a nudge and not a vault.
 
 ## One more thing
 


### PR DESCRIPTION
## Why

Second dogfood of `refine-design-post`, this time on a **mature, diagram-rich** post — a stress test of whether the audit finds real gaps or manufactures them. It found a handful of genuine ones (mostly the new structural rules), left the strong parts alone, and fed the lessons back into the guides.

## What changed in the post

- **Users & use-cases opening** + a `<UseCaseDiagram>` (Author / Reader / Internal tester + their use cases) before `## Problem` — the required opening it lacked. Gate passes (side-split layout).
- **Dropped "PostHog project 448205"** — an incidental internal ID with no reader value. Kept the blog's own domain + repo (the post is openly about this site).
- **Tablified the 456-word "Verification & assurance"** wall-of-text: 4 numbered principles → a `Principle | Guards against | Fail-closed` table. The one density flag, now clean.
- **Trimmed the "Does this work on localhost?" FAQ** that fully restated Dev/prod parity → a verdict + a link up.
- **Added a North Star section** with a fork-in-the-road diagram (per-doc keys / membership tiers / segment-gating / drop-in gate), resisting tiers first. The wink stays the final beat.

## Captured back into the guides (self-healing step)

- **STYLE-GUIDE.md**: an FAQ that re-explains a section is redundancy (verdict + link up, not a re-explanation); strip an incidental internal ID even in a post about your own system.
- **SECTION-QUESTIONS.md**: even a strong post usually lacks the users/use-cases opening — auditing a good post is mostly *add that + break the one wall-of-text*, not manufacturing findings.

## Verification

- `<UseCaseDiagram>` gate **passes** (run the real `computeUseCaseLayout` directly).
- Route 200, dev server compiles clean, `validate-design-clarity` + `validate-visual-density` pass (wall-of-text gone), 0 em-dashes, fences balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)