### PR TITLE
fix(blog-ui): stabilize Walkthrough transport + quiet the Assumption tag

### DIFF
--- a/packages/blog-ui/src/components/Assumption/styles.module.css
+++ b/packages/blog-ui/src/components/Assumption/styles.module.css
@@ -1,37 +1,45 @@
-/* Assumption — amber inline highlight flagging an unvalidated premise for review. */
+/* Assumption — a quiet inline marker flagging an unvalidated premise for review.
+   ONE signal, not two: a soft amber tint on the text with a small leading label. No filled
+   pill, no raised border (that read as a clunky button); the tint carries the "review this". */
 
 .assumption {
-  background: color-mix(in srgb, #f6c343 38%, transparent);
-  border-bottom: 2px solid #e0a000;
-  border-radius: 3px;
-  padding: 0.05rem 0.3rem;
-  color: inherit; /* keep the page text color; the highlight carries the signal */
+  background: color-mix(in srgb, #f6c343 16%, transparent);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.08em 0.35em;
+  /* nudge the whole marker to sit on the text baseline instead of riding high */
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  color: inherit;
 }
 
+/* A small, unobtrusive label. Lowercase, not a shouty filled pill: a hairline amber outline
+   + amber ink, so it annotates rather than competes with the sentence. */
 .tag {
-  display: inline-block;
-  margin-right: 0.4rem;
-  padding: 0 0.35rem;
-  border-radius: 4px;
-  background: #e0a000;
-  color: #2b2200;
-  font-size: 0.7em;
+  display: inline;
+  margin-right: 0.35em;
+  padding: 0 0.3em;
+  border: 1px solid color-mix(in srgb, #e0a000 55%, transparent);
+  border-radius: 100px;
+  background: transparent;
+  color: #a06a00;
+  font-size: 0.66em;
   font-weight: 700;
+  font-style: normal;
   text-transform: uppercase;
-  letter-spacing: 0.03em;
-  vertical-align: baseline;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  vertical-align: 0.08em; /* small lift so the tiny caps center on the body text */
 }
 
 .body {
   font-style: italic;
 }
 
-/* Dark mode: a deeper amber that still reads as "highlighted to review". */
+/* Dark mode: a slightly stronger tint + a lighter amber so it still reads as "to review". */
 [data-theme='dark'] .assumption {
-  background: color-mix(in srgb, #f6c343 22%, transparent);
-  border-bottom-color: #f6c343;
+  background: color-mix(in srgb, #f6c343 14%, transparent);
 }
 [data-theme='dark'] .tag {
-  background: #f6c343;
-  color: #241c00;
+  border-color: color-mix(in srgb, #f6c343 50%, transparent);
+  color: #f0c860;
 }

--- a/packages/blog-ui/src/components/Walkthrough/index.tsx
+++ b/packages/blog-ui/src/components/Walkthrough/index.tsx
@@ -286,8 +286,60 @@ const Walkthrough: React.FC<WalkthroughProps> = ({
   const typedText = typed?.text || '';
   const typedSel = typed?.sel || '';
 
+  // The timeline (progress rail + one dot per step, a marker that slides to the active step).
+  // Rendered ABOVE the scene so it stays anchored: a scene's height varies per step (a tall
+  // mock vs a short one), and controls chained below it would jump vertically as you advance.
+  const n = steps.length;
+  const pct = (i: number) => (n <= 1 ? 50 : (i / (n - 1)) * 100);
+  const activePct = activeStep < 0 ? 0 : pct(activeStep);
+  const timelineAndControls = (
+    <div className={styles.transport}>
+      <div className={styles.controls}>
+        <button
+          type="button"
+          className={styles.playBtn}
+          onClick={() => {
+            if (playing) {
+              // PAUSE: stop the animation in place.
+              clearTimers();
+              setPlaying(false);
+              loopingRef.current = false;
+            } else {
+              // RESTART: the player isn't resumable mid-step (the sequence is imperative),
+              // so this honestly restarts from the top — which loop()/play() already does.
+              loopingRef.current = false;
+              loop();
+            }
+          }}
+          aria-label={playing ? 'Pause walkthrough' : 'Restart walkthrough'}>
+          {playing ? '❚❚ Pause' : '↺ Restart'}
+        </button>
+        <span className={styles.caption}>{caption}</span>
+      </div>
+      <div className={styles.timeline} aria-label="Walkthrough progress">
+        <div className={styles.tlRail} />
+        <div className={styles.tlFill} style={{width: `${activePct}%`}} />
+        {steps.map((s, i) => (
+          <span
+            key={i}
+            className={clsx(
+              styles.tlDot,
+              i < activeStep && styles.tlDone,
+              i === activeStep && styles.tlActive
+            )}
+            style={{left: `${pct(i)}%`}}
+            title={s.say || `Step ${i + 1}`}
+            aria-current={i === activeStep ? 'step' : undefined}
+          />
+        ))}
+        <span className={styles.tlMarker} style={{left: `${activePct}%`}} />
+      </div>
+    </div>
+  );
+
   return (
     <div ref={rootRef} className={clsx(styles.walkthrough, className)} style={style}>
+      {timelineAndControls}
       <div className={styles.viewport}>
         {/* APP scene */}
         <div
@@ -368,59 +420,6 @@ const Walkthrough: React.FC<WalkthroughProps> = ({
             {node}
           </div>
         ))}
-      </div>
-
-      {/* timeline: a continuous rail with one dot per step at an even position; a fill
-          bar + a single marker that SLIDES to the active step, so the viewer follows one
-          moving "you are here" along the sequence. Dots are inset from both ends so the
-          first/last are centered, not clipped. */}
-      {(() => {
-        const n = steps.length;
-        const pct = (i: number) => (n <= 1 ? 50 : (i / (n - 1)) * 100);
-        const activePct = activeStep < 0 ? 0 : pct(activeStep);
-        return (
-          <div className={styles.timeline} aria-label="Walkthrough progress">
-            <div className={styles.tlRail} />
-            <div className={styles.tlFill} style={{width: `${activePct}%`}} />
-            {steps.map((s, i) => (
-              <span
-                key={i}
-                className={clsx(
-                  styles.tlDot,
-                  i < activeStep && styles.tlDone,
-                  i === activeStep && styles.tlActive
-                )}
-                style={{left: `${pct(i)}%`}}
-                title={s.say || `Step ${i + 1}`}
-                aria-current={i === activeStep ? 'step' : undefined}
-              />
-            ))}
-            <span className={styles.tlMarker} style={{left: `${activePct}%`}} />
-          </div>
-        );
-      })()}
-
-      <div className={styles.controls}>
-        <button
-          type="button"
-          className={styles.playBtn}
-          onClick={() => {
-            if (playing) {
-              // PAUSE: stop the animation in place.
-              clearTimers();
-              setPlaying(false);
-              loopingRef.current = false;
-            } else {
-              // RESTART: the player isn't resumable mid-step (the sequence is imperative),
-              // so this honestly restarts from the top — which loop()/play() already does.
-              loopingRef.current = false;
-              loop();
-            }
-          }}
-          aria-label={playing ? 'Pause walkthrough' : 'Restart walkthrough'}>
-          {playing ? '❚❚ Pause' : '↺ Restart'}
-        </button>
-        <span className={styles.caption}>{caption}</span>
       </div>
     </div>
   );

--- a/packages/blog-ui/src/components/Walkthrough/styles.module.css
+++ b/packages/blog-ui/src/components/Walkthrough/styles.module.css
@@ -168,10 +168,16 @@
    marker that SLIDES (with a slight bounce) to the active step. The inner band is inset
    from both ends (left/right margin = the dot radius) so the first/last dots are centered
    on the rail, not clipped at the edge. Dots/fill/marker are positioned by `left: %`. */
+/* the transport (controls + progress) sits ABOVE the scene so it stays put as scene height
+   varies per step; the scene's dynamic height only ever pushes content DOWN, never the bar. */
+.transport {
+  margin-bottom: 0.9rem;
+}
+
 .timeline {
   position: relative;
   height: 16px;
-  margin: 0.8rem 7px 0; /* 7px end-inset centers the first/last dot */
+  margin: 0 7px; /* 7px end-inset centers the first/last dot; no vertical margin (transport spaces it) */
 }
 .tlRail {
   position: absolute;
@@ -233,7 +239,7 @@
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  margin-top: 0.5rem;
+  margin-bottom: 0.5rem; /* space between the controls and the progress rail below them */
 }
 .playBtn {
   flex: 0 0 auto;


### PR DESCRIPTION
Two visual fixes from a browser review of `self-healing-storefront`, both **general blog-ui component enhancements** (they improve every use of these components site-wide).

## 1. Walkthrough: controls no longer jump

**Before:** the progress rail + Pause/caption controls were rendered **below** the scene. Because each step's mock has a different height (a tall wins-ledger vs a short scanner mock), the controls floated at different vertical positions as you stepped through — jumping under the cursor.

**Fix:** moved the transport (controls + progress rail) **above** the scene in a new `.transport` wrapper. The scene's dynamic height now only ever pushes content *down*, never the control. Verified in the browser stepping through mocks of varying height.

## 2. Assumption: a quiet annotation, not a raised pill

**Before:** the inline `<Assumption>` tag read as a clunky raised gold button — a filled amber pill + an amber highlight + a 2px bottom border stacked into a doubled, 3D-looking signal.

**Fix:** one quiet signal instead of two — a soft amber text tint + a small **hairline-outlined** label (transparent fill), baseline-aligned, with `box-decoration-break: clone` for clean multi-line wrapping. It now annotates the text instead of competing with it.

## Verification

- blog-ui builds clean (ESM + DTS).
- **Both fixes confirmed rendered in the browser** (the concurrent chrome lock cleared, so I got a real look): the Walkthrough controls sit above a mock, and the Assumption tag is a subtle outlined label in the §2.3 table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)