### PR TITLE
fix(em-dash): purge 84 literal em-dashes from blog prose

### DIFF
--- a/bytesofpurpose-blog/blog/2020-01-06-a-learning-plan-for-graphql.mdx
+++ b/bytesofpurpose-blog/blog/2020-01-06-a-learning-plan-for-graphql.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-graphql
 title: "A Learning Plan for GraphQL"
-description: "What to know when you're picking up GraphQL — why you'd reach for it over REST, and a curated set of docs, tutorials, and tools to learn it from."
+description: "What to know when you're picking up GraphQL: why you'd reach for it over REST, and a curated set of docs, tutorials, and tools to learn it from."
 authors: [oeid]
 tags: [backend, software-engineering, learning-plan]
 date: 2020-01-06
@@ -11,13 +11,13 @@ draft: true
 import CategoryCarousel from '@site/src/components/CategoryCarousel';
 
 When I set out to learn GraphQL, the question that actually mattered wasn't "how do
-I write a query" — it was **"why would I reach for this instead of REST?"** GraphQL
+I write a query": it was **"why would I reach for this instead of REST?"** GraphQL
 lets a client ask for exactly the fields it needs in one round trip, instead of
 stitching together several REST endpoints and throwing away the parts it didn't
 want. That's the whole pitch: the client describes the shape of the data, the server
 resolves it. Everything else is detail you can pick up once that clicks.
 
-This is the learning plan I kept — the resources worth starting from, grouped by how
+This is the learning plan I kept: the resources worth starting from, grouped by how
 I actually used them.
 
 <!-- truncate -->
@@ -30,8 +30,8 @@ A good way in, in order:
 lands before the syntax. The goal is to be able to say *when* GraphQL helps and when
 it doesn't.
 
-[Step 2] Work through **one core-concepts tutorial** end to end — schema, types,
-queries, resolvers — rather than skimming several.
+[Step 2] Work through **one core-concepts tutorial** end to end (schema, types,
+queries, resolvers) rather than skimming several.
 
 [Step 3] **Tinker with a real engine.** Stand up a GraphQL layer over a database
 (Hasura over Postgres is the fastest path) and run a stress test against the
@@ -51,12 +51,12 @@ practices that keep a schema sane as it grows.
 
 Once the concepts land, the fastest way to internalize them is to put a GraphQL API
 in front of actual data and poke at it. These are the engines, tutorials, and schema
-tools I used to do that — Hasura over Postgres especially.
+tools I used to do that, Hasura over Postgres especially.
 
 <CategoryCarousel topic="learn-about-graphql" category="Tinker with GraphQL and Postgres ..." />
 
 ---
 
 > This roadmap is curated from my own running notes on GraphQL. The resource lists
-> are a living collection — they're maintained as data, so the list grows without the
+> are a living collection: they're maintained as data, so the list grows without the
 > post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-01-06-questions-for-understanding-design-patterns.md
+++ b/bytesofpurpose-blog/blog/2020-01-06-questions-for-understanding-design-patterns.md
@@ -1,14 +1,14 @@
 ---
 slug: questions-for-understanding-design-patterns
 title: "Questions for Understanding Design Patterns"
-description: "A reader's question-set for working through the classic Gang of Four Design Patterns book — the questions that actually unlock object-oriented design."
+description: "A reader's question-set for working through the classic Gang of Four Design Patterns book: the questions that actually unlock object-oriented design."
 authors: [oeid]
 tags: [software-engineering, design-patterns, question-set, best-practices]
 date: 2020-01-06
 draft: true
 ---
 
-When I first sat down with *Design Patterns: Elements of Reusable Object-Oriented Software* (Gamma, Helm, Johnson, and Vlissides — the "Gang of Four"), I didn't take notes the usual way. Instead of summarizing what the book said, I wrote down the **questions** each section was answering. A pattern only sticks once you can state the problem it solves, so a good question is worth more than a tidy summary.
+When I first sat down with *Design Patterns: Elements of Reusable Object-Oriented Software* (Gamma, Helm, Johnson, and Vlissides, the "Gang of Four"), I didn't take notes the usual way. Instead of summarizing what the book said, I wrote down the **questions** each section was answering. A pattern only sticks once you can state the problem it solves, so a good question is worth more than a tidy summary.
 
 What follows is that question-set: the questions I'd want a reader to be able to answer after a careful first pass through the book's introduction. Use them as a study guide, a self-quiz, or a checklist for whether a chapter actually landed.
 
@@ -18,9 +18,9 @@ What follows is that question-set: the questions I'd want a reader to be able to
 
 - How is the quality of an object-oriented system measured?
 - How can developers leverage the expertise of other skilled architects and developers?
-- How does one design reusable object-oriented software — and what constraints must the design meet to do so?
+- How does one design reusable object-oriented software, and what constraints must the design meet to do so?
 - How can a design be tested to ensure it is reusable?
-- What do experienced designers know that beginners don't? What traps do they avoid, and how do they steer clear of design déjà vu — solving the same problem the same wrong way again?
+- What do experienced designers know that beginners don't? What traps do they avoid, and how do they steer clear of design déjà vu, solving the same problem the same wrong way again?
 - What activities do design patterns facilitate?
 - What are the essential elements of a design pattern?
 
@@ -44,7 +44,7 @@ What follows is that question-set: the questions I'd want a reader to be able to
 ## Modeling classes and relationships
 
 - How are object implementations (classes) represented in UML?
-- How do you represent an abstract class in a UML diagram — and how do you tell that a class *is* abstract? What is an abstract class?
+- How do you represent an abstract class in a UML diagram, and how do you tell that a class *is* abstract? What is an abstract class?
 - How do you represent inheritance in a UML diagram? What is inheritance?
 - What is the difference between a class and a type?
 - What is the difference between class inheritance and interface inheritance?
@@ -72,7 +72,7 @@ What follows is that question-set: the questions I'd want a reader to be able to
   - What are the different ways a program can be distributed?
   - How do patterns benefit an *application*? What is an application?
   - How do patterns benefit a *toolkit*? What is a toolkit?
-  - What is a *framework*? What is inversion of control? What are the pros and cons of using a framework, and what risks do you incur? How do patterns help you build good frameworks — and how do patterns differ from frameworks?
+  - What is a *framework*? What is inversion of control? What are the pros and cons of using a framework, and what risks do you incur? How do patterns help you build good frameworks, and how do patterns differ from frameworks?
   - Which is harder to design: applications, toolkits, or frameworks?
 
 ## Actually using them
@@ -82,4 +82,4 @@ What follows is that question-set: the questions I'd want a reader to be able to
 
 ---
 
-> These questions follow the introduction of *Design Patterns: Elements of Reusable Object-Oriented Software* by Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides (Addison-Wesley, 1994). The questions are mine; the book is theirs — go read it.
+> These questions follow the introduction of *Design Patterns: Elements of Reusable Object-Oriented Software* by Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides (Addison-Wesley, 1994). The questions are mine; the book is theirs. Go read it.

--- a/bytesofpurpose-blog/blog/2020-02-23-a-learning-plan-for-nlp.mdx
+++ b/bytesofpurpose-blog/blog/2020-02-23-a-learning-plan-for-nlp.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-nlp
 title: "A Learning Plan for NLP"
-description: "A short, honest starting point for natural language processing — how to approach a first NLP project and a few resources to learn from."
+description: "A short, honest starting point for natural language processing: how to approach a first NLP project and a few resources to learn from."
 authors: [oeid]
 tags: [ai-engineering, llm, learning-plan]
 date: 2020-02-23
@@ -32,4 +32,4 @@ These are the few resources I started from. The list is maintained as data, so i
 
 ---
 
-> This roadmap is curated from my own running notes on NLP. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.
+> This roadmap is curated from my own running notes on NLP. The resource lists are a living collection: they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-02-27-a-learning-plan-for-machine-learning.mdx
+++ b/bytesofpurpose-blog/blog/2020-02-27-a-learning-plan-for-machine-learning.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-machine-learning
 title: "A Learning Plan for Machine Learning"
-description: "What to know when you're getting into machine learning — how to approach it, and a curated set of concepts, courses, and techniques to learn from."
+description: "What to know when you're getting into machine learning: how to approach it, and a curated set of concepts, courses, and techniques to learn from."
 authors: [oeid]
 tags: [ai-engineering, llm, learning-plan]
 date: 2020-02-27
@@ -61,4 +61,4 @@ its own: gradient descent, the train/test split, distance measures, and AutoML.
 
 ---
 
-> This roadmap is curated from my own running notes on machine learning. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.
+> This roadmap is curated from my own running notes on machine learning. The resource lists are a living collection: they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-03-15-a-learning-plan-for-kubernetes.mdx
+++ b/bytesofpurpose-blog/blog/2020-03-15-a-learning-plan-for-kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-kubernetes
 title: "A Learning Plan for Kubernetes"
-description: "What to know when picking up Kubernetes — the core building blocks, then the patterns, scaling, and cloud specifics, with curated resources."
+description: "What to know when picking up Kubernetes: the core building blocks, then the patterns, scaling, and cloud specifics, with curated resources."
 authors: [oeid]
 tags: [backend, software-engineering, cloud, learning-plan]
 date: 2020-03-15
@@ -18,7 +18,7 @@ and most of the cluster stops feeling like magic.
 
 The second pass is operational: how you scale workloads, how autoscaling actually
 behaves under load, and how a managed offering on a specific cloud changes the setup.
-This is the learning plan I kept as running notes — the resources worth starting from,
+This is the learning plan I kept as running notes: the resources worth starting from,
 grouped by which pass I used them in.
 
 <!-- truncate -->
@@ -27,7 +27,7 @@ grouped by which pass I used them in.
 
 A good way in, in order:
 
-[Step 1] Learn the **core objects and tooling** first — declare pods, deployments, and
+[Step 1] Learn the **core objects and tooling** first: declare pods, deployments, and
 services, get fluent with `kubectl`, package with `helm`, and understand when an
 operator is the right pattern.
 
@@ -49,7 +49,7 @@ drive the cluster with day to day.
 
 ## Patterns, scaling & cloud
 
-Once the building blocks land, this is where the operational knowledge lives — the
+Once the building blocks land, this is where the operational knowledge lives: the
 patterns that keep workloads healthy, how autoscaling behaves, and the cloud-specific
 managed setups.
 
@@ -57,4 +57,4 @@ managed setups.
 
 ---
 
-> This roadmap is curated from my own running notes on Kubernetes. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.
+> This roadmap is curated from my own running notes on Kubernetes. The resource lists are a living collection: they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-03-23-how-oauth-lets-an-app-act-on-your-behalf.md
+++ b/bytesofpurpose-blog/blog/2020-03-23-how-oauth-lets-an-app-act-on-your-behalf.md
@@ -1,14 +1,14 @@
 ---
 slug: how-oauth-lets-an-app-act-on-your-behalf
 title: "How OAuth Lets an App Act on Your Behalf"
-description: "A plain-language walkthrough of the OAuth handshake — how a third-party app gets access to your data without ever seeing your password."
+description: "A plain-language walkthrough of the OAuth handshake: how a third-party app gets access to your data without ever seeing your password."
 authors: [oeid]
 tags: [backend, software-engineering, best-practices]
 date: 2020-03-23
 draft: true
 ---
 
-The thing that finally made OAuth click for me was framing it around a single question: *how does an app get to act on my behalf without me ever handing it my password?* Once you trace the handshake from that angle, the moving parts — request tokens, access tokens, the redirect dance — stop being jargon and start being obvious.
+The thing that finally made OAuth click for me was framing it around a single question: *how does an app get to act on my behalf without me ever handing it my password?* Once you trace the handshake from that angle, the moving parts (request tokens, access tokens, the redirect dance) stop being jargon and start being obvious.
 
 Here's the walkthrough I wrote for myself, using Jira as the concrete example of the system that owns the data.
 
@@ -16,9 +16,9 @@ Here's the walkthrough I wrote for myself, using Jira as the concrete example of
 
 ## The cast of characters
 
-Say I have data in **Jira** — issues, projects, comments. I own these resources, which makes me the **resource owner**: I'm the one who decides whether that information is kept, shared, or deleted.
+Say I have data in **Jira**: issues, projects, comments. I own these resources, which makes me the **resource owner**: I'm the one who decides whether that information is kept, shared, or deleted.
 
-Now I start using **another app** that integrates with Jira. At some point I take an action in that app that requires data *from* Jira. The app needs access — but I do **not** want to give it my Jira username and password. That's the whole problem OAuth exists to solve.
+Now I start using **another app** that integrates with Jira. At some point I take an action in that app that requires data *from* Jira. The app needs access, but I do **not** want to give it my Jira username and password. That's the whole problem OAuth exists to solve.
 
 ## The handshake
 
@@ -26,15 +26,15 @@ Here's the sequence that lets the app reach my Jira data without ever learning m
 
 1. The app requests a **request token** from Jira.
 2. The app **redirects me to Jira** to authorize that request token. It also tells Jira where to send me back afterward.
-3. On Jira's own site, I enter my username and password — **into Jira, never into the app** — and approve the request.
+3. On Jira's own site, I enter my username and password (**into Jira, never into the app**) and approve the request.
 4. Jira sends me back to the app, now carrying an **authorized request token**.
 5. The app exchanges that authorized request token for an **access token**, and uses the access token to call Jira's API for my data.
 
-The key move is step 3: my credentials only ever touch Jira. The app walks away with tokens, not with my password — and I can revoke those tokens later without changing my password everywhere.
+The key move is step 3: my credentials only ever touch Jira. The app walks away with tokens, not with my password, and I can revoke those tokens later without changing my password everywhere.
 
 ## Why two tokens instead of one
 
-It's reasonable to ask why the flow bothers with a *request* token and *then* an *access* token, rather than just handing the app one credential. The separation is what makes the authorization step meaningful: the request token represents "an app is *asking*," and only after I approve it on the resource owner's site does it become something that can be exchanged for real access. The access token is then the thing that's scoped, refreshable, and revocable — independent of my login.
+It's reasonable to ask why the flow bothers with a *request* token and *then* an *access* token, rather than just handing the app one credential. The separation is what makes the authorization step meaningful: the request token represents "an app is *asking*," and only after I approve it on the resource owner's site does it become something that can be exchanged for real access. The access token is then the thing that's scoped, refreshable, and revocable, independent of my login.
 
 That word **scope** matters: an access token is granted for a limited set of permissions, not blanket access to everything I own. The app gets exactly what I approved and no more.
 
@@ -42,9 +42,9 @@ That word **scope** matters: an access token is granted for a limited set of per
 
 When I wrote these notes I lined up the canonical references worth reading next:
 
-- [Refreshing access tokens](https://www.oauth.com/oauth2-servers/access-tokens/refreshing-access-tokens/) — how an access token is renewed without sending the user back through the flow.
-- [Why OAuth has both a request token and an access token](https://stackoverflow.com/questions/3584718/why-is-oauth-designed-to-have-request-token-and-access-token) — the design rationale for the two-token split.
-- [OAuth scopes](https://oauth.net/2/scope/) — the mechanism that limits what an access token is allowed to do.
-- [Jira's REST API OAuth authentication](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-oauth-authentication/) — the concrete provider flow this walkthrough is modeled on.
+- [Refreshing access tokens](https://www.oauth.com/oauth2-servers/access-tokens/refreshing-access-tokens/): how an access token is renewed without sending the user back through the flow.
+- [Why OAuth has both a request token and an access token](https://stackoverflow.com/questions/3584718/why-is-oauth-designed-to-have-request-token-and-access-token): the design rationale for the two-token split.
+- [OAuth scopes](https://oauth.net/2/scope/): the mechanism that limits what an access token is allowed to do.
+- [Jira's REST API OAuth authentication](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-oauth-authentication/): the concrete provider flow this walkthrough is modeled on.
 
-The mental model is the durable part: **an app acts on your behalf by holding a scoped, revocable token that it earned through your explicit approval — not by holding your password.** Everything else is detail.
+The mental model is the durable part: **an app acts on your behalf by holding a scoped, revocable token that it earned through your explicit approval, not by holding your password.** Everything else is detail.

--- a/bytesofpurpose-blog/blog/2020-05-11-a-learning-plan-for-agile.mdx
+++ b/bytesofpurpose-blog/blog/2020-05-11-a-learning-plan-for-agile.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-agile
 title: "A Learning Plan for Agile"
-description: "A starting point for learning Agile, Scrum, and Kanban — how to approach it and a curated set of guides and books."
+description: "A starting point for learning Agile, Scrum, and Kanban: how to approach it and a curated set of guides and books."
 authors: [oeid]
 tags: [software-engineering, best-practices, learning-plan]
 date: 2020-05-11
@@ -32,4 +32,4 @@ The canonical guide, the practical books, and the starting points for actually r
 
 ---
 
-> This roadmap is curated from my own running notes on Agile. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.
+> This roadmap is curated from my own running notes on Agile. The resource lists are a living collection: they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2020-06-16-questions-for-productionizing-a-machine-learning-system.md
+++ b/bytesofpurpose-blog/blog/2020-06-16-questions-for-productionizing-a-machine-learning-system.md
@@ -1,7 +1,7 @@
 ---
 slug: questions-for-productionizing-a-machine-learning-system
 title: "Questions for Productionizing a Machine Learning System"
-description: "The operational questions that decide how an ML system actually runs in production — when to predict, how to rank, how often to train, and how to stay explainable."
+description: "The operational questions that decide how an ML system actually runs in production: when to predict, how to rank, how often to train, and how to stay explainable."
 authors: [oeid]
 tags: [ai-engineering, llm, question-set]
 date: 2020-06-16
@@ -19,7 +19,7 @@ through an ML system's design, grouped by the concern they belong to.
 ## Feedback and prediction cadence
 
 - What problem are ML engineers generally concerned with here in the first place?
-- How do you ingest feedback — can it be batched up, or does it need to be handled as
+- How do you ingest feedback: can it be batched up, or does it need to be handled as
   it arrives?
 - How often are predictions actually generated? Is this a bulk job, an online
   request, or both?
@@ -28,7 +28,7 @@ through an ML system's design, grouped by the concern they belong to.
   you may need to recompute the top results. How do you reconcile "fresh per request"
   with "the world changed underneath you"?
 - Without online-learning capability, the best you can do may be recomputing once a
-  day — and the model itself might take a while to run. Does your latency budget allow
+  day, and the model itself might take a while to run. Does your latency budget allow
   that?
 
 ## Ranking
@@ -42,7 +42,7 @@ through an ML system's design, grouped by the concern they belong to.
 
 - How frequently do you retrain?
 - When you're doing online training, when do you take a snapshot of the model?
-- Where do heuristics fit — what can you lean on them for while the learned system
+- Where do heuristics fit: what can you lean on them for while the learned system
   catches up?
 
 ## Consumption
@@ -57,7 +57,7 @@ through an ML system's design, grouped by the concern they belong to.
   visibility into *why* they're seeing something, and giving them a genuinely good
   recommendation.
 - What algorithm can balance these? You want a good recommendation service in the
-  long run — but optimizing purely for that can mean recommending bad things in the
+  long run, but optimizing purely for that can mean recommending bad things in the
   short run while the system explores. How much short-run cost will you accept for
   long-run quality?
 

--- a/bytesofpurpose-blog/blog/2020-07-14-a-learning-plan-for-postgresql.mdx
+++ b/bytesofpurpose-blog/blog/2020-07-14-a-learning-plan-for-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-postgresql
 title: "A Learning Plan for PostgreSQL"
-description: "What to know to get good with PostgreSQL — practical query recipes, schema-design best practices, and tooling, with curated resources."
+description: "What to know to get good with PostgreSQL: practical query recipes, schema-design best practices, and tooling, with curated resources."
 authors: [oeid]
 tags: [data-engineering, databases, learning-plan]
 date: 2020-07-14
@@ -25,7 +25,7 @@ I've organized them around two muscles: the everyday querying patterns I lean on
 
 ## Querying recipes
 
-These are the patterns I reach for daily — joins, aggregation, date math, and handling nulls cleanly.
+These are the patterns I reach for daily: joins, aggregation, date math, and handling nulls cleanly.
 
 <CategoryCarousel topic="learn-about-postgresql" category="Querying recipes" />
 
@@ -41,4 +41,4 @@ A small set of tools handles most day-to-day work: psql for the terminal, DBeave
 
 <CategoryCarousel topic="learn-about-postgresql" category="Tooling" />
 
-> This roadmap is curated from my own running notes on PostgreSQL. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.
+> This roadmap is curated from my own running notes on PostgreSQL. The resource lists are a living collection: they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2021-07-05-answering-leadership-principle-interview-questions.md
+++ b/bytesofpurpose-blog/blog/2021-07-05-answering-leadership-principle-interview-questions.md
@@ -8,14 +8,14 @@ date: 2021-07-05
 draft: true
 ---
 
-Behavioral interviews at a lot of companies — Amazon most famously — are built around
+Behavioral interviews at a lot of companies (Amazon most famously) are built around
 a published set of **leadership principles**. The questions feel open-ended ("tell me
 about a time…"), but each one is really probing for a specific principle. If you know
 which principle a question maps to and you have a crisp story ready, the whole format
 gets a lot less intimidating.
 
 This is the prep map I built for myself: each principle, the kind of question that
-surfaces it, and the method for answering. The stories are mine, anonymized — the
+surfaces it, and the method for answering. The stories are mine, anonymized; the
 point here is the *structure*, which transfers to any company that interviews this
 way.
 
@@ -26,16 +26,16 @@ way.
 Answer every behavioral question in the **STAR** format. It forces a complete story
 and keeps you from rambling:
 
-- **Situation** — the problem and its context (who, what, where, when). Keep it brief.
-- **Task** — what *you* specifically had to do, and the constraints (deadlines, costs,
+- **Situation**: the problem and its context (who, what, where, when). Keep it brief.
+- **Task**: what *you* specifically had to do, and the constraints (deadlines, costs,
   technical limits).
-- **Action** — the specific actions you took. Choose actions that *demonstrate*
+- **Action**: the specific actions you took. Choose actions that *demonstrate*
   desirable traits (initiative, leadership, judgment) without you having to name them.
-- **Result** — how it turned out. Quantify if you can, then add what you learned and
+- **Result**: how it turned out. Quantify if you can, then add what you learned and
   what you'd do differently.
 
-A useful variant interviewers use to evaluate the answer is **SBI** — Situation,
-Behavior, Impact — which is just STAR viewed from the listener's side. If your story
+A useful variant interviewers use to evaluate the answer is **SBI** (Situation,
+Behavior, Impact), which is just STAR viewed from the listener's side. If your story
 has a clear situation, a behavior that was yours, and a measurable impact, it works
 under either lens.
 
@@ -144,34 +144,34 @@ mine, anonymized, to show how a story maps onto STAR.
 
 ### A turnaround story (Earn Trust / Dive Deep / Deliver Results)
 
-- **Situation** — I was brought in to lead a team fixing the performance of a complex
+- **Situation**: I was brought in to lead a team fixing the performance of a complex
   GPU-based ML system that processed images. It was supposed to handle 600 images per
-  second; it was managing about 50. The customer was frustrated — at that rate their
+  second; it was managing about 50. The customer was frustrated: at that rate their
   backlog would take a year instead of a month, and they were losing faith we could
   deliver.
-- **Task** — Decompose the architecture, find the strategic improvements that would
+- **Task**: Decompose the architecture, find the strategic improvements that would
   raise throughput in time, and explain each change to the customer so they understood
   *why* it mattered.
-- **Action** — I broke the architecture down, diagrammed it, and mapped every
+- **Action**: I broke the architecture down, diagrammed it, and mapped every
   bottleneck. I documented each proposed enhancement with its rationale, and ran daily
   standups to keep everyone aligned on progress.
-- **Result** — Within a month we took it from ~50 to ~680 images per second. The
+- **Result**: Within a month we took it from ~50 to ~680 images per second. The
   methodical, transparent approach rebuilt the customer's trust, cleared their backlog,
   and opened the door to several follow-on projects.
 
-That one story credibly covers three principles — which is the goal. Strong stories
+That one story credibly covers three principles, which is the goal. Strong stories
 are reusable across principles; you reframe the emphasis to fit the question.
 
 ### A reuse story (Invent and Simplify / Ownership)
 
-- **Situation** — Across many projects I kept solving the same underlying problem: the
+- **Situation**: Across many projects I kept solving the same underlying problem: the
   same pattern of insights, feedback, and evolving profiles, re-implemented each time.
-- **Task** — Take ownership of the recurring problem and convince leadership to
+- **Task**: Take ownership of the recurring problem and convince leadership to
   dedicate resources to solving it once, properly.
-- **Action** — Built proof-of-concepts that showed technical leaders where the reuse
+- **Action**: Built proof-of-concepts that showed technical leaders where the reuse
   potential was, and quantified the time and code that a standardized approach would
   save.
-- **Result** — The standardized components ended up used across teams, and the effort
+- **Result**: The standardized components ended up used across teams, and the effort
   pinned down the definition of a previously ambiguous, overloaded term inside the org.
 
 ## Putting it together

--- a/bytesofpurpose-blog/blog/2021-10-04-a-learning-plan-for-java.mdx
+++ b/bytesofpurpose-blog/blog/2021-10-04-a-learning-plan-for-java.mdx
@@ -1,7 +1,7 @@
 ---
 slug: a-learning-plan-for-java
 title: "A Learning Plan for Java"
-description: "What to know to be effective in Java beyond the language itself — the libraries, concurrency model, and Spring ecosystem worth learning, with curated resources."
+description: "What to know to be effective in Java beyond the language itself: the libraries, concurrency model, and Spring ecosystem worth learning, with curated resources."
 authors: [oeid]
 tags: [backend, software-engineering, java, learning-plan]
 date: 2021-10-04
@@ -66,4 +66,4 @@ on the job.
 
 ---
 
-> This roadmap is curated from my own running notes on Java. The resource lists are a living collection — they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.
+> This roadmap is curated from my own running notes on Java. The resource lists are a living collection: they're maintained as data, so the list grows without the post changing. Dead links from the original notes have been pruned.

--- a/bytesofpurpose-blog/blog/2026-01-28-what-makes-something-a-process.md
+++ b/bytesofpurpose-blog/blog/2026-01-28-what-makes-something-a-process.md
@@ -1,15 +1,15 @@
 ---
 slug: what-makes-something-a-process
 title: "What Makes Something a Process"
-description: "A small framework for thinking about personal and software processes — what a process actually is, the elements every one shares, and how it differs from a workflow or a technique."
+description: "A small framework for thinking about personal and software processes: what a process actually is, the elements every one shares, and how it differs from a workflow or a technique."
 authors: [oeid]
 tags: [software-engineering, best-practices]
 date: 2026-01-28
 draft: true
 ---
 
-I kept using the word "process" for very different things — a checklist, a habit, a
-build pipeline — until I sat down and tried to define it precisely. It turned out to
+I kept using the word "process" for very different things (a checklist, a habit, a
+build pipeline) until I sat down and tried to define it precisely. It turned out to
 be a useful exercise: once you can say what makes something *a process* (as opposed
 to a one-off task or a vague intention), you can tell when you actually have one,
 when you're missing one, and when two of them are quietly fighting each other.
@@ -22,7 +22,7 @@ This is the small framework I landed on.
 
 A process is **the context in which you use your tools**. A tool is a hammer; a
 process is "framing a wall." More precisely, a process **orchestrates multiple
-activities to accomplish an end goal** — and that goal can be either the creation of
+activities to accomplish an end goal**, and that goal can be either the creation of
 an artifact or the fulfillment of an inner state. Processes generally exist to help
 you make or repeat a **big decision** without re-deriving it from scratch every time.
 
@@ -31,22 +31,22 @@ you make or repeat a **big decision** without re-deriving it from scratch every 
 When I write a process down, these are the slots I fill in. If I can't fill them, I
 don't really have a process yet.
 
-- **Purpose** — what goal does it accomplish?
-- **Trigger** — when does the process apply? When do you *enter* it?
-- **Inputs** — what goes into it?
-- **Outputs** — what comes out?
-- **Major questions** — what primary concerns does it address?
-- **Activities** — what steps are involved?
-- **Metrics** — how do you know it's meeting its purpose?
+- **Purpose**: what goal does it accomplish?
+- **Trigger**: when does the process apply? When do you *enter* it?
+- **Inputs**: what goes into it?
+- **Outputs**: what comes out?
+- **Major questions**: what primary concerns does it address?
+- **Activities**: what steps are involved?
+- **Metrics**: how do you know it's meeting its purpose?
 
 ## The attributes that distinguish a process
 
 A real process, as opposed to a task or an intention, has four properties. It must:
 
 1. **Accomplish a certain goal**
-2. **Be repetitive** — you run it more than once
-3. **Be measurable** — you can tell whether it's working
-4. **Be acted on continuously** — it's a living thing, not a one-time event
+2. **Be repetitive**: you run it more than once
+3. **Be measurable**: you can tell whether it's working
+4. **Be acted on continuously**: it's a living thing, not a one-time event
 
 That second and fourth point are what separate a *process* from a *project*. A
 project ends; a process recurs.
@@ -55,11 +55,11 @@ project ends; a process recurs.
 
 These three get used interchangeably, but the distinctions are useful:
 
-- A **technique** is the most tangible and specific — a single concrete way of doing
+- A **technique** is the most tangible and specific: a single concrete way of doing
   one thing.
 - A **process** is higher level: it orchestrates several activities (which may each
   use techniques) toward a goal.
-- A **workflow** is the orchestration mechanism — the order, triggers, and handoffs
+- A **workflow** is the orchestration mechanism: the order, triggers, and handoffs
   by which a process's activities actually run.
 
 So a process is *what* you're trying to accomplish and the activities involved; a
@@ -69,13 +69,13 @@ inside one of them.
 ## Where processes fight: conflict at the handoffs
 
 The most useful insight I got from this was about where processes *break*. Conflicts
-don't usually happen inside an activity — they happen at the **handoffs between
+don't usually happen inside an activity. They happen at the **handoffs between
 them**:
 
 - If the **inputs and outputs aren't clear** at a boundary, you get conflict.
 - If the two sides have **different expectations** at the boundary, you get conflict.
 
-This is exactly **impedance mismatch** in code — the friction when one function hands
+This is exactly **impedance mismatch** in code: the friction when one function hands
 data to another that expected a different shape. Designing a process well is largely
 about making its internal handoffs explicit: each activity's outputs should be
 precisely what the next activity expects as input. When you find a process that keeps
@@ -83,7 +83,7 @@ producing friction, look at the seams, not the steps.
 
 ## How to know you're done
 
-A process also needs a **definition of done** — when do you know you've completed a
+A process also needs a **definition of done**: when do you know you've completed a
 run, and how do you determine completeness? Without it, a process either never ends
 or ends arbitrarily. Pair that with the *breadth vs. depth* question when you're
 designing one: **breadth** asks whether you've covered all the different activities;


### PR DESCRIPTION
## Why

Follow-up to the em-dash entity fix (#205): that PR's entity-aware sweep surfaced ~183 pre-existing **literal** em-dashes (—) across the corpus. This cleans up the reader-facing **prose** subset.

## What changed

- **84 literal em-dashes → context-appropriate punctuation** across 12 blog files (the 2020-2021 learning-plan / questions posts + `2026-01-28-what-makes-something-a-process`). Colon for a definition, comma for a joined clause, parentheses for an aside, per context. A pure 1:1 swap (84 insertions / 84 deletions), meaning preserved exactly.

## Deliberately left (noted, not fixed)

- **96 em-dashes in 30 `.tsx` files** — all verified to sit inside code comments (`//` or `/* */`), NOT reader-facing JSX text or shown strings. The scanner is code-inclusive so it still reports them, but they never reach a reader (same scoping the em-dash hook uses).
- **1 `--` in `docs/craft/software-development/engineering-reading-list.mdx`** — it's the verbatim title of an external article (`Kafka is fast -- I'll use Postgres`). Rewriting it would misquote the source, so it's kept as a faithful quote. **Flagging for your call** if house style should override a quoted title.

## Verification

- 0 literal em-dashes remain in any `.md`/`.mdx` (scanner-verified).
- 0 new `—`, `--`, or `&#8212;`/`&mdash;` introduced (diff added-lines checked).
- Replacements independently spot-checked for readability (e.g. "moving parts — request tokens, access tokens — stop" → "moving parts (request tokens, access tokens) stop").

Done by a subagent, independently verified before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)