### PR TITLE
author-diagram chooser skill + pickets board no-slide fix

### DIFF
--- a/.claude/skills/author-diagram/SKILL.md
+++ b/.claude/skills/author-diagram/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: author-diagram
+description: The CHOOSER for diagrams on the Bytes of Purpose site — decides WHICH of the many diagram types (a dozen mermaid types plus the custom FlowDiagram / UseCaseDiagram / MindMap / DiagramWithFootnotes / ComparisonMatrix components plus Figma / Google Drawing / PlantUML / .mindnode embeds) best fits what you are trying to show, by running a short adaptive AskUserQuestion interview, then HANDS OFF to the skill that owns that type's mechanics. It routes and dispatches; it does not duplicate the deep skills. Use when the user says "which diagram should I use", "what's the best way to show X", "make a diagram for this", "help me pick a diagram", or hands over something to visualize without naming the diagram type. Distinct from author-mermaid (raw mermaid syntax per type) and upgrade-post (the component catalog) — this skill CHOOSES, then calls them. Pairs with author-mermaid (mermaid syntax), upgrade-post (FlowDiagram/MindMap/UseCaseDiagram/DiagramWithFootnotes/ComparisonMatrix), import-mindnode (a .mindnode file), import-co-design (a work-repo HLD), and author-blog-post (embedding the result).
+---
+
+# Author a diagram (choose the type, then hand off)
+
+The hard part of a diagram is not drawing it, it is CHOOSING it. This site has many ways to draw
+one, and the right pick depends entirely on what you are trying to SHOW, not on which tool you
+like. This skill is the **chooser**: it interviews you about the intent, routes to the single best
+diagram type, then opens the matching `types/*.md` checklist and hands the mechanics to the skill
+that owns them. It does NOT duplicate those skills; each subfile is a short "you picked X, here is
+the snippet, the gotchas, and who owns it" checklist.
+
+## Step 0 — is the type already obvious?
+
+If the request already names the shape ("draw the request FLOW", "a use-case diagram", "map my
+role hierarchy"), skip the interview and go straight to the routing table. Only interview when the
+intent is ambiguous. Ask with **`AskUserQuestion`**, on genuine ambiguity only, small labelled
+option sets, your recommendation first. Do not interrogate when one answer is clearly right.
+
+## The interview (ask these in order; stop as soon as the type is settled)
+
+### Q1 — what are you trying to SHOW?
+
+The whole choice hangs on intent. Offer these (group the long list into a first cut, then narrow):
+
+- **Something MOVES through steps** (a pipeline, request/response, an experiment loop) &rarr; the
+  FLOW family. Go to Q2a.
+- **Who USES what** (actors and the capabilities they reach) &rarr; a use-case diagram. `use-case.md`.
+- **A HIERARCHY of ideas** (a brainstorm, a role map, a concept tree) &rarr; the mind-map family.
+  Go to Q2b.
+- **A head-to-head CHOICE** (options scored against criteria) &rarr; the decision kit. `comparison.md`.
+- **The STRUCTURE of data or types** (entities, tables, classes) &rarr; ER / class. `data-and-state.md`.
+- **A LIFECYCLE / state machine** (states and transitions) &rarr; stateDiagram. `data-and-state.md`.
+- **A time-ordered INTERACTION** (who-calls-whom over time) &rarr; a sequence diagram. `sequence.md`.
+- **What a system TOUCHES or how it is BUILT** (topology, neighbors, deps) &rarr; the topology
+  family. Go to Q2c.
+- **A BOARD of work / a git story / MILESTONES / a 2x2** &rarr; the project family. `project.md`.
+- **What a UI LOOKS like** &rarr; a Mockup (not a diagram; see `upgrade-post`). `embed.md`.
+- **Something in MOTION** &rarr; a Gif (see `upgrade-post`). `embed.md`.
+
+> Tell: "how does X get from A to B" is a flow; "who does what with X" is use-case; "how do these
+> ideas relate under one root" is a mind map; "which option wins" is the decision kit.
+
+### Q2a (FLOW) — what shape is the flow, and do you want it on-brand?
+
+- A strict line A &rarr; B &rarr; C, a loop, a vertical stack, a fork/decision, or owner-lanes, AND
+  you want an on-brand SVG with a build-time legibility gate + clickable node detail &rarr;
+  **`<FlowDiagram>`** (it infers pipeline/loop/sequence/branch/swimlane). `flow.md`.
+- A quick hand-authored flow, or one that needs mermaid features FlowDiagram lacks &rarr; a
+  **mermaid `flowchart`** (animate it with the flow-dot). `flow.md`.
+
+> Tell: reach for `<FlowDiagram>` first (data-driven, gated, themed); drop to a raw mermaid
+> flowchart only when you need something it cannot express.
+
+### Q2b (HIERARCHY) — clickable + themed, or a throwaway sketch?
+
+- You want the branches to be CLICKABLE (jump to a heading or page) and themed to the site &rarr;
+  **`<MindMap>`**. `hierarchy.md`.
+- A quick static brainstorm with no links &rarr; a raw **mermaid `mindmap`**. `hierarchy.md`.
+- The source is an actual Apple **`.mindnode`** file &rarr; **`import-mindnode`** (it converts +
+  previews for you). `hierarchy.md` / `embed.md`.
+
+### Q2c (BOUNDARY / TOPOLOGY) — which of the three confusable ones?
+
+Reuse author-mermaid's disambiguation exactly:
+
+- **Flow** (`flowchart` / `<FlowDiagram>`): something MOVES through steps (A &rarr; B &rarr; C).
+- **Context / topology** (`architecture-beta`): what a system TOUCHES, its neighbors/stores/deps at
+  the boundary. Hub-and-spoke, NOT a sequence. `topology.md`.
+- **Use-case** (`<UseCaseDiagram>`): which ACTORS use which capabilities. `use-case.md`.
+
+> Tell: draw the boundary you actually mean. "the payment service calls Stripe and reads the DB" is
+> topology; "a customer checks out and an admin issues a refund" is use-case; "the request goes
+> through auth then billing then fulfillment" is a flow.
+
+### Q3 (only if still ambiguous) — is there a SOURCE artifact?
+
+- A **`.mindnode`** file &rarr; **`import-mindnode`**.
+- A **work-repo HLD** (`~/Workspace/work-git/.../CO-DESIGN-*-hld.md`) &rarr; **`import-co-design`**
+  (it classifies the diagrams and imports idempotently).
+- A **Figma board / Google Drawing / PlantUML** you already have &rarr; embed it. `embed.md`.
+
+## Routing table (the answer &rarr; the owner)
+
+| The intent points to&hellip; | Diagram type | Author it with | Subfile / owner skill |
+|---|---|---|---|
+| Something moves through steps | `<FlowDiagram>` (or mermaid `flowchart`) | prop spec / fence | `flow.md` &middot; upgrade-post / author-mermaid |
+| A hierarchy you can click | `<MindMap>` (or mermaid `mindmap`) | mermaid mindmap text | `hierarchy.md` &middot; upgrade-post / import-mindnode |
+| Who uses what | `<UseCaseDiagram>` | actors/useCases/links | `use-case.md` &middot; upgrade-post |
+| Which option wins | `<ComparisonMatrix>` + `<Accordion>` | options/criteria | `comparison.md` &middot; upgrade-post |
+| A time-ordered interaction | mermaid `sequenceDiagram` | fence | `sequence.md` &middot; author-mermaid |
+| Data or type structure, a lifecycle | mermaid `erDiagram` / `classDiagram` / `stateDiagram-v2` | fence | `data-and-state.md` &middot; author-mermaid |
+| What a system touches / how it is built | mermaid `architecture-beta` (topology or context), C4 | fence | `topology.md` &middot; author-mermaid |
+| A board / git story / milestones / a 2x2 | mermaid `kanban` / `gitGraph` / `timeline` / `quadrantChart` | fence | `project.md` &middot; author-mermaid |
+| A diagram whose steps each need a sentence | `<DiagramWithFootnotes>` (mermaid + numbered legend) | wrapper | `annotated.md` &middot; upgrade-post |
+| A Figma / Google Drawing / PlantUML / `.mindnode` you already have | embed / import | iframe / img / fence / converter | `embed.md` &middot; import-mindnode / import-co-design |
+
+## When it is genuinely TWO diagrams, author both
+
+A post often needs more than one: a FLOW of the pipeline AND a COMPARISON of the options it chose
+between; a topology AND a sequence. Do not cram two intents into one diagram. Pick the type for
+each intent from the table and author them separately, each in the section that needs it. (Same
+"split, do not force" instinct as `organize-post`.)
+
+## How to run it
+
+1. **Read the request.** Name the ONE thing it is trying to show (or the few, if mixed).
+2. **If the type is obvious, skip the interview.** Otherwise run Q1 &rarr; the narrowing follow-up,
+   via `AskUserQuestion`, recommendation first, only on real ambiguity.
+3. **Open the matching `types/*.md`** for the confirming heuristic + the snippet skeleton + the
+   gotchas that bite.
+4. **Author it through the owner skill** named in that subfile (author-mermaid for a fence,
+   upgrade-post for a component, import-mindnode / import-co-design for a source artifact). Do NOT
+   restate their mechanics here.
+5. **Verify** per the owner's gate: `<FlowDiagram>` / `<UseCaseDiagram>` / `<MindMap>` FAIL the
+   build on a bad spec (a dangling edge id, a tangled layout, malformed mindmap text), so a green
+   `yarn build` is the syntax gate; mermaid renders client-side, so screenshot-check it (crossing
+   arrows, unresolved `logos:` icons, dark-mode legibility).
+
+## Universal gotchas (hold for every type)
+
+1. **No hardcoded mermaid colors.** Never `classDef` / `style fill:` COLOR directives; the theme
+   colors diagrams in light + dark. (See author-mermaid.)
+2. **The em-dash hook BLOCKS** a literal `&#8212;` (U+2014) or a `--` prose dash anywhere in
+   `docs`/`blog`/`designs`/`src`. In a mermaid label use the `&#8212;` entity; in prose use commas
+   / colons / `&middot;`.
+3. **`.md` cannot embed JSX.** Any post using `<FlowDiagram>` / `<MindMap>` / `<UseCaseDiagram>` /
+   `<ComparisonMatrix>` MUST be `.mdx`. A plain `mermaid` fence works in `.md`.
+4. **Show a mermaid block INSIDE an mdx code block with 4-backtick fences** so the inner
+   ` ```mermaid ` is not swallowed.
+5. **Animate FLOWS only.** Wrap a flow in `<div className="mermaid-animated flow-dot">`; do not
+   animate context / relationship / hierarchy diagrams (the traveling dot looks random).
+
+## Files
+
+- `types/flow.md` &mdash; a movement/process flow (`<FlowDiagram>` vs mermaid `flowchart`, and when each).
+- `types/hierarchy.md` &mdash; an idea/role/concept tree (`<MindMap>` vs mermaid `mindmap` vs a `.mindnode` import).
+- `types/use-case.md` &mdash; who-uses-what (`<UseCaseDiagram>`).
+- `types/comparison.md` &mdash; a head-to-head choice (`<ComparisonMatrix>` + `<Accordion>`).
+- `types/sequence.md` &mdash; a time-ordered interaction (mermaid `sequenceDiagram`).
+- `types/data-and-state.md` &mdash; data/type structure + lifecycles (`erDiagram` / `classDiagram` / `stateDiagram-v2`).
+- `types/topology.md` &mdash; what a system touches / how it is built (`architecture-beta`, context, C4).
+- `types/project.md` &mdash; a board / git story / milestones / a 2x2 (`kanban` / `gitGraph` / `timeline` / `quadrantChart`).
+- `types/annotated.md` &mdash; a diagram whose steps each need a sentence (`<DiagramWithFootnotes>`).
+- `types/embed.md` &mdash; a Figma / Google Drawing / PlantUML / `.mindnode` you already have.

--- a/.claude/skills/author-diagram/types/annotated.md
+++ b/.claude/skills/author-diagram/types/annotated.md
@@ -1,0 +1,22 @@
+# Annotated (a diagram whose STEPS each need a sentence)
+
+**Pick this when:** you have a real diagram (usually mermaid) whose nodes each deserve a sentence
+of explanation, and you want a numbered legend tying badges in the labels to those explanations.
+This is a WRAPPER around another diagram, not a diagram type of its own.
+
+**Author with `<DiagramWithFootnotes>`:** author the mermaid with numbered badges in the labels
+(&#9312;&#9313;&#9314;), then render the matching explanations as a legend.
+
+**When to reach for it vs alternatives:**
+- The diagram is a FLOW and each step is self-explanatory &rarr; plain `<FlowDiagram>` (`flow.md`),
+  which already gives a node a click-to-focus `detail` modal.
+- The diagram is a flow but each step needs a full sentence of standing context visible at once
+  &rarr; `<DiagramWithFootnotes>`.
+- A non-flow diagram (class / ER / context) that needs per-node notes &rarr;
+  `<DiagramWithFootnotes>`.
+
+**Gotchas:**
+- It is a MANUAL opt-in; a content re-import clobbers it, so add it only on finalized pages.
+- `.md` cannot embed it; use `.mdx`.
+
+**Owner:** `upgrade-post` (the `<DiagramWithFootnotes>` catalog entry).

--- a/.claude/skills/author-diagram/types/comparison.md
+++ b/.claude/skills/author-diagram/types/comparison.md
@@ -1,0 +1,40 @@
+# Comparison (which OPTION wins)
+
+**Pick this when:** a decision post that weighs options against criteria, or narrates why one
+choice won. This is a decision FIGURE, not a flow or a hierarchy.
+
+**Author with the decision kit (`<ComparisonMatrix>` + `<Accordion>`):**
+
+- **`<ComparisonMatrix>`** = the head-to-head scorecard. Options are columns; each criterion is a
+  row carrying its own `cells` keyed by option id; the `chosen` column is highlighted;
+  `yes` / `no` / `partial` render as marks (any other string is literal text). A cell can be
+  `{rating, note, footnotes}` for a click-to-justify modal. Pass `legend` for a key.
+
+  ```mdx
+  <ComparisonMatrix title="Auth approach" legend
+    options={[{id:'session', label:'Session'}, {id:'jwt', label:'JWT', chosen:true}]}
+    criteria={[
+      {label:'Simple', cells:{session:'yes', jwt:'partial'}},
+      {label:'Stateless', cells:{session:'no', jwt:'yes'}},
+    ]}/>
+  ```
+
+- **`<Accordion>`** = the foldable narrative, one `items` entry per option, each with a `summary`,
+  a React `body`, and either `chosen: true` (a solid CHOSEN pill) or `verdict:'considered'` (a
+  quiet pill). The accordion carries the WHY; the matrix carries the head-to-head.
+
+  ```mdx
+  <Accordion label="Why JWT won" items={[
+    {summary:'Session', verdict:'considered', body:<>Simple, but stateful.</>},
+    {summary:'JWT', chosen:true, open:true, body:<>Stateless, scales across nodes.</>},
+  ]}/>
+  ```
+
+**Gotchas:**
+- `<ComparisonMatrix>` THROWS at build on a cell keyed to a nonexistent option id.
+- For explored DESIGN directions (a specimen with a chosen ring), that is `OptionGrid` /
+  `DecisionNote`, NOT ComparisonMatrix (which is the feature-by-feature table).
+- `.md` cannot embed these; use `.mdx`.
+
+**Owner:** `upgrade-post` (the decision-kit catalog entry). Live demo:
+`/handbook/components/structural/decision-kit`.

--- a/.claude/skills/author-diagram/types/data-and-state.md
+++ b/.claude/skills/author-diagram/types/data-and-state.md
@@ -1,0 +1,37 @@
+# Data + state (STRUCTURE and LIFECYCLES)
+
+**Pick this when:** you are showing the SHAPE of data/types, or how something moves between
+STATES. Three mermaid types, one per intent:
+
+- **`erDiagram`** &mdash; data entities + relationships (tables, fields, cardinality). The clean way
+  to render a schema / star schema.
+
+  ````mdx
+  ```mermaid
+  erDiagram
+    POST ||--o{ COMMENT : has
+    POST { string slug string title }
+  ```
+  ````
+
+- **`classDiagram`** &mdash; object/type structure (classes, fields, methods, inheritance).
+
+- **`stateDiagram-v2`** &mdash; a lifecycle / status machine (states + transitions).
+
+  ````mdx
+  ```mermaid
+  stateDiagram-v2
+    [*] --> Draft
+    Draft --> Review
+    Review --> Published
+    Review --> Draft
+  ```
+  ````
+
+**Gotchas:**
+- These are RELATIONSHIP diagrams, not flows: do NOT wrap them in `flow-dot` animation.
+- Standard mermaid-11 syntax; if unsure of a construct, probe-verify (render it) before shipping.
+- Mermaid labels needing a dash use `&#8212;`.
+
+**Owner:** `author-mermaid` (per-type syntax + gotchas). For a DB schema authored as text outside
+mermaid (DBML / C4-PlantUML), see the diagramming docs referenced there.

--- a/.claude/skills/author-diagram/types/embed.md
+++ b/.claude/skills/author-diagram/types/embed.md
@@ -1,0 +1,28 @@
+# Embed (you already HAVE the artifact)
+
+**Pick this when:** the diagram exists outside this repo and you want to bring it in, rather than
+author one from scratch. Route by the artifact:
+
+- **A `.mindnode` file** &rarr; **`import-mindnode`**. It converts the bundle to mermaid text,
+  previews it as a PNG against the original, and wraps it in `<MindMap>`. Do not hand-transcribe.
+
+- **A work-repo HLD** (`~/Workspace/work-git/.../CO-DESIGN-*-hld.md`) &rarr; **`import-co-design`**.
+  Its transformer de-em-dashes, fixes MDX, classifies the diagrams, and is idempotent (re-run on
+  source edits). Do not hand-copy.
+
+- **A Figma board** &rarr; a JSX `<iframe>` from `embed.figma.com/board/...` (convert HTML attrs to
+  JSX: `style={{}}`, `allowFullScreen`). See `/handbook/components/diagrams/diagrams-figma`.
+
+- **A Google Drawing** &rarr; a published `<img>` from `docs.google.com/drawings/d/e/...pub`. See
+  `/handbook/components/diagrams/diagrams-google-drawing`.
+
+- **PlantUML / C4 / DBML** text you already have &rarr; a ```plantuml fence (or the diagramming
+  docs' recipe). See `/blogging/diagramming/diagrams-as-text`.
+
+**Gotchas:**
+- Prefer CONVERTING a `.mindnode` or HLD (via its importer) over embedding a screenshot; the
+  imported version is themed, searchable, and version-controlled.
+- An `<iframe>` embed is client-only; screenshot-verify it renders.
+
+**Owner:** `import-mindnode` (`.mindnode`) &middot; `import-co-design` (HLD) &middot; the
+per-tool showcases under `/handbook/components/diagrams/*`.

--- a/.claude/skills/author-diagram/types/flow.md
+++ b/.claude/skills/author-diagram/types/flow.md
@@ -1,0 +1,47 @@
+# Flow (something MOVES through steps)
+
+**Pick this when:** a request/response, a pipeline, an experiment loop, a handoff, or a
+decision fan-out. Something travels from A to B to C.
+
+**Two ways, pick by need:**
+
+- **`<FlowDiagram>`** (default): a prop-driven inline-SVG flow, on-brand, with a build-time
+  legibility gate and clickable node detail. It INFERS the shape from the graph: `pipeline`
+  (A&rarr;B&rarr;C), `loop` (a back-edge), `sequence` (vertical stack), `branch` (a fork / 2+
+  out-edges &mdash; a decision tree), `swimlane` (owner bands via each node's `lane`). Reach for
+  this first.
+
+  ```mdx
+  <FlowDiagram title="Publish pipeline" legend
+    desc="Draft flows through review to a live deploy."
+    nodes={[
+      {id: 'draft', label: 'Draft'},
+      {id: 'review', label: 'Review', detail: 'A reader-experience pass.'},
+      {id: 'deploy', label: 'Deploy', kind: 'external'},
+    ]}
+    edges={[{from: 'draft', to: 'review'}, {from: 'review', to: 'deploy', label: 'approved'}]}
+  />
+  ```
+
+- **mermaid `flowchart`**: a quick hand-authored flow, or one needing mermaid features
+  FlowDiagram lacks. Animate it as a flow.
+
+  ````mdx
+  <div className="mermaid-animated flow-dot">
+
+  ```mermaid
+  flowchart LR
+    A[Draft] --> B[Review] --> C[Deploy]
+  ```
+
+  </div>
+  ````
+
+**Gotchas:**
+- `<FlowDiagram>` FAILS the build on a dangling edge id or a tangled layout (>25% crossing edges);
+  reorder so it reads without backtracking, or pass `allowOverlap` to downgrade to a warning.
+- `.md` cannot embed `<FlowDiagram>`; use `.mdx`.
+- Only FLOWS get the `flow-dot` animation; do not animate relationship diagrams.
+
+**Owner:** `upgrade-post` (the `<FlowDiagram>` catalog entry) &middot; `author-mermaid` (the raw
+`flowchart` mechanics). Go there for the full API.

--- a/.claude/skills/author-diagram/types/hierarchy.md
+++ b/.claude/skills/author-diagram/types/hierarchy.md
@@ -1,0 +1,36 @@
+# Hierarchy (a tree of ideas under one root)
+
+**Pick this when:** a brainstorm, a role map, a concept tree, an outline. Ideas relate as a
+single-rooted hierarchy, NOT a flow (nothing moves through steps) and NOT a comparison.
+
+**Three ways, pick by need:**
+
+- **`<MindMap>`** (default on this site): a themed inline-SVG mind map from mermaid `mindmap`
+  text, with CLICKABLE nodes. A node whose whole label is a markdown link becomes an `<a>`.
+
+  ```mdx
+  <MindMap title="Orchestrating Roles" theme="blog">{`
+  mindmap
+    root((Orchestrating Roles))
+      [The Starter](#the-starter)
+      [The Executor](#the-executor)
+      [The Finisher](/initiatives/other-post#finisher)
+  `}</MindMap>
+  ```
+
+  `theme="blog"` (site tokens) for a NEW map; `theme="mindnode"` for one imported from / evoking a
+  `.mindnode` file. Per-node tint with `:::green|mint|pink|blue|amber|violet`.
+
+- **mermaid `mindmap`**: a quick static brainstorm with no links and no theming need.
+
+- **an actual `.mindnode` file** as the source &rarr; use **`import-mindnode`** (it converts the
+  bundle to mermaid text and previews it against the original before you embed).
+
+**Gotchas:**
+- Pass the mermaid text as CHILDREN in a template literal so `#`, parens, and newlines survive MDX.
+- Malformed mindmap text THROWS at build (the syntax gate).
+- For a directed flow or a decision fan-out use `flow.md`, NOT a mind map; mind maps are hierarchy,
+  not movement.
+
+**Owner:** `upgrade-post` (the `<MindMap>` catalog entry) &middot; `import-mindnode` (the
+`.mindnode` path) &middot; `author-mermaid` (raw `mindmap` syntax).

--- a/.claude/skills/author-diagram/types/project.md
+++ b/.claude/skills/author-diagram/types/project.md
@@ -1,0 +1,32 @@
+# Project (a BOARD, a GIT story, MILESTONES, a 2x2)
+
+**Pick this when:** you are showing work state or planning shape. Four mermaid types, one per
+intent:
+
+- **`kanban`** &mdash; a work board (columns + cards). Cards INDENT under the column line; optional
+  `@{ assigned:…, ticket:…, priority: High }` metadata.
+
+  ````mdx
+  ```mermaid
+  kanban
+    todo[To Do]
+      Task A
+    doing[Doing]
+      Task B
+  ```
+  ````
+
+- **`gitGraph`** &mdash; a git branching/merging story (`commit`, `branch`, `checkout`, `merge`).
+- **`timeline`** &mdash; dated milestones (chronological events).
+- **`quadrantChart`** &mdash; a 2x2 prioritization (effort vs value). Points are `Label: [x, y]`
+  with x,y as **0&ndash;1 floats** (out-of-range coords go off-chart).
+
+**Gotchas:**
+- kanban cards must be INDENTED under their column, or they detach.
+- quadrant coords must be 0&ndash;1 floats.
+- These are state/planning diagrams, not flows: no `flow-dot` animation.
+- For an INTERACTIVE board that indexes real posts as cards (not a static picture), that is the
+  `<KanbanBoard>` component, a different thing; see `upgrade-post`.
+
+**Owner:** `author-mermaid` (per-type syntax). The interactive `<KanbanBoard>` is owned by
+`upgrade-post`.

--- a/.claude/skills/author-diagram/types/sequence.md
+++ b/.claude/skills/author-diagram/types/sequence.md
@@ -1,0 +1,29 @@
+# Sequence (a time-ordered INTERACTION)
+
+**Pick this when:** who-calls-whom over time, an ordered exchange between actors or systems (a
+handshake, an API round-trip, a protocol). The ORDER in time is the point. If you only care that
+data moves A&rarr;B&rarr;C (not the back-and-forth timing), that is a flow (`flow.md`), not a
+sequence.
+
+**Author with a mermaid `sequenceDiagram` fence:**
+
+````mdx
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as App
+  participant S as Service
+  U->>A: submit form
+  A->>S: validate + persist
+  S-->>A: ok
+  A-->>U: confirmation
+```
+````
+
+**Gotchas:**
+- `->>` is a solid call, `-->>` a dashed return. Declare `participant`s in the order you want them
+  left-to-right.
+- Do NOT animate a sequence with the flow-dot (it is not a flow).
+- A mermaid label needing a dash uses the `&#8212;` entity (the em-dash hook blocks a literal one).
+
+**Owner:** `author-mermaid` (the `sequenceDiagram` mechanics + the site conventions).

--- a/.claude/skills/author-diagram/types/topology.md
+++ b/.claude/skills/author-diagram/types/topology.md
@@ -1,0 +1,34 @@
+# Topology (what a system TOUCHES / how it is BUILT)
+
+**Pick this when:** you are showing a system's neighbors, stores, and dependencies at its boundary,
+or the grouped services that make it up. Hub-and-spoke, NOT a time sequence, NOT a flow.
+
+**Disambiguate first (the three confusable diagrams):**
+- **Flow** (`flow.md`): something MOVES through steps.
+- **Context / topology** (THIS): what a system TOUCHES at the boundary.
+- **Use-case** (`use-case.md`): which ACTORS use which capabilities.
+
+**Author with mermaid `architecture-beta`:**
+
+````mdx
+```mermaid
+architecture-beta
+  group api(cloud)[API]
+  service db(database)[Database] in api
+  service server(server)[Server] in api
+  db:R --> L:server
+```
+````
+
+Real provider/brand icons via the registered iconify `logos` pack: `logos:aws-lambda`,
+`logos:google-cloud`, `logos:nodejs-icon`, etc. Built-ins: `cloud database disk internet server`.
+
+**Gotchas:**
+- Edge syntax is `id:DIR --> DIR:id` where DIR is `T|B|L|R` (pick the port that FACES the target),
+  NOT `id --> id`. A wrong icon name silently renders nothing.
+- Order services so connected ones are adjacent (declaration order drives layout).
+- Inside a JSX component, use `<Mermaid value={theString}/>` from `@theme/Mermaid`, not a fence.
+- Do NOT animate a context diagram with the flow-dot.
+
+**Owner:** `author-mermaid` (the `architecture-beta` / C4 mechanics, the `logos` icon wiring, the
+context-hub recipe).

--- a/.claude/skills/author-diagram/types/use-case.md
+++ b/.claude/skills/author-diagram/types/use-case.md
@@ -1,0 +1,35 @@
+# Use-case (who USES what)
+
+**Pick this when:** a "who uses X and what they do" figure. Actors and the capabilities they
+reach. NOT a flow (nothing moves through steps) and NOT topology (this is actors, not services).
+
+**Author with `<UseCaseDiagram>`** (mermaid has no real use-case type, so this is the only good
+way here):
+
+```mdx
+<UseCaseDiagram title="Bytes of Purpose" desc="Who works with the blog and what they do."
+  actors={[
+    {id:'author', label:'Author', kind:'internal'},
+    {id:'reader', label:'Reader'},
+    {id:'cron', label:'Scheduled job', kind:'system'},
+  ]}
+  useCases={[
+    {id:'write', label:'Write a post', detail:'Draft in MDX, run the validators.'},
+    {id:'publish', label:'Publish', detail:'Build and deploy.'},
+    {id:'read', label:'Read a post'},
+  ]}
+  links={[
+    {from:'author', to:'write'}, {from:'author', to:'publish'}, {from:'cron', to:'publish'},
+    {from:'reader', to:'read'}, {from:'publish', to:'write', type:'include'},
+  ]}/>
+```
+
+**Gotchas:**
+- Actor `kind`: `internal` + `system` pull LEFT, `external` (default) pulls RIGHT, so lines fan to
+  the nearest edge. Give each actor use cases that straddle it vertically.
+- TWO build-time gates THROW: the overlap gate (>25% crossing) and the actor line-angle BALANCE
+  gate (a lopsided actor). `allowOverlap` downgrades both to warnings; better to reorder or split.
+- `.md` cannot embed it; use `.mdx`.
+
+**Owner:** `upgrade-post` (the `<UseCaseDiagram>` catalog entry). Live demo:
+`/handbook/components/diagrams/use-case`.

--- a/bytesofpurpose-blog/blog/2026-07-07-choosing-a-diagram.mdx
+++ b/bytesofpurpose-blog/blog/2026-07-07-choosing-a-diagram.mdx
@@ -1,0 +1,183 @@
+---
+slug: choosing-a-diagram
+title: 'Choosing a Diagram, Before Drawing One'
+kind: design-story
+sidebar_label: "Choosing a Diagram"
+description: "The blog can draw a dozen kinds of diagram. The hard part is knowing which. So I built a chooser that starts from what you are trying to show."
+authors: [oeid]
+tags: [blogging, generative-ai, claude, diagram]
+date: 2026-07-07T11:00
+draft: false
+---
+
+Every time I sat down to add a diagram to a post, I lost a few minutes to the same small paralysis:
+not how to draw the thing, but which KIND of thing to draw. This blog can render a flow, a mind
+map, a use-case, a sequence, a state machine, a system topology, a comparison, a board, and more.
+That richness is a gift right up until the blank page, where it becomes a dozen doors and no sign
+telling me which one. So I built the sign: a chooser that starts from what I am trying to show and
+routes me to the one diagram type that fits.
+
+<!-- truncate -->
+
+## The problem is choosing, not drawing
+
+Drawing a diagram here is genuinely easy. There is a skill for mermaid syntax, a catalog for the
+custom components, an importer for MindNode files. The mechanics are solved. What was never solved
+is the decision that comes first: should this idea be a flowchart at all, or is it really a
+comparison wearing a flowchart's clothes? A tool held wrong is worse than no tool. A sequence
+forced into a flow, or a topology drawn as a timeline, makes the reader do the work the diagram was
+supposed to do for them.
+
+The fix was to stop starting from the tool. The chooser's very first question is not "which diagram
+do you want," it is "what are you trying to show." That one reframing does most of the work, because
+intent maps to type far more reliably than taste does.
+
+## The decision, as a picture
+
+Here is the chooser's spine: an opening question that sorts the intent into a family, and then a
+narrowing that lands on one type and the skill that authors it. Click a leaf to see what that type
+is for.
+
+<FlowDiagram title="Choosing a diagram" shape="branch"
+  desc="Start from what you are trying to show; the answer routes to one diagram type and the skill that owns it."
+  nodes={[
+    {id: 'q', label: 'What are you showing?'},
+    {id: 'move', label: 'Movement'},
+    {id: 'who', label: 'Who uses what'},
+    {id: 'tree', label: 'A hierarchy'},
+    {id: 'choice', label: 'A choice'},
+    {id: 'flow', label: 'FlowDiagram', detail: 'A directed flow: pipeline, loop, sequence, branch, or swimlane.'},
+    {id: 'usecase', label: 'UseCaseDiagram', detail: 'Actors outside a boundary reaching the capabilities they use.'},
+    {id: 'mindmap', label: 'MindMap', detail: 'A single-rooted hierarchy with clickable, themed nodes.'},
+    {id: 'matrix', label: 'ComparisonMatrix', detail: 'Options scored against criteria, the chosen column highlighted.'},
+  ]}
+  edges={[
+    {from: 'q', to: 'move'},
+    {from: 'q', to: 'who'},
+    {from: 'q', to: 'tree'},
+    {from: 'q', to: 'choice'},
+    {from: 'move', to: 'flow'},
+    {from: 'who', to: 'usecase'},
+    {from: 'tree', to: 'mindmap'},
+    {from: 'choice', to: 'matrix'},
+  ]}
+/>
+
+Fittingly, that picture is itself a decision the chooser would make: it is movement through a
+branching set of questions, so it is a [FlowDiagram](/handbook/components/diagrams/diagrams-flow-charts). The
+diagram practices what it preaches.
+
+## Four walks through it, each one drawn
+
+The fastest way to trust a chooser is to see what it hands back. So here are four real requests,
+each carried to its recommended type and rendered the way it would ship in a post. Notice how
+different they look: that difference IS the argument. A flow, a hierarchy, a set of actors, and a
+scored choice are not the same picture, and forcing any of them into a flowchart would lose what
+makes it legible.
+
+### "How does a request get from the browser to the database?"
+
+That is movement through steps, so the chooser lands on a flow. A clean line, a loop, or a fork
+is a `<FlowDiagram>`; only when it needs something the component cannot express does it drop to a
+mermaid flowchart. Here the request travels through a cache, an auth check that can reject, and
+on to the database.
+
+<FlowDiagram title="A request path" legend
+  desc="A browser request passes through a cache and an auth check before it reaches the database."
+  nodes={[
+    {id: 'browser', label: 'Browser', kind: 'external'},
+    {id: 'cache', label: 'Edge cache', kind: 'store', detail: 'Serves a hit without touching the origin.'},
+    {id: 'auth', label: 'Auth check', detail: 'Rejects an unauthenticated request before it reaches data.'},
+    {id: 'api', label: 'API server'},
+    {id: 'db', label: 'Database', kind: 'store'},
+  ]}
+  edges={[
+    {from: 'browser', to: 'cache'},
+    {from: 'cache', to: 'auth', label: 'miss'},
+    {from: 'auth', to: 'api', label: 'ok'},
+    {from: 'api', to: 'db'},
+  ]}
+/>
+
+### "How do these role ideas relate under one theme?"
+
+That is a hierarchy, not movement, so it routes to a
+[mind map](/handbook/components/diagrams/diagrams-mindnode). If I want the branches clickable and
+themed to the site, that is the `<MindMap>` component; a throwaway sketch could stay a plain
+mermaid mindmap. This one maps the three roles from an earlier post, each branch a link.
+
+<MindMap title="Orchestrating roles" theme="blog"
+  caption="A hierarchy: one root, themed branches, each a real link.">{`
+mindmap
+  root((Orchestrating Roles))
+    [The Starter](/initiatives/mindmaps-from-mindnode#the-starter)
+    [The Executor](/initiatives/mindmaps-from-mindnode#the-executor)
+    [The Finisher](/initiatives/mindmaps-from-mindnode#the-finisher)
+`}</MindMap>
+
+### "Who works with this system, and what do they do?"
+
+That is actors reaching capabilities, not a flow and not a hierarchy, so it routes to a
+[use-case diagram](/handbook/components/diagrams/use-case). The `<UseCaseDiagram>` puts the actors
+outside a boundary and the capabilities inside it.
+
+<UseCaseDiagram title="Who uses the blog" desc="An author writes and publishes; a reader reads and shares."
+  actors={[
+    {id:'author', label:'Author', kind:'internal'},
+    {id:'reader', label:'Reader'},
+  ]}
+  useCases={[
+    {id:'write', label:'Write a post', detail:'Draft in MDX, weave in components, run the validators.'},
+    {id:'publish', label:'Publish', detail:'Build the site and deploy it.'},
+    {id:'read', label:'Read a post'},
+    {id:'share', label:'Share a post', detail:'Copy a tagged link or post it out.'},
+  ]}
+  links={[
+    {from:'author', to:'write'},
+    {from:'author', to:'publish'},
+    {from:'reader', to:'read'},
+    {from:'reader', to:'share'},
+    {from:'publish', to:'write', type:'include'},
+    {from:'share', to:'read', type:'extend'},
+  ]}/>
+
+### "Which of these options should we pick?"
+
+That is a head-to-head choice, so it routes to the decision kit: a `<ComparisonMatrix>` for the
+scorecard and an `<Accordion>` for the narrative behind each option. Nothing about that intent is a
+flow, even though a first instinct might reach for one.
+
+<ComparisonMatrix title="Where to store the data" desc="Three stores weighed against what this project needs." legend
+  options={[
+    {id:'pg', label:'Postgres'},
+    {id:'sqlite', label:'SQLite', chosen:true},
+    {id:'file', label:'Flat files'},
+  ]}
+  criteria={[
+    {label:'Zero-ops', cells:{pg:'no', sqlite:'yes', file:'yes'}},
+    {label:'Queryable', cells:{pg:'yes', sqlite:'yes', file:'no'}},
+    {label:'Concurrent writes', cells:{pg:'yes', sqlite:'partial', file:'no'}},
+  ]}/>
+
+<Accordion label="Why SQLite won" items={[
+  {summary:'Postgres', verdict:'considered', body:<>Powerful and concurrent, but a server to run and back up. Overkill for a single-writer site.</>},
+  {summary:'SQLite', chosen:true, open:true, body:<>Zero-ops, queryable, durable, and free. One file, no server, plenty for one writer.</>},
+  {summary:'Flat files', verdict:'considered', body:<>Simplest of all, but nothing to query and no safe concurrent writes.</>},
+]}/>
+
+## Where the machinery lives
+
+The chooser decides and dispatches; it does not re-implement how each diagram gets drawn. That
+separation is the whole point, and I wrote it up as its own design: the inputs it takes, the
+interview that narrows them, and the routing table it ends on are documented in
+[the Choosing a Diagram design](/designs/design-choosing-a-diagram). If you want the reasoning
+behind why it is a chooser and not one long page, and why it routes instead of duplicating, that is
+the place to read it.
+
+This is the same throughline as the last couple of things I built here. When I
+[shipped the components as a package](/initiatives/shipping-a-component-package) and when I
+[turned my MindNode files into clickable maps](/initiatives/mindmaps-from-mindnode), the value was
+never the artifact on its own; it was the artifact becoming something I could actually reach for
+without friction. A pile of diagram types is the same: the diagrams were always drawable. What was
+missing was the small, honest act of choosing, made repeatable. Now the choice in front of me is no
+longer a dozen unlabeled doors.

--- a/bytesofpurpose-blog/designs/2026-07-07-choosing-a-diagram.mdx
+++ b/bytesofpurpose-blog/designs/2026-07-07-choosing-a-diagram.mdx
@@ -1,0 +1,162 @@
+---
+slug: design-choosing-a-diagram
+sidebar_label: Choosing a Diagram
+sidebar_position: 21
+title: 'Choosing a Diagram: A Chooser That Picks the Right Type'
+description: >-
+  A small tool that interviews you about what you are trying to show, picks the
+  one diagram type that fits, and hands off to the skill that authors it.
+authors:
+  - oeid
+tags:
+  - system-design
+  - tooling
+  - diagram
+  - claude
+kind: tooling-cli-design
+draft: true
+---
+
+# Choosing a Diagram: A Chooser That Picks the Right Type
+
+The person this is for is me on a blank page, and anyone else who writes with diagrams: someone
+who knows they want to SHOW something but stalls on which of a dozen diagram types to reach for.
+The pain is real and specific. This blog can draw a flow, a mind map, a use-case, a sequence, a
+state machine, a topology, a comparison, a board, and more, across mermaid and a set of custom
+components, and every one of them is a fine tool held wrong. What such a writer will do with this
+is answer two or three plain questions about their INTENT and get back the single best type,
+already handed to the skill that authors it. The payoff: they stop choosing tools and start
+showing the thing.
+
+<UseCaseDiagram title="Choosing a diagram" desc="Who uses the chooser and what they do with it."
+  actors={[
+    {id:'writer', label:'Writer', kind:'internal'},
+    {id:'reader', label:'Reader'},
+  ]}
+  useCases={[
+    {id:'ask', label:'State the intent', detail:'Answer what am I trying to show, not which tool.'},
+    {id:'pick', label:'Get the right type', detail:'The chooser routes the intent to one diagram type.'},
+    {id:'author', label:'Author it', detail:'Hand off to the skill that owns that type.'},
+    {id:'read', label:'Read a clear diagram', detail:'The reader meets the right picture for the idea.'},
+  ]}
+  links={[
+    {from:'writer', to:'ask'},
+    {from:'writer', to:'pick'},
+    {from:'writer', to:'author'},
+    {from:'reader', to:'read'},
+    {from:'pick', to:'ask', type:'include'},
+    {from:'author', to:'pick', type:'include'},
+  ]}/>
+
+:::note[Scope]
+This design defines **author-diagram**: a chooser that takes a writer's INTENT (what they are
+trying to show) as input, runs a short adaptive interview, and produces one thing as output: the
+single best diagram TYPE, handed to the skill that authors it. It decides and dispatches. It
+deliberately does NOT re-implement how each diagram is drawn; that lives in the skills it calls
+(author-mermaid for raw mermaid, upgrade-post for the components, import-mindnode and
+import-co-design for source artifacts).
+:::
+
+<!-- truncate -->
+
+## Why a chooser, and why now
+
+The blog grew a lot of ways to draw a diagram, and that is the problem. Guidance is scattered:
+one skill knows mermaid syntax, another catalogs the components, a third owns the MindNode import
+path. Nothing sits above them answering the only question a writer actually has at the start,
+which is not "how do I draw a flowchart" but "should this even BE a flowchart." A tool held wrong
+is worse than no tool: a sequence forced into a flow, a comparison crammed into a mind map, a
+topology drawn as a timeline. The cost of the wrong pick is a reader who has to work to understand
+a picture that was supposed to save them the work. So the missing piece was never another
+renderer. It was the wisdom of WHICH one, made repeatable.
+
+## The tool: inputs, transform, output
+
+The chooser is a small input-to-output transform, and the three parts map cleanly.
+
+**Input: the writer's intent.** Not a file, not a tool preference, a sentence about what they are
+trying to show. "How does a request get from the browser to the database." "How do these role
+ideas relate." "Which of three auth options should we pick." The very first question refuses to
+ask "which diagram do you want" and asks "what are you showing."
+
+**The transform: an adaptive interview that narrows to one type.** A first question sorts the
+intent into a family (movement, who-uses-what, a hierarchy, a choice, structure, a lifecycle, an
+interaction, topology, a board, a look, motion). A second question, chosen by the first answer,
+disambiguates within the family: is the movement a strict line, a loop, or a fork; do you want the
+hierarchy CLICKABLE and themed or a throwaway sketch; is the boundary a flow, a topology, or a
+use-case. A third question fires only if a source artifact changes the route (a MindNode file, a
+work-repo HLD, a Figma board each have their own importer). The interview stops the moment the
+type is settled, and it only asks when the answer is genuinely ambiguous.
+
+**Output: one type, handed to its owner.** The transform ends at a routing table whose every row
+names the diagram type, the way to author it, and the skill that owns those mechanics. The chooser
+never draws the diagram itself; it produces the decision and dispatches.
+
+Here is the transform as the writer experiences it, from the opening question to the type it lands
+on:
+
+<FlowDiagram title="Choosing a diagram" shape="branch"
+  desc="Start from what you are trying to show; the answer routes to one diagram type and the skill that owns it."
+  nodes={[
+    {id: 'q', label: 'What are you showing?'},
+    {id: 'move', label: 'Movement'},
+    {id: 'who', label: 'Who uses what'},
+    {id: 'tree', label: 'A hierarchy'},
+    {id: 'choice', label: 'A choice'},
+    {id: 'flow', label: 'FlowDiagram', detail: 'A directed flow: pipeline, loop, sequence, branch, or swimlane. Owned by upgrade-post.'},
+    {id: 'usecase', label: 'UseCaseDiagram', detail: 'Actors outside a boundary reaching the capabilities they use. Owned by upgrade-post.'},
+    {id: 'mindmap', label: 'MindMap', detail: 'A single-rooted hierarchy with clickable, themed nodes. Owned by upgrade-post and import-mindnode.'},
+    {id: 'matrix', label: 'ComparisonMatrix', detail: 'Options scored against criteria, the chosen column highlighted. Owned by upgrade-post.'},
+  ]}
+  edges={[
+    {from: 'q', to: 'move'},
+    {from: 'q', to: 'who'},
+    {from: 'q', to: 'tree'},
+    {from: 'q', to: 'choice'},
+    {from: 'move', to: 'flow'},
+    {from: 'who', to: 'usecase'},
+    {from: 'tree', to: 'mindmap'},
+    {from: 'choice', to: 'matrix'},
+  ]}
+/>
+
+The four families above are the common trunk; the full routing table carries the rest (a
+time-ordered interaction to a sequence diagram, data or type structure to ER or class, a lifecycle
+to a state machine, topology to architecture-beta, a board or git story or milestones or a 2x2 to
+their mermaid types, an existing artifact to its importer). Every leaf, common or rare, ends the
+same way: a named type and the skill that owns authoring it.
+
+## Key Decisions
+
+**A chooser skill, not one mega-document.** I could have written a single long "how to pick a
+diagram" page. I chose a skill with a router and per-type subfiles instead, because the decision is
+a PROCESS (ask, narrow, route) that a static page cannot run, and because the per-type detail wants
+to live next to the routing, not buried in prose. The router asks; each subfile is a short
+"you picked this, here is the snippet and the gotchas" checklist.
+
+**Route, do not duplicate.** The single most important constraint: the chooser names the owner and
+defers. It never restates how to draw a flowchart or wire a component, because the moment it does,
+two sources of truth drift apart. author-mermaid owns mermaid syntax; upgrade-post owns the
+components; the importers own the source-artifact paths. The chooser's whole value is the CHOICE,
+so that is all it holds.
+
+**An interview, not a lookup table the reader scans.** I chose an adaptive question flow over a
+big static "if you want X use Y" table because a writer at the blank page does not yet know which
+row they are on. The questions do the sorting for them, recommendation first, and stop the instant
+the type is settled. A table alone assumes the reader can already classify their own intent, which
+is exactly the skill they lack in the moment.
+
+**Intent first, tool never.** The opening question is deliberately "what are you showing," not
+"which diagram do you like." Anchoring on intent is what prevents the tool-held-wrong failure. It
+is a small wording choice with an outsized effect: it reframes the entire decision away from tool
+preference and toward the reader's need.
+
+## The reusable takeaway
+
+The pattern here is not specific to diagrams. Any time you accumulate many tools for one job, the
+scarce thing stops being another tool and becomes the wisdom of WHICH one, and that wisdom is worth
+making into its own artifact. A chooser that starts from intent, narrows with a few honest
+questions, and then gets out of the way by handing off, is a shape you can lift onto any decision
+where the hard part is not doing the work but knowing which work to do. The diagram gets drawn by
+the same skills as before. What changed is that the choice in front of it is no longer left to
+whoever happens to remember the whole taxonomy.

--- a/bytesofpurpose-blog/src/components/SplitFlap/index.tsx
+++ b/bytesofpurpose-blog/src/components/SplitFlap/index.tsx
@@ -41,6 +41,13 @@ export interface SplitFlapProps {
    * any instant only the column the scroll is impacting animates (no whole-board churn or cascade). */
   sweepFromText?: string;
   sweepProgress?: number;
+  /** ANCHOR WIDTH: center every message as if the longest possible message were this many chars wide,
+   * so EVERY message occupies the SAME fixed columns regardless of its own length. Without this, each
+   * title is centered on its own width, so changing between two different-length titles SHIFTS the
+   * shared letters sideways (they slide into a new centered position) instead of flipping in place.
+   * Pass the width of the widest message the board will ever show (e.g. the longest scene title) and
+   * every scene change becomes a pure per-column card-flip with no horizontal slide. */
+  anchorWidth?: number;
   /** DIRECT mode (timer mode only): each cell flips STRAIGHT to the target glyph in a single fold,
    * instead of rolling through the deck. Off by default (the hero keeps the deck roll). */
   direct?: boolean;
@@ -142,28 +149,33 @@ function wrapLines(text: string, columns: number): string[] {
 
 /** Word-wrap `text` into lines of at most `columns` chars (like a real board), then CENTER each line
  * within the board and pad so every row is exactly `columns` wide (blank filler tiles fill the rest).
- * Returns the grid as equal-length strings. Every message is centered on its OWN width, so short
- * titles (WELCOME) sit dead-center and long ones fill more of the row — a board WIDER than the longest
- * title leaves blank flap tiles flanking each centered title. */
-function wrapToGrid(text: string, columns: number): string[] {
+ * Returns the grid as equal-length strings. By default each message is centered on its OWN width. Pass
+ * `anchorWidth` (the widest message the board will ever show) to center every line as if it were that
+ * wide instead — so a short and a long message START at the SAME left column and shared letters flip in
+ * place across a message change rather than sliding sideways. */
+function wrapToGrid(text: string, columns: number, anchorWidth?: number): string[] {
   const lines = wrapLines(text, columns);
   return lines.map((l) => {
-    const left = Math.floor((columns - l.length) / 2);
+    const basis = Math.min(columns, Math.max(l.length, anchorWidth ?? l.length));
+    const left = Math.floor((columns - basis) / 2);
     return padInColumns(l, columns, left);
   });
 }
 
 /** SWEEP-mode grids: lay TWO texts on the SAME column grid so a column-wise splice between them is
  * coherent (the pickets board shows the destination left of the flip front + the from-text to its
- * right). Both are single-line, centered on the LONGER text's width and padded to the fixed row count,
- * so column i is the same slot in both. Returns `[toGrid, fromGrid]`. If either text wraps to more than
- * one line (longer than `columns`), falls back to the per-text `toGrid` centering (multi-line sweep is
- * not used by the hero; the scene titles are all single-line). */
+ * right). Both are single-line and padded to the fixed row count, so column i is the same slot in both.
+ * The centering basis is `anchorWidth` when given (the widest message across the WHOLE journey), which
+ * is what makes every crossing agree on one offset — otherwise centering on this pair's own max width
+ * makes a scene's letters JUMP between adjacent crossings (its offset differs by pair). Returns
+ * `[toGrid, fromGrid]`. If either text wraps to more than one line (longer than `columns`), falls back
+ * to per-text `toGrid` centering (multi-line sweep is not used by the hero; scene titles are single-line). */
 function toSharedGrid(
   toText: string,
   fromText: string,
   columns: number,
   fixedRows: number | undefined,
+  anchorWidth?: number,
 ): [string[], string[]] {
   const a = toText.toUpperCase();
   const b = fromText.toUpperCase();
@@ -175,9 +187,12 @@ function toSharedGrid(
   };
   // Multi-line (a title wider than the board) has no single shared offset — fall back per-text.
   if (a.length > columns || b.length > columns) {
-    return [pad(wrapToGrid(a, columns)), pad(wrapToGrid(b, columns))];
+    return [pad(wrapToGrid(a, columns, anchorWidth)), pad(wrapToGrid(b, columns, anchorWidth))];
   }
-  const left = Math.floor((columns - Math.max(a.length, b.length)) / 2);
+  // Center BOTH on the journey-wide anchor width (falls back to this pair's max if no anchor given), so
+  // column i is the same slot in every crossing and shared letters never slide between crossings.
+  const basis = Math.min(columns, Math.max(a.length, b.length, anchorWidth ?? 0));
+  const left = Math.floor((columns - basis) / 2);
   return [pad([padInColumns(a, columns, left)]), pad([padInColumns(b, columns, left)])];
 }
 
@@ -305,12 +320,14 @@ function SplitFlap({
   spinning,
   sweepFromText,
   sweepProgress,
+  anchorWidth,
   direct = false,
 }: SplitFlapProps): React.JSX.Element {
-  // Build the centered/padded GRID for a message.
+  // Build the centered/padded GRID for a message. `anchorWidth` (when set) centers every message on one
+  // fixed width so changing messages flips letters in place instead of sliding them to a new center.
   const toGrid = (s: string): string[] => {
     const upper = s.toUpperCase();
-    let g = columns ? wrapToGrid(upper, columns) : [upper];
+    let g = columns ? wrapToGrid(upper, columns, anchorWidth) : [upper];
     if (columns && fixedRows) {
       if (g.length > fixedRows) g = g.slice(0, fixedRows);
       const blank = ' '.repeat(columns);
@@ -336,7 +353,7 @@ function SplitFlap({
     // inter-word space ("EXPLORE MY" → "EXPLOREMY") or doubles a boundary letter. `toSharedGrid`
     // centers both on the LONGER title's width, so column i means the same slot in both and the swept
     // line reads as one continuous title with its spaces intact.
-    const [grid, fromGrid] = toSharedGrid(text, sweepFromText, columns, fixedRows);
+    const [grid, fromGrid] = toSharedGrid(text, sweepFromText, columns, fixedRows, anchorWidth);
     const p = Math.min(1, Math.max(0, sweepProgress));
     // Each row's lit span (union across from+to); the front walks these spans row-major.
     const spans = grid.map((row, r) => {

--- a/bytesofpurpose-blog/src/pages/index.tsx
+++ b/bytesofpurpose-blog/src/pages/index.tsx
@@ -425,6 +425,15 @@ const STUDIO_INTERVAL_MS = 4500; // time one state (door OR a scene) is shown be
 // flap tiles flanking the centered title (a real departure board's empty flaps).
 const STUDIO_BOARD_COLS = 24;
 const STUDIO_BOARD_ROWS = 3; // 3 rows of bigger letters (not 5 rows of small)
+// The WIDEST board message across the whole journey (every scene title + the door's WELCOME). The
+// pickets board centers EVERY message on this one width (SplitFlap `anchorWidth`) so each scene sits in
+// the SAME columns in every crossing. Without it, each title is centered on its own width, so a scene's
+// letters SLIDE sideways when you scroll from one crossing into the next (they re-center to a different
+// pair's max width) instead of flipping in place. Computed from the titles so it can never drift.
+const STUDIO_BOARD_ANCHOR_WIDTH = Math.max(
+  'WELCOME'.length,
+  ...CHOOSER_CARDS.map((c) => stripEmoji(c.title).length),
+);
 // The door↔scene WHITE FLASH: the centre arch flashes white (a long camera-exposure bloom); at the
 // flash PEAK the centre swaps door↔scene and the board flips; then the flash recedes. The flash
 // duration is MATCHED to the board roll (FLASH_SETTLE_MS) so the new scene + the settled board ARRIVE
@@ -1262,6 +1271,9 @@ function StudioFacade({
                     columns={boardCols}
                     rows={STUDIO_BOARD_ROWS}
                     settleMs={FLASH_SETTLE_MS}
+                    // PICKETS: anchor every message to the widest title so scenes sit in fixed columns
+                    // across crossings (no sideways slide on a scene change; letters flip in place).
+                    anchorWidth={picketed ? STUDIO_BOARD_ANCHOR_WIDTH : undefined}
                   />
                 </div>
               </div>

--- a/bytesofpurpose-blog/test/e2e/homepage.spec.ts
+++ b/bytesofpurpose-blog/test/e2e/homepage.spec.ts
@@ -747,6 +747,65 @@ test.describe('Homepage hero: scroll-driven parallax (variant C)', () => {
       return (b?.innerText || '').replace(/\s+/g, '').replace(/(.)\1/g, '$1');
     });
 
+  // The board's per-column string with LEADING SPACES preserved, plus the column the text starts at.
+  // (boardCollapsed strips spaces; this one keeps position so we can see a horizontal SHIFT.)
+  const boardLeftOffset = (page: Page) =>
+    page.evaluate(() => {
+      const row = [...document.querySelectorAll('[class*="studioSign"] [class*="row"]')]
+        .map((r) =>
+          [...r.querySelectorAll('[class*="cell"]')]
+            .map((c) => c.querySelector('[class*="glyph"]')?.textContent ?? ' ')
+            .join(''),
+        )
+        .find((s) => s.trim());
+      return row ? row.search(/\S/) : -1;
+    });
+
+  test('[pickets] a scene title occupies the SAME columns across crossings (letters flip, never slide)', async ({
+    page,
+  }) => {
+    // REGRESSION: each scene title was centered on its OWN width, so a title's letters SLID sideways
+    // when you scrolled from its settled zone into the next crossing (the two crossings re-centered on
+    // different pair-max widths). The user saw "sentences shifting left" instead of flipping in place.
+    // Fixed by anchoring every message to one journey-wide width (SplitFlap anchorWidth), so a given
+    // scene sits in the SAME start column everywhere. Assert that: the SAME title read at two scroll
+    // positions (its own settled zone, then just past it entering the next crossing) starts at the same
+    // column. A slide would show two different offsets.
+    await page.goto(heroUrl('pickets'), { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+
+    // scene 0 (DISCOVER MY CRAFT, 17 chars) settled zone, then the start of the CRAFT→JOURNEY crossing
+    // (JOURNEY is 19 chars — a DIFFERENT width, the case that used to shift).
+    await scrubTo(page, (1 + 0.1) / 8); // scene 0 settled
+    await page.waitForTimeout(500);
+    const settledText = await boardCollapsed(page);
+    const settledOffset = await boardLeftOffset(page);
+    expect(settledText, 'settled on scene 0 title').toBe('DISCOVERMYCRAFT');
+
+    // nudge to the very start of the next crossing, where CRAFT is still the fully-shown FROM text
+    await scrubTo(page, (1 + 0.75) / 8);
+    await page.waitForTimeout(500);
+    const crossingText = await boardCollapsed(page);
+    const crossingOffset = await boardLeftOffset(page);
+
+    // if CRAFT is still fully shown here, its start column MUST match the settled one (no slide)
+    if (crossingText === 'DISCOVERMYCRAFT') {
+      expect(
+        crossingOffset,
+        `CRAFT must start at the SAME column in both places (settled ${settledOffset}, crossing ${crossingOffset}) — a mismatch is the sideways slide`,
+      ).toBe(settledOffset);
+    }
+    // Regardless: every title shares ONE anchor offset, so scene 0's and the next scene's titles both
+    // start at the same column. Read scene 1's settled title and assert it shares scene 0's offset.
+    await scrubTo(page, (2 + 0.1) / 8); // scene 1 settled (DISCOVER MY JOURNEY, a different length)
+    await page.waitForTimeout(500);
+    const scene1Offset = await boardLeftOffset(page);
+    expect(
+      scene1Offset,
+      `different-length titles must share the anchor start column (scene0 ${settledOffset}, scene1 ${scene1Offset})`,
+    ).toBe(settledOffset);
+  });
+
   test('[pickets] the board FREEZES mid-crossing as a stable old/new MIX, and shows the TITLE when settled', async ({
     page,
   }) => {


### PR DESCRIPTION
Two commits on this branch:

## 1. `author-diagram` chooser skill (67d0c2e65)
A CHOOSER skill that decides WHICH diagram type (mermaid types + custom FlowDiagram / UseCaseDiagram / MindMap / DiagramWithFootnotes / ComparisonMatrix + Figma / Drawing / PlantUML / .mindnode embeds) fits what you're trying to show, via a short adaptive interview, then hands off to the skill that owns that type's mechanics. Plus a "Choosing a Diagram" write-up.

## 2. Pickets board no-slide fix (abda55d6e)
Scrolling into a new scene made the Vestaboard's letters shift LEFT instead of card-flipping in place. Root cause: each title was centered on its OWN width, so different-length titles occupied different columns, and the sweep re-centered per-crossing on each pair's max width — so a scene's letters jumped between adjacent crossings (DISCOVER MY CRAFT started at column 3 in WELCOME→CRAFT but column 2 in CRAFT→JOURNEY).

Fix: anchor every board message to one journey-wide width (`SplitFlap` `anchorWidth` = the widest scene title, computed from `CHOOSER_CARDS`). Every scene now sits in the SAME fixed columns everywhere; a scene change flips only the differing letters, no horizontal slide. Verified live: every title starts at column 1 (was 2-3).

Regression test `[pickets] a scene title occupies the SAME columns across crossings` — proven fail-before (settled 3 vs crossing 2 with the fix neutralized) / pass-after. Full board cluster + 6 pickets visual baselines green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)