### PR TITLE
fix(self-healing-storefront): remove the 3rd duplicate use-case diagram + doc artifact-driven dev

### DIFF
--- a/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
+++ b/.claude/skills/refine-design-post/SECTION-QUESTIONS.md
@@ -164,7 +164,11 @@ the road" recipe). One direction needs no fork; two or more do. Propose it; `aut
   buried persona-mermaid showed, that buried mermaid is now duplication ("state a thing once") — delete
   it and point up to the opener; keep only the parts that add MORE than the opener (e.g. a personas
   table that also lists the system actors). A distill-up that leaves both is a self-inflicted "same
-  thing twice" finding. — [self-healing-storefront.mdx]
+  thing twice" finding. **SWEEP FOR ALL of them:** a thorough post can carry the same use-case view
+  THREE times (a §1.4 persona-wants mermaid, a §8 "Use Cases" diagram, a §10.2 "Use Case Diagram") —
+  after adding the opener, grep the whole post for every actor→use-case mermaid and remove each, not
+  just the first one you spot. Keep only the non-duplicative DETAIL (a personas table, an
+  actor→goal→flow list). — [self-healing-storefront.mdx]
 
 ## Notes for the auditor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,22 @@ kind (the `draft-docs` plugin's docs kind-emoji wiring), so its title carries no
 The owning skill is **`manage-hubs`** (the hub registry, the generic generator+component pattern,
 the add-a-hub checklist); this convention is the enforcement.
 
+## ⚠️ Operating convention: artifact-driven development — mock the component, get sign-off, THEN build
+
+When you decide to build a **new frontend / blog-ui component** (or a non-trivial change to one's
+look or API), **do NOT jump straight to code**. First make an **artifact** (a self-contained HTML
+mock via the Artifact tool) that shows the component's LOOK, its BEHAVIOR (with a working mini-demo of
+the key interaction), its proposed **MDX API**, and **how it relates to existing components** (so we
+don't build a near-duplicate of, say, `ComparisonMatrix`). Publish it, get the user's **sign-off on
+the artifact**, iterate on the artifact from their feedback, and only THEN implement the real
+component. A mock is cheap to change; a built-and-linked blog-ui component is not. Ground the artifact
+in the repo's own design system (the `custom.css` tokens, Fraunces/Geist, brand-green) so the mock
+reads as native, not templated (see `artifact-design` + `implement-with-design-system`). The loop is
+**mock → approve → build → the visual+mobile pass below → showcase**. Worked example: the
+`<DecisionTable>` spec artifact was reviewed and refined (a status-hover tooltip was added from user
+feedback) before a single line of the real component was written. Owning skills: `modify-blog-ui-component`,
+`maintain-showcase`; the pass that CLOSES the loop is the next convention.
+
 ## ⚠️ Operating convention: every new interactive component gets a visual + mobile pass
 
 A component that **renders content or takes input** (a board, a modal, a card, a chart, a

--- a/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
+++ b/bytesofpurpose-blog/designs/2026-06-22-self-healing-storefront.mdx
@@ -861,31 +861,7 @@ graph LR
 
 ## 8. Use Cases
 
-The primary use cases, derived from the personas (§1.4). Squares are actors, circles are use cases; dashed arrows show one use case triggering another.
-
-```mermaid
-graph LR
-    OWNER[Store Owner]
-    OP[Operator]
-    AGENT[Experimentation Agent]
-
-    OWNER --> UC1((Connect store<br/>& set autonomy/guardrails))
-    OWNER --> UC2((Approve a gated<br/>pricing/checkout test))
-    OWNER --> UC3((Read wins ledger<br/>/ pause everything))
-    OP --> UC4((Supervise portfolio<br/>& override))
-    OP --> UC5((Tune ideation engine))
-    AGENT --> UC6((Ideate & prioritize<br/>hypotheses))
-    AGENT --> UC7((Generate variants))
-    AGENT --> UC8((Run experiment<br/>on live traffic))
-    AGENT --> UC9((Decide ship/kill<br/>& attribute lift))
-
-    UC6 -.-> UC7 -.-> UC8 -.-> UC9
-    UC9 -.-> UC2
-    UC9 -.-> UC3
-
-```
-
-**Key use cases (actor → goal → flow):**
+The use-case *diagram* (who drives what) is the [`<UseCaseDiagram>` in the opener](#who-its-for-and-what-they-do-with-it). This section is the detail behind it: each use case as **actor → goal → flow**.
 
 - **UC1: Onboard a store** *(Store Owner)* → start getting safe, automated experiments → connect store, pick autonomy tier, set revenue floor / brand rules / no-touch zones.
 - **UC2: Approve a gated experiment** *(Store Owner)* → allow a higher-risk pricing/checkout test → review the agent's proposed change + expected impact on a single approve/decline card.


### PR DESCRIPTION
## Why

You still saw duplicative use-case diagrams after #210. Correct: the distill-up in #210 removed the §1.4 and §10.2 duplicates but **missed §8 "Use Cases"** — a third actor→use-case mermaid duplicating the opener `<UseCaseDiagram>`. This removes it and hardens the rule so it can't recur.

## What changed

- **Removed the §8 mermaid** (the opener's `<UseCaseDiagram>` covers it). **Kept** its "Key use cases (actor → goal → flow)" list — the detail the diagram lacks — and reframed §8 as that detail behind the opener. Now exactly **one** canonical use-case diagram; §1.4 (personas table), §8 (actor→goal→flow), §10.2 (pointer) are non-duplicative supporting reference.
- **SECTION-QUESTIONS.md**: sharpened the distill-up rule — **sweep for ALL duplicate views** (a thorough post can carry the same use-case view 3× across §1.4/§8/§10.2); grep the whole post, don't stop at the first.
- **CLAUDE.md**: new operating convention **"artifact-driven development"** — mock a new frontend component as an artifact, get sign-off, THEN build (the loop the `<DecisionTable>` spec followed).

## Verification

- **0** `actor→use-case` mermaid duplicates remain (grep-confirmed); 1 real `<UseCaseDiagram>` (the opener).
- 0 em-dash, fences balanced (28), route 200, compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)