### PR TITLE
fix(em-dash): exempt a dash inside a markdown link's [title] text

### DIFF
--- a/.claude/hooks/em-dash-voice-hook.sh
+++ b/.claude/hooks/em-dash-voice-hook.sh
@@ -13,7 +13,8 @@
 # DODGE this hook. That is a workaround, not a fix — it reads as a typo and still carries
 # the same AI-dash cadence. So a "--" used as a clause/sentence dash is flagged the same
 # way. (Legitimate "--" is NOT flagged: CLI flags like --port, YAML/markdown "---" rules,
-# HTML "<!-- -->" comments, and anything inside a fenced ``` code block.)
+# HTML "<!-- -->" comments, anything inside a fenced ``` code block, and a dash inside a
+# markdown link's [title] text, which is often the verbatim title of an external article.)
 #
 # SCOPE: user-facing content only —
 #   - prose: bytesofpurpose-blog/{docs,blog,designs,changelog}/**.{md,mdx}
@@ -85,11 +86,18 @@ hits=$(awk -v mode="$in_scope" '
 
     flagged=0; reason=""
 
+    # Strip markdown-link DISPLAY TEXT (the [title] / ![alt] bracket text) before dash scanning:
+    # a dash inside a link label is a quoted external title (a faithful reproduction), not the
+    # authors AI-voice cadence. Blinds detection to bracket contents ONLY; a dash in prose or the
+    # (url) still flags. (awk: "[^]]" = any char except "]".)
+    scan=line
+    gsub(/!?\[[^]]*\]/, "", scan)
+
     # 0) em-dash HTML entities — &#8212; (decimal), &#x2014; (hex), &mdash; (named). These
     # RENDER as an em-dash, so they are the same AI-voice tell wearing an entity disguise
     # (the mermaid-label bypass the author-mermaid skill used to recommend). Flag them
     # EVERYWHERE, including inside a mermaid fence (labels are reader-facing).
-    if (line ~ /&#8212;|&#[xX]0*2014;|&mdash;/) {
+    if (scan ~ /&#8212;|&#[xX]0*2014;|&mdash;/) {
       flagged=1; reason="em-dash entity"
     }
 
@@ -98,14 +106,14 @@ hits=$(awk -v mode="$in_scope" '
     if (infence && !inmermaid) { if (flagged) { } else next }
 
     # 1) em-dash U+2014 (literal char) — reader-facing everywhere, incl. mermaid labels
-    if (index(line, "\xE2\x80\x94") > 0) { flagged=1; reason=(reason=="" ? "em-dash" : reason " + em-dash") }
+    if (index(scan, "\xE2\x80\x94") > 0) { flagged=1; reason=(reason=="" ? "em-dash" : reason " + em-dash") }
 
     # Inside a mermaid fence, stop here: the "--" checks below would false-fire on mermaid
     # edge syntax (-->, ---, --). Only the em-dash char + entities apply to mermaid.
     if (inmermaid) { if (flagged) { printf "  L%d [%s]: %s\n", NR, reason, (length(raw)>120?substr(raw,1,117) "...":raw); } next }
 
-    # 2) "--" bypass — scan a SANITIZED copy of the line
-    s=line
+    # 2) "--" bypass — scan a SANITIZED copy of the (link-title-stripped) line
+    s=scan
     # drop inline code spans `...`
     gsub(/`[^`]*`/, "", s)
     # drop html comments <!-- ... -->
@@ -157,7 +165,8 @@ count=$(printf '%s\n' "$hits" | grep -c .)
   echo "occurrence, offering: replace with a comma · a colon · split into two sentences"
   echo "(period) · parentheses · keep as-is. Apply the user's choice, then continue."
   echo "(Flagged: U+2014 \"—\" and \"--\" used as a sentence dash. A lone hyphen, en-dash,"
-  echo " CLI flags like --port, \"---\" rules, <!-- comments -->, and fenced code are NOT flagged.)"
+  echo " CLI flags like --port, \"---\" rules, <!-- comments -->, fenced code, and a dash inside"
+  echo " a markdown link's [title] (a quoted external title) are NOT flagged.)"
 } >&2
 
 exit 2

--- a/bytesofpurpose-blog/scripts/validate-em-dash.js
+++ b/bytesofpurpose-blog/scripts/validate-em-dash.js
@@ -19,7 +19,8 @@
  * rule is the same AI-voice anti-pattern wearing a disguise). The "--" matcher mirrors the
  * hook: it flags "--" only when it reads as a prose dash (" -- " spaced, or "word-- "
  * attached-before) and SKIPS legitimate "--": CLI flags (--port), "---" rules / frontmatter
- * delimiters, "<!-- -->" comments, and fenced ``` code blocks. (The em-dash check stays
+ * delimiters, "<!-- -->" comments, fenced ``` code blocks, and a dash inside a markdown link's
+ * [title] text (a quoted external title). (The em-dash check stays
  * code-inclusive; the "--" check is code-aware because "--" is common+legitimate in code.)
  * Only U+2014 ("—") and the "--" bypass are flagged; en-dash (–) and a lone hyphen (-) are fine.
  *
@@ -80,8 +81,18 @@ files.sort();
 
 // "--" bypass: does this (code-sanitized, non-rule) line use "--" as a prose dash?
 // Mirrors em-dash-voice-hook.sh.
+// Strip the DISPLAY TEXT of a markdown link/image (`[title]` / `![alt]`) from a line before
+// dash scanning. The bracket text of a link is a LABEL — often the verbatim title of an
+// external article — so a dash there is a faithful quote, not the author's AI-voice cadence.
+// This blinds the scanner to bracket contents ONLY; a dash anywhere else on the line (prose,
+// or the (url)) still flags. Example: `[Kafka is fast -- I'll use Postgres](https://…)` is
+// exempt, but `foo -- bar [x](y)` still trips.
+function stripLinkTitles(line) {
+  return line.replace(/!?\[[^\]]*\]/g, '');
+}
+
 function hasDashBypass(line) {
-  let s = line;
+  let s = stripLinkTitles(line);
   s = s.replace(/`[^`]*`/g, ''); // drop inline code spans
   s = s.replace(/<!--/g, '').replace(/-->/g, ''); // drop html comment markers
   const collapsed = s.replace(/\s/g, '');
@@ -108,11 +119,15 @@ for (const file of files) {
     const trimmed = line.trimStart();
     const isFenceToggle = /^(```|~~~)/.test(trimmed);
 
-    const emCount = line.includes(EM_DASH) ? line.split(EM_DASH).length - 1 : 0;
+    // Scan with markdown-link DISPLAY TEXT stripped: a dash inside `[title]` is a quoted
+    // external title (a faithful reproduction), not the author's AI-voice cadence. A dash
+    // anywhere else on the line still flags.
+    const scanLine = stripLinkTitles(line);
+    const emCount = scanLine.includes(EM_DASH) ? scanLine.split(EM_DASH).length - 1 : 0;
     // Em-dash HTML entities (&#8212; decimal, &#x2014; hex, &mdash; named) RENDER as an
     // em-dash, so they are the same AI-voice tell in disguise. Common inside mermaid labels
     // (the old bypass). Code-inclusive like the em-dash check.
-    const entityCount = (line.match(/&#8212;|&#[xX]0*2014;|&mdash;/g) || []).length;
+    const entityCount = (scanLine.match(/&#8212;|&#[xX]0*2014;|&mdash;/g) || []).length;
     const dashBypass = !inFence && !isFenceToggle && hasDashBypass(line);
 
     if (isFenceToggle) inFence = !inFence;


### PR DESCRIPTION
## Why

You decided external article titles should stay **verbatim**. But a title like `Kafka is fast -- I'll use Postgres` (a real blog post) contains a `--`, so `validate-em-dash` + the em-dash hook kept flagging it forever and would nag on any future edit to that file. A guard that cries wolf on a decision you've deliberately ruled correct erodes the guard. This encodes the exemption so the decision isn't re-litigated every scan.

## What changed

A dash inside a markdown link's **display text** (`[title]` / `![alt]`) is now exempt in both guards. The bracket text of a link is a label, often the verbatim title of an external article, so a dash there is a faithful quote, not the author's AI-voice cadence. The exemption is narrow: a dash in surrounding **prose** or in the `(url)` still flags.

- **`validate-em-dash.js`** — new `stripLinkTitles()` applied before the em-dash-char, entity, and `--` checks.
- **`em-dash-voice-hook.sh`** — same carve-out in the awk (strip `[title]` into a `scan` copy).
- Both guards' exemption-list docs updated.

The `[Kafka is fast -- I'll use Postgres]` line was the **one remaining `--` finding** in the whole corpus; the reading list now reports clean.

## Verification

Proven with a **5-case truth table on BOTH guards**:

| Case | Expect | Result |
|---|---|---|
| `--` inside a link `[title]` | exempt | ✅ clean |
| em-dash char inside a link `[title]` | exempt | ✅ clean |
| `--` in prose | flag | ✅ flags |
| `--` in prose on a line that ALSO has a link | flag | ✅ flags (only `[title]` exempt) |
| em-dash char in prose | flag | ✅ flags |

Plus: the `.tsx` code-comment count is unchanged (96, no regression), 0 entity findings, and the real `engineering-reading-list.mdx` is clean.

> Note: an errant backtick in a code comment first broke the hook's shell parsing (it exited 2 on every file, which would have blocked *all* doc edits). The truth table caught it before commit; fixed by removing the backticks from the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)