### PR TITLE
feat(validate): two-tier mermaid legibility system (cheap per-edit + heavy per-session)

### DIFF
--- a/.claude/hooks/mermaid-render-check.sh
+++ b/.claude/hooks/mermaid-render-check.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Stop hook: the HEAVY mermaid legibility check, run once at session end (not per edit).
+#
+# The cheap per-edit hook (validate-mermaid-complexity) scores a fence by TEXT metrics. This
+# one actually HEADLESS-RENDERS the mermaid diagrams CHANGED this session (via Playwright) and
+# flags what text can't see: a diagram that fails to render, whose nodes overlap, or that
+# renders far too tall/wide to read. It is git-gated + scoped to changed files so it only runs
+# when a session actually touched a design/blog diagram, and stays fast otherwise. Advisory:
+# always exits 0, never blocks the Stop.
+
+proj="${CLAUDE_PROJECT_DIR:-$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)}"
+[ -n "$proj" ] || exit 0
+script="$proj/bytesofpurpose-blog/scripts/validate-mermaid-render.mjs"
+[ -f "$script" ] || exit 0
+
+# Gate 1: did this session change a design/blog/docs .md(x) that CONTAINS a mermaid fence?
+# (Cheap git check first — never launch Chromium unless a real diagram changed.) Includes
+# untracked (new) files, which `git diff HEAD` omits — a brand-new diagram post must count.
+changed=$(
+  {
+    git -C "$proj" diff --name-only HEAD -- bytesofpurpose-blog 2>/dev/null
+    git -C "$proj" ls-files --others --exclude-standard -- bytesofpurpose-blog 2>/dev/null
+  } \
+  | grep -E '\.(md|mdx)$' \
+  | grep -E '/(designs|blog|docs)/' \
+  | grep -v '/_' | sort -u || true)
+[ -n "$changed" ] || exit 0
+
+# Of those, keep only the ones that actually contain a ```mermaid fence.
+have_mermaid=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if grep -q '```mermaid' "$proj/$f" 2>/dev/null; then
+    have_mermaid="yes"
+    break
+  fi
+done <<< "$changed"
+[ -n "$have_mermaid" ] || exit 0
+
+# Run the heavy render check on just the changed files. It prints its own warnings to stderr;
+# surface them, but never block (exit 0 regardless).
+out=$(cd "$proj/bytesofpurpose-blog" && node "$script" --changed 2>&1)
+case "$out" in
+  *"[warn:mermaid-render-"*)
+    printf '%s\n' "$out" >&2
+    printf '\n(heavy mermaid render check, session end — advisory, does not block.)\n' >&2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/validate-mermaid-complexity-hook.sh
+++ b/.claude/hooks/validate-mermaid-complexity-hook.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# PostToolUse hook for Edit|Write: WARN (never block) when a hand-authored mermaid flow
+# diagram is too dense to read (a 40-node flowchart, a node fanning out to eight others).
+# A ```mermaid ``` fence has no legibility gate (unlike <FlowDiagram>/<UseCaseDiagram>,
+# which gate their own layout), so this nudges the author to split it, collapse a subgraph,
+# or reach for <FlowDiagram>. Cheap TEXT metrics (node/edge/fan-out), not a render.
+#
+# Sibling of validate-visual-density-hook.sh (warn-tier). Pairs with
+# scripts/validate-mermaid-complexity.js + the author-mermaid / upgrade-post skills.
+
+input=$(cat)
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+
+case "$file_path" in
+  *.md|*.mdx) ;;
+  *) exit 0 ;;
+esac
+case "$file_path" in
+  */bytesofpurpose-blog/docs/*|*/bytesofpurpose-blog/blog/*|*/bytesofpurpose-blog/designs/*) ;;
+  *) exit 0 ;;
+esac
+[ -f "$file_path" ] || exit 0
+
+# Skip sidecar/partials (filenames starting with _).
+case "$(basename "$file_path")" in
+  _*) exit 0 ;;
+esac
+
+# Fast pre-check: no mermaid fence → nothing to score, skip spawning node.
+grep -q '```mermaid' "$file_path" 2>/dev/null || exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+script="$proj/bytesofpurpose-blog/scripts/validate-mermaid-complexity.js"
+[ -f "$script" ] || exit 0
+
+out=$(node "$script" "$file_path" 2>&1)
+case "$out" in
+  *"[warn:mermaid-dense]"*)
+    printf '%s\n' "$out" >&2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-mermaid-complexity-hook.sh\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-feature-docs-hook.py\"",
             "timeout": 30
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -181,6 +181,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/refine-capture-reminder.sh\"",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/mermaid-render-check.sh\"",
+            "timeout": 90
           }
         ]
       }

--- a/.claude/skills/author-mermaid/SKILL.md
+++ b/.claude/skills/author-mermaid/SKILL.md
@@ -51,6 +51,15 @@ flowchart LR
 > ignore it: split the diagram, collapse a `subgraph` into a single node, or switch to `<FlowDiagram>`
 > (a nodes/edges spec that gates its own layout). Only flow diagrams are scored; sequence/ER/class/
 > state/timeline/mindmap lay themselves out and are skipped.
+>
+> **The heavier check (session end).** The text metrics above can't see a diagram that is few-node
+> but still renders huge. So a second, HEAVIER tier — `scripts/validate-mermaid-render.mjs`
+> (`make validate-mermaid-render`, `--changed` for git-scoped) + the `Stop` hook
+> `mermaid-render-check.sh` — actually HEADLESS-RENDERS the changed flow diagrams with Playwright at
+> session end and flags what the source text can't: a **render-fail** (a syntax error the draft-only
+> client render hides until publish), **overlapping nodes**, or an **oversize** render (>1600px tall /
+> >3000px wide, an illegible thumbnail). Git-gated to changed diagrams and non-blocking; it only runs
+> when a session actually touched one. Two tiers: cheap-per-edit (text) + heavy-per-session (render).
 
 ### architecture-beta (system/infra topology)
 Declaration `architecture-beta`; `group id(icon)[Title]`; `service id(icon)[Title] in group`;

--- a/.claude/skills/author-mermaid/SKILL.md
+++ b/.claude/skills/author-mermaid/SKILL.md
@@ -43,6 +43,15 @@ flowchart LR
   A[Discover] --> B[Scan] --> C[Score] --> D[Draft]
 ```
 
+> **Keep a flowchart legible — the complexity guard.** A hand-authored ```mermaid ``` fence
+> has NO layout gate (unlike `<FlowDiagram>`/`<UseCaseDiagram>`, which fail the build on a tangled
+> layout). A warn-tier check, `scripts/validate-mermaid-complexity.js` (`make validate-mermaid-complexity`)
+> + the PostToolUse `validate-mermaid-complexity-hook.sh`, nudges (never blocks) when a `graph`/`flowchart`
+> gets too dense to read: **>20 nodes, >24 edges, or one node fanning out to 7+**. When it fires, don't
+> ignore it: split the diagram, collapse a `subgraph` into a single node, or switch to `<FlowDiagram>`
+> (a nodes/edges spec that gates its own layout). Only flow diagrams are scored; sequence/ER/class/
+> state/timeline/mindmap lay themselves out and are skipped.
+
 ### architecture-beta (system/infra topology)
 Declaration `architecture-beta`; `group id(icon)[Title]`; `service id(icon)[Title] in group`;
 edges `id:DIR --> DIR:id` where DIR is `T|B|L|R`. Built-in icons: `cloud database disk internet server`.

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ validate-questions: ## Lint the optional `questions:` frontmatter (present → m
 validate-visual-density: ## Nudge: flag H2 sections that run long (>280 words) with no visual (advisory — a picture is worth a thousand words)
 	( cd ${SITEROOT} && node scripts/validate-visual-density.js $(DIRS) )
 
+validate-mermaid-complexity: ## Nudge: flag a hand-authored mermaid flow diagram too dense to read (>20 nodes / >24 edges / a node fanning to 7+) — split it or use <FlowDiagram>
+	( cd ${SITEROOT} && node scripts/validate-mermaid-complexity.js $(DIRS) )
+
 validate-design-clarity: ## Nudge: mechanical clarity/leak tells in /designs posts (trailing "…", verbatim dupes, banned proprietary terms, thin sections, ascii-redraw of a mermaid) — the greppable half of the refine-design-post skill
 	@# The banned-term list is SENSITIVE, so it lives ONLY in the gitignored .env (key DESIGN_LEAK_TERMS),
 	@# NOT in git. Extract it per-var (NOT `source .env` — shell-special chars) and export it for the

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ validate-visual-density: ## Nudge: flag H2 sections that run long (>280 words) w
 validate-mermaid-complexity: ## Nudge: flag a hand-authored mermaid flow diagram too dense to read (>20 nodes / >24 edges / a node fanning to 7+) — split it or use <FlowDiagram>
 	( cd ${SITEROOT} && node scripts/validate-mermaid-complexity.js $(DIRS) )
 
+validate-mermaid-render: ## HEAVY: headless-render mermaid flow diagrams (Playwright) to catch what text metrics can't — render-fail, overlapping nodes, oversize. Add --changed for git-scoped. Also the session-end Stop hook.
+	( cd ${SITEROOT} && node scripts/validate-mermaid-render.mjs $(DIRS) )
+
 validate-design-clarity: ## Nudge: mechanical clarity/leak tells in /designs posts (trailing "…", verbatim dupes, banned proprietary terms, thin sections, ascii-redraw of a mermaid) — the greppable half of the refine-design-post skill
 	@# The banned-term list is SENSITIVE, so it lives ONLY in the gitignored .env (key DESIGN_LEAK_TERMS),
 	@# NOT in git. Extract it per-var (NOT `source .env` — shell-special chars) and export it for the

--- a/bytesofpurpose-blog/scripts/validate-mermaid-complexity.js
+++ b/bytesofpurpose-blog/scripts/validate-mermaid-complexity.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+/**
+ * validate-mermaid-complexity.js — nudge a mermaid flow diagram that is too dense to read.
+ *
+ * The `<UseCaseDiagram>` / `<FlowDiagram>` components enforce a build-time legibility gate
+ * (they compute their own layout, so they can throw on too-many-crossings / a lopsided fan).
+ * A hand-authored ```mermaid ``` fence has NO such gate: a 40-node flowchart or a node
+ * fanning out to eight others renders as spaghetti and nothing catches it. Mermaid lays out
+ * in the browser, so a TRUE crossing check would need a headless render (slow, not
+ * hook-friendly). Instead this uses cheap TEXT metrics that correlate with "unreadable":
+ *
+ *   mermaid-dense   a graph/flowchart fence exceeds a node / edge / fan-out threshold.  [WARN]
+ *
+ * Only `graph` / `flowchart` diagrams are scored (the ones that tangle). Sequence, ER,
+ * class, state, gitGraph, timeline, mindmap, kanban, quadrant, architecture etc. lay
+ * themselves out and are skipped. Thresholds are deliberately set ABOVE the common,
+ * legible 12-16 node diagrams, so this flags only the genuine outliers and won't cry wolf.
+ *
+ * The nudge, when it fires: split the diagram, collapse a subgraph into one node, or reach
+ * for `<FlowDiagram>` (which gates its own layout). See the author-mermaid + upgrade-post
+ * skills.
+ *
+ * Usage:
+ *   node scripts/validate-mermaid-complexity.js [paths…]   # scan (default: blog designs docs)
+ *   node scripts/validate-mermaid-complexity.js --json      # machine-readable findings
+ *   node scripts/validate-mermaid-complexity.js --error-only # exit 2 if any finding (strict gate)
+ *
+ * Exit codes: 0 clean · 1 findings (scan) · 2 findings (--error-only). Advisory: the HOOK
+ * runs it in default (warn) mode and never blocks; `make validate-mermaid-complexity` sweeps.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_DIRS = ['blog', 'designs', 'docs'];
+
+// Thresholds — set above the common legible range (the corpus's typical dense-but-fine
+// diagram is ~12-16 nodes / ~14 edges / fan ~4). A finding fires when ANY is exceeded.
+const MAX_NODES = 20; // more distinct nodes than this is a lot to trace at a glance
+const MAX_EDGES = 24; // more connections than this reads as a web
+const MAX_FANOUT = 7; // one node with this many outgoing edges is a hub that tangles
+
+const isContent = (n) => /\.mdx?$/.test(n) && !path.basename(n).startsWith('_');
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    if (entry.name.startsWith('_') || entry.name === 'node_modules') continue;
+    const fp = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(fp, out);
+    else if (isContent(entry.name)) out.push(fp);
+  }
+  return out;
+}
+
+// The mermaid diagram kinds that lay out as a node graph and can tangle. Everything else
+// (sequence/er/class/state/gitGraph/timeline/mindmap/kanban/quadrant/architecture/C4…)
+// has its own layout and is not scored here.
+const FLOW_KINDS = /^(graph|flowchart)\b/;
+
+// Edge operators in flowchart syntax (solid, dotted, thick, with-or-without a label).
+const EDGE_RE = /--+>|--+|-\.-+>|-\.-+|==+>|==+/g;
+// A node reference is a token immediately followed by a shape bracket: A[, B(, C{, D([, etc.
+const NODE_DECL_RE = /\b([A-Za-z][\w]*)\s*[[({]/g;
+// The source node of an edge (a bare id or a shaped node) at the start of an edge expr.
+const EDGE_SRC_RE = /(?:^|\n)\s*([A-Za-z][\w]*)\b[^\n]*?(?:--+>|--+|-\.-+>|-\.-+|==+>|==+)/g;
+
+/** Score one mermaid body: {kind, nodes, edges, maxFanout, hub}. */
+function scoreMermaid(body) {
+  const lines = body.split('\n');
+  const first = lines.map((l) => l.trim()).find((l) => l && !l.startsWith('%%')) || '';
+  const kind = first.split(/\s+/)[0] || '?';
+  if (!FLOW_KINDS.test(first)) return {kind, skip: true};
+
+  // Distinct node ids (declared with a shape). Undecorated ids that only appear on edges
+  // are also nodes, but counting declared shapes is a stable, conservative proxy.
+  const nodes = new Set();
+  let m;
+  NODE_DECL_RE.lastIndex = 0;
+  while ((m = NODE_DECL_RE.exec(body))) nodes.add(m[1]);
+
+  const edges = (body.match(EDGE_RE) || []).length;
+
+  // Max fan-out: the most outgoing edges from any single source node.
+  const fan = {};
+  EDGE_SRC_RE.lastIndex = 0;
+  while ((m = EDGE_SRC_RE.exec(body))) fan[m[1]] = (fan[m[1]] || 0) + 1;
+  let maxFanout = 0;
+  let hub = '';
+  for (const [id, c] of Object.entries(fan)) {
+    if (c > maxFanout) {
+      maxFanout = c;
+      hub = id;
+    }
+  }
+  return {kind, nodes: nodes.size, edges, maxFanout, hub, skip: false};
+}
+
+function checkFile(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const findings = [];
+  const rel = path.relative(ROOT, file);
+  // Walk every ```mermaid … ``` fence, tracking the line it opens on for reporting.
+  const lines = raw.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    if (/^\s*```mermaid\s*$/.test(lines[i])) {
+      const startLine = i + 1;
+      const bodyLines = [];
+      i++;
+      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+        bodyLines.push(lines[i]);
+        i++;
+      }
+      const s = scoreMermaid(bodyLines.join('\n'));
+      if (!s.skip) {
+        const reasons = [];
+        if (s.nodes > MAX_NODES) reasons.push(`${s.nodes} nodes (> ${MAX_NODES})`);
+        if (s.edges > MAX_EDGES) reasons.push(`${s.edges} edges (> ${MAX_EDGES})`);
+        if (s.maxFanout >= MAX_FANOUT)
+          reasons.push(`node "${s.hub}" fans out to ${s.maxFanout} (>= ${MAX_FANOUT})`);
+        if (reasons.length) {
+          findings.push({
+            file: rel,
+            line: startLine,
+            kind: s.kind,
+            nodes: s.nodes,
+            edges: s.edges,
+            maxFanout: s.maxFanout,
+            detail: reasons.join('; '),
+          });
+        }
+      }
+    }
+    i++;
+  }
+  return findings;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const errorOnly = args.includes('--error-only');
+  const targets = args.filter((a) => !a.startsWith('--'));
+
+  const resolveTarget = (t) => {
+    const abs = path.resolve(t);
+    try {
+      return fs.statSync(abs).isDirectory() ? walk(abs) : [abs];
+    } catch {
+      return [];
+    }
+  };
+  const files = targets.length
+    ? targets.flatMap(resolveTarget)
+    : DEFAULT_DIRS.flatMap((d) => walk(path.join(ROOT, d)));
+
+  const findings = files.flatMap(checkFile);
+
+  if (json) {
+    console.log(JSON.stringify({total: findings.length, findings}, null, 2));
+    process.exit(0);
+  }
+
+  if (!findings.length) {
+    console.log('✅ mermaid complexity: no over-dense flow diagrams found.');
+    process.exit(0);
+  }
+
+  console.error(
+    `🕸️  mermaid complexity: ${findings.length} dense flow diagram(s) in ${
+      new Set(findings.map((f) => f.file)).size
+    } file(s) (warn)`,
+  );
+  for (const f of findings) {
+    console.error(`\n  ${f.file}:${f.line}  [warn:mermaid-dense]`);
+    console.error(`      ↳ ${f.kind} is dense: ${f.detail}`);
+  }
+  console.error(
+    '\n(advice only, not blocking.) A dense hand-authored mermaid has no legibility gate' +
+      '\n(unlike <FlowDiagram>/<UseCaseDiagram>, which gate their own layout). Consider:' +
+      '\nsplit it into two diagrams, collapse a subgraph into one node, or reach for' +
+      '\n<FlowDiagram> (a nodes/edges spec that fails the build on a tangled layout).' +
+      '\nSee the author-mermaid + upgrade-post skills.',
+  );
+  process.exit(errorOnly ? 2 : 1);
+}
+
+main();

--- a/bytesofpurpose-blog/scripts/validate-mermaid-render.mjs
+++ b/bytesofpurpose-blog/scripts/validate-mermaid-render.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// validate-mermaid-render.mjs — the HEAVY, less-frequent mermaid legibility check.
+//
+// The cheap sibling (validate-mermaid-complexity.js) scores a fence by TEXT metrics on every
+// edit. This one does what text can't: it HEADLESS-RENDERS each mermaid diagram with the real
+// mermaid engine (via Playwright's bundled Chromium) and inspects the ACTUAL layout —
+//
+//   render-fail     the diagram fails to render (a mermaid syntax error the draft-only,
+//                   client-rendered page would hide until the post is published).   [WARN]
+//   node-overlap    two node bounding-boxes overlap (they collide / sit on top of
+//                   each other) — a real "unreadable" the source text can't reveal. [WARN]
+//   oversize        the rendered SVG is far wider or taller than a readable page
+//                   column (it will shrink to an illegible thumbnail or scroll off). [WARN]
+//
+// Because a Chromium launch costs ~1-3s, this is NOT a per-edit hook. It is meant to run:
+//   - on session completion, git-gated to the diagrams TOUCHED this session (the Stop hook), or
+//   - deliberately, `make validate-mermaid-render` (optionally over given files).
+// Warn-tier: exit 0 clean · 1 findings. Never blocks.
+//
+// Usage:
+//   node scripts/validate-mermaid-render.mjs [files…]        # render the mermaid in these files
+//   node scripts/validate-mermaid-render.mjs --changed        # only files changed vs HEAD (git)
+//   node scripts/validate-mermaid-render.mjs --json           # machine-readable
+
+import {readFileSync, existsSync} from 'node:fs';
+import {execFileSync} from 'node:child_process';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+// Legibility thresholds for the RENDERED svg (px). Only HEIGHT and EXTREME width are flagged:
+// a `flowchart LR` is naturally wide and the site wraps diagrams in overflow-x:auto, so a wide-
+// but-normal-height diagram scrolls fine — width alone is NOT a problem. A very TALL diagram
+// overflows vertically (tiny text once scaled to fit), and an absurdly wide one won't scroll
+// comfortably either. These are set past the legible corpus (most render < 1000px tall).
+const MAX_H = 1600; // taller than this = vertical overflow / illegible when scaled
+const MAX_W = 3000; // only an EXTREME width (well past normal horizontal scroll) is flagged
+const OVERLAP_TOLERANCE = 4; // px of bbox intersection to ignore (touching borders are fine)
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const changedOnly = args.includes('--changed');
+let files = args.filter((a) => !a.startsWith('--'));
+
+// --changed: the design/blog content files that differ from HEAD (tracked changes AND new
+// untracked files — a brand-new diagram post is exactly when you want the check) that contain
+// a mermaid fence.
+if (changedOnly) {
+  const repoRoot = ROOT.replace(/\/bytesofpurpose-blog$/, '');
+  const gitLines = (cmdArgs) => {
+    try {
+      return execFileSync('git', cmdArgs, {cwd: repoRoot, encoding: 'utf8'})
+        .split('\n')
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+  const list = [
+    ...gitLines(['diff', '--name-only', 'HEAD', '--', 'bytesofpurpose-blog']),
+    // untracked (new) files, which `git diff HEAD` does not list:
+    ...gitLines(['ls-files', '--others', '--exclude-standard', '--', 'bytesofpurpose-blog']),
+  ];
+  files = [...new Set(list)]
+    .filter((f) => /\.mdx?$/.test(f) && /\/(designs|blog|docs)\//.test(f))
+    .map((f) => path.resolve(repoRoot, f))
+    .filter((f) => existsSync(f) && !path.basename(f).startsWith('_'));
+}
+
+// Pull every ```mermaid … ``` fence from a file, with its 1-based opening line.
+function mermaidFences(file) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  const out = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (/^\s*```mermaid\s*$/.test(lines[i])) {
+      const startLine = i + 1;
+      const body = [];
+      i++;
+      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) {
+        body.push(lines[i]);
+        i++;
+      }
+      out.push({startLine, code: body.join('\n')});
+    }
+    i++;
+  }
+  return out;
+}
+
+// Render + inspect all fences from all files in ONE browser session.
+async function run() {
+  const specs = [];
+  for (const f of files) {
+    if (!existsSync(f)) continue;
+    for (const fence of mermaidFences(f)) {
+      // Only score graph/flowchart: they lay out as a node graph and can overlap/oversize.
+      // Sequence/ER/class/state/timeline/mindmap/etc. self-lay-out (and are more fragile to
+      // parse out of context), so skip them here — same scope as the cheap text sibling.
+      const first =
+        fence.code
+          .split('\n')
+          .map((l) => l.trim())
+          .find((l) => l && !l.startsWith('%%')) || '';
+      if (!/^(graph|flowchart)\b/.test(first)) continue;
+      // Strip the repo's %% animate: flow %% directive + entity dashes so mermaid parses it raw.
+      const code = fence.code
+        .replace(/^\s*%%.*$/gm, '')
+        .replace(/&#8212;|&#x2014;|&mdash;/g, '-');
+      specs.push({file: path.relative(ROOT, f), line: fence.startLine, code});
+    }
+  }
+  if (!specs.length) {
+    if (asJson) console.log(JSON.stringify({total: 0, findings: []}, null, 2));
+    else console.log('✅ mermaid render: no mermaid diagrams in the given files.');
+    process.exit(0);
+  }
+
+  let chromium;
+  try {
+    ({chromium} = await import('playwright'));
+  } catch {
+    console.error(
+      '⚠️  mermaid render: Playwright not available; skipping (this is the heavy render check, ' +
+        'not the per-edit heuristic). Install browsers with `npx playwright install chromium`.',
+    );
+    process.exit(0); // absence of the renderer is not a failure of the content
+  }
+
+  const findings = [];
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.setViewportSize({width: 1440, height: 1600});
+    // Load mermaid from the installed package into the page context.
+    const mermaidPath = path.resolve(ROOT, 'node_modules/mermaid/dist/mermaid.min.js');
+    await page.setContent('<!doctype html><html><body><div id="host"></div></body></html>');
+    await page.addScriptTag({path: mermaidPath});
+    await page.evaluate(() => window.mermaid.initialize({startOnLoad: false}));
+
+    for (const spec of specs) {
+      const result = await page.evaluate(async (code) => {
+        try {
+          const {svg} = await window.mermaid.render('m' + Math.floor(performance.now()), code);
+          const host = document.getElementById('host');
+          host.innerHTML = svg;
+          const svgEl = host.querySelector('svg');
+          const vb = svgEl.viewBox && svgEl.viewBox.baseVal;
+          const w = vb && vb.width ? vb.width : svgEl.getBoundingClientRect().width;
+          const h = vb && vb.height ? vb.height : svgEl.getBoundingClientRect().height;
+          // Node bounding boxes: mermaid marks nodes with class "node" (flowchart) / "nodes".
+          const nodes = [...host.querySelectorAll('.node')].map((n) => {
+            const b = n.getBoundingClientRect();
+            return {x: b.x, y: b.y, w: b.width, h: b.height};
+          });
+          return {ok: true, w, h, nodes};
+        } catch (e) {
+          return {ok: false, error: String(e && e.message ? e.message : e)};
+        }
+      }, spec.code);
+
+      if (!result.ok) {
+        findings.push({...spec, id: 'render-fail', detail: `does not render: ${result.error}`});
+        continue;
+      }
+      const reasons = [];
+      if (result.h > MAX_H) {
+        reasons.push(
+          `renders ${Math.round(result.w)}×${Math.round(result.h)}px — ${Math.round(result.h)}px ` +
+            `tall (> ${MAX_H}) overflows vertically and shrinks to illegible text`,
+        );
+      } else if (result.w > MAX_W) {
+        reasons.push(
+          `renders ${Math.round(result.w)}px wide (> ${MAX_W}) — too wide to scroll comfortably`,
+        );
+      }
+      // Overlap: any two node bboxes intersecting by more than the tolerance.
+      const ns = result.nodes || [];
+      let overlaps = 0;
+      for (let a = 0; a < ns.length; a++) {
+        for (let b = a + 1; b < ns.length; b++) {
+          const ix = Math.min(ns[a].x + ns[a].w, ns[b].x + ns[b].w) - Math.max(ns[a].x, ns[b].x);
+          const iy = Math.min(ns[a].y + ns[a].h, ns[b].y + ns[b].h) - Math.max(ns[a].y, ns[b].y);
+          if (ix > OVERLAP_TOLERANCE && iy > OVERLAP_TOLERANCE) overlaps++;
+        }
+      }
+      if (overlaps) reasons.push(`${overlaps} pair(s) of nodes overlap (collide)`);
+
+      if (reasons.length) {
+        findings.push({
+          ...spec,
+          id: reasons.some((r) => r.includes('overlap')) ? 'node-overlap' : 'oversize',
+          detail: reasons.join('; '),
+        });
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({total: findings.length, findings}, null, 2));
+    process.exit(0);
+  }
+  if (!findings.length) {
+    console.log(`✅ mermaid render: ${specs.length} diagram(s) render clean and legible.`);
+    process.exit(0);
+  }
+  console.error(
+    `🖼️  mermaid render: ${findings.length} legibility issue(s) across ${
+      new Set(findings.map((f) => f.file)).size
+    } file(s) (warn)`,
+  );
+  for (const f of findings) {
+    console.error(`\n  ${f.file}:${f.line}  [warn:mermaid-render-${f.id}]`);
+    console.error(`      ↳ ${f.detail}`);
+  }
+  console.error(
+    '\n(advice only, not blocking.) This RENDERED each diagram to catch what the source-text' +
+      '\ncheck cannot. A render-fail is a syntax error the draft-only page would hide until' +
+      '\npublish; overlap/oversize is a real legibility problem. Fix: correct the syntax, split' +
+      '\nthe diagram, or switch to <FlowDiagram> (gates its own layout). See author-mermaid.',
+  );
+  process.exit(1);
+}
+
+run().catch((e) => {
+  // A crash in the heavy renderer must not block anything — degrade to a warning.
+  console.error(`⚠️  mermaid render: check errored (non-blocking): ${e && e.message ? e.message : e}`);
+  process.exit(0);
+});


### PR DESCRIPTION
## Why

Answers task #28 (*do mermaid diagrams need a legibility gate like `<UseCaseDiagram>` has?*) and its follow-up (*can we also have a less-frequent heavier check on session completion?*). A hand-authored ```mermaid ``` fence has **no** layout gate, unlike `<FlowDiagram>`/`<UseCaseDiagram>` which throw on a tangled layout. The corpus survey found 29 heavy flow diagrams of 100 (a 41-node flowchart, nodes fanning to 8). So: **two tiers.**

## Tier 1 — cheap, per-edit (text metrics)

- **`scripts/validate-mermaid-complexity.js`** + **`validate-mermaid-complexity-hook.sh`** (PostToolUse, 15s). Scores a `graph`/`flowchart` fence by distinct nodes / edges / max fan-out; warns over **>20 nodes, >24 edges, or a node fanning to 7+**. Never blocks.
- Calibrated: flags the 5 real outliers, spares the many legible 12-19 node diagrams.

## Tier 2 — heavy, per-session (headless render)

The text metrics can't see a few-node diagram that still renders huge. So a second tier actually **renders** each changed diagram:

- **`scripts/validate-mermaid-render.mjs`** — renders each `graph`/`flowchart` with the real mermaid engine via Playwright's Chromium (prior art: `render-mindmap.mjs`), then inspects the actual SVG: **render-fail** (a syntax error the draft-only client render hides until publish), **overlapping nodes**, or **oversize** (>1600px tall / >3000px wide = illegible thumbnail). `--changed` scopes to git-changed + untracked files. Degrades to exit 0 if Playwright is absent.
- **`mermaid-render-check.sh`** — a `Stop` hook (90s) that git-gates (only when a session touched a diagram, incl. new files), renders just those, warns, never blocks.
- `make validate-mermaid-render` target.

## Calibration + a real bug caught

- Only HEIGHT + extreme width are flagged (a wide `flowchart LR` scrolls fine via `overflow-x:auto`). Verified: legible posts (self-healing, claude-abacus, premium-gating) → **0 findings**; the 41-node autonomous-build-agents → 3 real oversize diagrams.
- Testing caught a genuine bug: `git diff HEAD` omits **untracked** files, so a brand-new diagram post was skipped. Fixed with `ls-files --others` in both `--changed` and the hook gate.

## Docs

`author-mermaid` skill documents both tiers (cheap-per-edit text + heavy-per-session render) and the remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)