### PR TITLE
Recover the career-development premium doc (never reached master)

### DIFF
--- a/bytesofpurpose-blog/docs/journey/career-development/README.mdx
+++ b/bytesofpurpose-blog/docs/journey/career-development/README.mdx
@@ -25,4 +25,4 @@ These posts contain personal application material, so the working details are **
 
 ## Worked examples
 
-- **[Director, Deployed Engineering (LangChain)](/career-development/langchain-director-deployed-engineering)** — JD analysis, evidence bank, and all three message drafts.
+- **[Director, Deployed Engineering (LangChain)](/career-development/langchain-director-deployed-engineering)**, JD analysis, evidence bank, and all three message drafts.

--- a/bytesofpurpose-blog/docs/journey/career-development/README.mdx
+++ b/bytesofpurpose-blog/docs/journey/career-development/README.mdx
@@ -1,0 +1,28 @@
+---
+slug: /career-development
+title: '🧭 Career Development'
+sidebar_label: '🧭 Career Development'
+sidebar_position: 0
+description: 'How I approach my own career: tailoring applications, crafting recruiter outreach, and the reusable language and checklists behind it. Premium worked examples per role.'
+authors: [oeid]
+tags: [career-development, overview]
+draft: false
+---
+
+# 🧭 Career Development
+
+The deliberate, behind-the-scenes work of steering my own career: analyzing a role,
+mapping my background to what it actually asks for, and crafting outreach that is sharp,
+honest, and in my own voice.
+
+Each role I target gets a single worked-example post that gathers everything in one place:
+the job analysis, an evidence bank mapped to the role's pillars, the honesty guardrails I
+hold myself to, and every draft of the message (with the reusable language and checklists
+behind them).
+
+These posts contain personal application material, so the working details are **premium**
+(sign in with LinkedIn to read the full breakdown).
+
+## Worked examples
+
+- **[Director, Deployed Engineering (LangChain)](/career-development/langchain-director-deployed-engineering)** — JD analysis, evidence bank, and all three message drafts.

--- a/bytesofpurpose-blog/docs/journey/career-development/_category_.json
+++ b/bytesofpurpose-blog/docs/journey/career-development/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "🧭 Career Development",
+  "position": 11
+}

--- a/bytesofpurpose-blog/docs/journey/career-development/langchain-director-deployed-engineering.mdx
+++ b/bytesofpurpose-blog/docs/journey/career-development/langchain-director-deployed-engineering.mdx
@@ -21,7 +21,7 @@ Everything below the fold is the working material itself, kept in one place so t
 
 ## The role
 
-**Director, Deployed Engineering — Central (LangChain)**
+**Director, Deployed Engineering, Central (LangChain)**
 
 - **Captured:** 2026-06-04
 - **Annual OTE:** $270k – $340k (base + variable + equity)
@@ -82,7 +82,7 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
 - **Amazon:** agentic AI in production (Driver Feedback), org-scale leadership by influence,
   experimentation rigor (Bar Raiser). (Scale + the bar.)
 
-### Pillar 1 — Achieve the technical win (customer-facing GTM)
+### Pillar 1: Achieve the technical win (customer-facing GTM)
 
 - **2020 Customer Hero Award:** unblocked negotiations with **5 Fortune 500 customers** via
   high-impact technical workshops that demonstrated platform value.
@@ -91,7 +91,7 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
 - Re-architected a GPU solution: **+536% throughput** (110→700 predictions/sec), cleared a
   **2-billion-image backlog** → contract renewal + 4 expansion deals.
 
-### Pillar 2 — Senior / executive stakeholder influence
+### Pillar 2: Senior / executive stakeholder influence
 
 - **Won a technical decision against ServiceNow's Chief AI Architect** when ServiceNow weighed
   consolidating onto an internal harness. Textbook technical win + exec influence.
@@ -99,10 +99,10 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
 - Technical authority for the ServiceNow Configuration Agent with internal stakeholders **and
   external partner Anthropic**.
 
-### Pillar 3 — Field insight → product roadmap (the deployed-engineering loop)
+### Pillar 3: Field insight → product roadmap (the deployed-engineering loop)
 
 - At CognitiveScale, **invented Profile-of-One**, the company's primary market differentiator.
-- **Three-in-one framing:** more than an SA — effectively the **director of Profile-of-One**
+- **Three-in-one framing:** more than an SA, effectively the **director of Profile-of-One**
   (invented it, owned its GTM strategy) *and* its **architect / sales engineer** (architected
   it to showcase value, ran customer POCs). Sharpest structural analog to this role: own the
   product/strategy *and* land the customer-facing technical win, on a developer AI platform.
@@ -111,7 +111,7 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
 - **Why the GTM claim is airtight:** drove alignment across **sales, marketing, product, and
   the C-suite (CEO, CTO, Chief Designer)** to position and take Profile-of-One to market.
 
-### Pillar 4 — Enablement / build the bench
+### Pillar 4: Enablement / build the bench
 
 - Authored **25+ reusable Spark queries** that became reference templates, saving **~150+
   engineer-weeks**.
@@ -119,13 +119,13 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
   prompts, used by **25+ engineers**; hosted learning sessions; incubated **10+ GenAI
   hackathon projects**.
 
-### Pillar 5 — Set & uphold the technical bar (rigor)
+### Pillar 5: Set & uphold the technical bar (rigor)
 
 - **Design & Experiment Bar Raiser** at Amazon: **200+ experiment design reviews** + **50+
   architecture reviews**; owned launch / no-launch / follow-on calls.
 - Built a **40+ story, SME-validated eval harness** that gated every ServiceNow agent release.
 
-### Pillar 6 — Leadership (by influence) + management-by-choice
+### Pillar 6: Leadership (by influence) + management-by-choice
 
 - Directed a **cross-functional team of 14** (10 engineers, 2 PM/Program, 2 SDMs); aligned
   **12+ teams across 3 orgs** and **100+ stakeholders**.
@@ -139,7 +139,7 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
   **anonymized, bidirectional feedback channel** he built), escalating staffing/resourcing,
   owning RAID logs, articulating timeline impact.
 
-### Pillar 7 — Build & deploy AI agents in production
+### Pillar 7: Build & deploy AI agents in production
 
 - **ServiceNow Configuration Agent (current):** led a small team to a **UAT-ready headless
   agent in 2 months**, on the **Claude Agent SDK**, integrated via **A2A** in AI Agent Studio,
@@ -186,7 +186,38 @@ the JD's pillars so the mapping stays visible. Distill *from* this; don't lose a
 **Subject:** Interest and Fit for the Director of Deployed Engineering Role
 *(alternates: "Director, Deployed Engineering: a strong fit" / "...: GTM + hands-on agents")*
 
-### Version B — the one I sent (disclaimer-first, ~215 words)
+### Version B: current best (disclaimer-first, ~235 words)
+
+The strongest cut. Surfaces technical strategy as its own pillar ("set technical strategy"),
+adds the current ServiceNow work, and closes by mirroring the JD's three core mandates
+(technical strategy, building/leading teams, owning business outcomes) tied to a CTO trajectory
+and an impact-forward ask, rather than "learn more" (so it reads as value added, not a learning
+opportunity for me). No em dashes; "influence" once; honest GTM/launch split; "user acceptance
+testing" instead of claiming production. Watch-out: "owning business outcomes" is defensible
+(deal influence, F500 wins/expansions) but invites a "what revenue number did you carry?"
+follow-up, since the role is peer to a sales leader with shared quota; be ready for it.
+
+Hi Janani,
+
+I came across the Director of Deployed Engineering role at LangChain. It's a strong match for what I do best, and I'd love to find the right person to talk to about it. If that's not you, a pointer would be much appreciated.
+
+In short, I am deeply technical, bring strong people and communication skills, and have a track record of leading strategic, ambiguous, cross-functional initiatives through influence across both startups and large organizations.
+
+At Amazon, I owned the design, experimentation, and launch strategy for an S-Team (C-suite) goal: bringing agentic customer-service support to a new line of business. I drove it by aligning engineering, product, and business across 12+ teams in 3 orgs and 100+ stakeholders.
+
+Earlier, across ~9 years in startups, I lived on the go-to-market side. At CognitiveScale I invented our enterprise AI development platform's flagship feature and owned its end-to-end GTM. I drove alignment across sales, marketing, product, and the exec team (CEO, CTO, Chief Designer). I also architected the solutions and customer POCs that proved its value, winning five Fortune 500 customers and expanding into follow-on deals.
+
+Today I'm leading a team building an agent to accelerate delivery at ServiceNow. In just two months, we implemented the agent from scratch, integrated it into ServiceNow's Agentic AI Ecosystem, and began user acceptance testing. More broadly, over the past two years I've been hands-on building agentic systems in production with LangChain, the OpenAI Agent SDK, Amazon Bedrock, the Strands SDK, and the Claude Agent SDK. I'm a builder at heart.
+
+Setting technical strategy, building and leading high-performing teams, and owning business outcomes is the work I most want to do formally next, as I pursue my longer-term goal of becoming a CTO. This role plays to my strengths and aligns with my objectives, and I'm confident I'd make an immediate impact. I'd welcome the chance to connect.
+
+Best,
+Omar
+
+### Version B-sent: what actually went to Janani (~215 words)
+
+The first touch sent to Janani. Differs from the current best above: warmer opener ("genuinely
+excited"), no ServiceNow paragraph, and a confidence (not management-intent) closer.
 
 Hi Janani,
 
@@ -198,19 +229,12 @@ At Amazon, I owned the design, experimentation, and launch strategy for an S-Tea
 
 Earlier, across ~9 years in startups, I lived on the go-to-market side. At CognitiveScale, I invented our flagship feature and owned its end-to-end GTM strategy, driving alignment across sales, marketing, product, and the executive team (CEO, CTO, and Chief Designer). I also architected the solutions and customer POCs that proved its value, winning five Fortune 500 customers and expanding into follow-on deals.
 
-Currently, I'm leading a small team building an agent to accelerate delivery at ServiceNow from zero to market. In just two months, we've built the agent and already begun UAT. More broadly, over the past two years I've been hands-on building agentic systems in production, working with LangChain, the OpenAI Agent SDK, Amazon Bedrock offerings, the Strands SDK, and the Claude Agent SDK. I'm deeply technical and a builder at heart.
-
 I'm confident I could bring real value here. I'd love to connect and learn more.
 
 Best,
 Omar
 
-> **Post-send revision:** the version actually sent to Janani did not include the ServiceNow
-> "current role" paragraph above. This revised paragraph is for the next role, a follow-up, or
-> reuse. Honesty check: "from zero to market" is stated as the goal, then grounded truthfully
-> with "already begun UAT" (the agent is UAT-ready, not yet in production).
-
-### Version A — full case (~330 words, "if they engage" / cover-letter seed)
+### Version A: full case (~330 words, "if they engage" / cover-letter seed)
 
 Hi Janani,
 
@@ -229,7 +253,7 @@ Could you point me in the right direction?
 Best,
 Omar
 
-### Version C — connection-request note (≤300 chars)
+### Version C: connection-request note (≤300 chars)
 
 Hi Janani, the Director, Deployed Engineering (Central) role really excites me. Not sure you're the right person, but if not I'd love a pointer. The blend it needs is mine: I lead teams, shape tech strategy, and build agents (first one on LangChain, now on the Claude Agent SDK). Would love to connect either way.
 

--- a/bytesofpurpose-blog/docs/journey/career-development/langchain-director-deployed-engineering.mdx
+++ b/bytesofpurpose-blog/docs/journey/career-development/langchain-director-deployed-engineering.mdx
@@ -1,0 +1,250 @@
+---
+slug: /career-development/langchain-director-deployed-engineering
+title: 'Targeting: Director, Deployed Engineering (LangChain)'
+description: 'How I tailored my outreach for a Director, Deployed Engineering role at LangChain: the job analysis, my evidence bank mapped to its pillars, and every draft of the recruiter message.'
+authors: [oeid]
+tags: [career-development, job-search, outreach]
+premium: true
+premium_teaser: 'A full worked example of tailoring an application to one role: the JD analysis, an evidence bank mapped to every pillar, honesty guardrails, and all three message drafts. Sign in with LinkedIn to read the rest.'
+draft: false
+---
+
+This is a complete, real worked example of how I prepare outreach for a single role:
+capturing and analyzing the job description, building an evidence bank that maps my
+background to each thing the role asks for, setting honesty guardrails so nothing
+overclaims, and iterating the recruiter message through several drafts and lengths.
+
+Everything below the fold is the working material itself, kept in one place so the whole
+"how the sausage gets made" is visible end to end.
+
+{/* Everything from here down is gated as premium via `premium: true` in frontmatter. */}
+
+## The role
+
+**Director, Deployed Engineering — Central (LangChain)**
+
+- **Captured:** 2026-06-04
+- **Annual OTE:** $270k – $340k (base + variable + equity)
+- **Reports to:** Global Head of Deployed Engineering
+- **Peer to:** Regional sales leader (shared ownership of outcomes)
+- **Location:** Central US (Chicago / Austin / Dallas / Minneapolis), remote
+- **Recruiter (confirmed):** Janani Siva, Talent @ LangChain ("Scaling High-Impact GTM Teams... I'm Hiring")
+
+### What the team does
+
+The Deployed Engineering team works directly with companies building and running AI agents
+in production, turning ideas and prototypes into systems teams can rely on. It is hands-on
+and highly technical, partnering with customer engineers across the full lifecycle, from
+pre-sales evaluations to post-deployment advisory work. The focus is achieving the technical
+win, co-designing agent architectures, and helping customers operate agents reliably at
+scale. Deployed Engineers sit at the intersection of engineering, product, and go-to-market.
+
+### What you'll do
+
+- Build and scale the deployed engineering team (hiring, onboarding, coaching, performance).
+- Achieve the technical win, driving urgency and focus with customers.
+- Partner with the regional sales leader, with shared accountability for revenue and success.
+- Lead technical strategy on the most strategic enterprise opportunities; engage senior
+  technical and business stakeholders to shape evaluations, architecture, and solution design.
+- Differentiate LangChain in competitive environments.
+- Set and uphold the technical bar; co-create global playbooks; develop future leaders.
+
+### What they're looking for
+
+- 10 years in sales engineering, solutions architecture, engineering, or similar
+  customer-facing technical roles at a dev tools / AI / infrastructure company.
+- Proven experience leading and scaling technical GTM teams.
+- Deep technical expertise (Python, software/platform engineering, solutions architecture).
+- Experience selling to developers and engineering-led buyers.
+- Leading complex enterprise engagements; building trust with senior stakeholders.
+- Exceptional communication and technical storytelling; influence executive audiences.
+- Bias for action, comfort with ambiguity, high bar for excellence.
+- **Bonus:** genAI / agents / observability / open source; early startup GTM org experience.
+
+> ⚠️ JD inconsistency: the posting's body says "East region" once on a Central-titled role.
+> Copy-paste typo; Austin is squarely Central, so ignore it.
+
+---
+
+## Evidence bank (mapped to the role's pillars)
+
+Raw material for tailoring the message, exec summary, and interview answers. Organized by
+the JD's pillars so the mapping stays visible. Distill *from* this; don't lose anything
+*into* the summary. Numbers are from the 2026-05/06 resume unless flagged.
+
+### The source stories
+
+- **ServiceNow (Principal AI Architect, current):** built and productionized a UAT-ready
+  agentic system; won the technical decision against an internal harness; external-partner
+  authority with Anthropic. (LangChain's exact thesis + technical-win motion.)
+- **CognitiveScale:** customer-facing technical wins, F500 C-suite POCs, field-to-product
+  loop, and a three-in-one role (de facto director + architect + sales engineer). (The GTM motion.)
+- **Amazon:** agentic AI in production (Driver Feedback), org-scale leadership by influence,
+  experimentation rigor (Bar Raiser). (Scale + the bar.)
+
+### Pillar 1 — Achieve the technical win (customer-facing GTM)
+
+- **2020 Customer Hero Award:** unblocked negotiations with **5 Fortune 500 customers** via
+  high-impact technical workshops that demonstrated platform value.
+- Drove first F500 customer (**Barclays Wealth**) + **4 follow-on engagements** via an AI/ML
+  **POC delivered to their C-suite in 9 weeks**.
+- Re-architected a GPU solution: **+536% throughput** (110→700 predictions/sec), cleared a
+  **2-billion-image backlog** → contract renewal + 4 expansion deals.
+
+### Pillar 2 — Senior / executive stakeholder influence
+
+- **Won a technical decision against ServiceNow's Chief AI Architect** when ServiceNow weighed
+  consolidating onto an internal harness. Textbook technical win + exec influence.
+- Delivered an AI/ML POC to **Barclays Wealth's C-suite**.
+- Technical authority for the ServiceNow Configuration Agent with internal stakeholders **and
+  external partner Anthropic**.
+
+### Pillar 3 — Field insight → product roadmap (the deployed-engineering loop)
+
+- At CognitiveScale, **invented Profile-of-One**, the company's primary market differentiator.
+- **Three-in-one framing:** more than an SA — effectively the **director of Profile-of-One**
+  (invented it, owned its GTM strategy) *and* its **architect / sales engineer** (architected
+  it to showcase value, ran customer POCs). Sharpest structural analog to this role: own the
+  product/strategy *and* land the customer-facing technical win, on a developer AI platform.
+  (Honesty: "effectively / de facto" director, not the title. CognitiveScale separately
+  *offered* him the actual Director title for this product; he declined to join Amazon.)
+- **Why the GTM claim is airtight:** drove alignment across **sales, marketing, product, and
+  the C-suite (CEO, CTO, Chief Designer)** to position and take Profile-of-One to market.
+
+### Pillar 4 — Enablement / build the bench
+
+- Authored **25+ reusable Spark queries** that became reference templates, saving **~150+
+  engineer-weeks**.
+- **Pioneered GenAI adoption** org-wide: a **central MCP server** with custom tools + shared
+  prompts, used by **25+ engineers**; hosted learning sessions; incubated **10+ GenAI
+  hackathon projects**.
+
+### Pillar 5 — Set & uphold the technical bar (rigor)
+
+- **Design & Experiment Bar Raiser** at Amazon: **200+ experiment design reviews** + **50+
+  architecture reviews**; owned launch / no-launch / follow-on calls.
+- Built a **40+ story, SME-validated eval harness** that gated every ServiceNow agent release.
+
+### Pillar 6 — Leadership (by influence) + management-by-choice
+
+- Directed a **cross-functional team of 14** (10 engineers, 2 PM/Program, 2 SDMs); aligned
+  **12+ teams across 3 orgs** and **100+ stakeholders**.
+- Led data strategy/architecture for **3+ large orgs**; defined the director-level metric an
+  org was measured by.
+- **Management-by-choice narrative (the highest-leverage objection reframe):** offered
+  management and director roles multiple times (incl. a Director seat at CognitiveScale to
+  direct Profile-of-One) and declined for personal reasons, never for lack of capability.
+  Did the substance without the title: coaching/mentoring, a **monthly forum consolidating
+  40+ engineers** across a large Amazon org to improve the employee experience (with an
+  **anonymized, bidirectional feedback channel** he built), escalating staffing/resourcing,
+  owning RAID logs, articulating timeline impact.
+
+### Pillar 7 — Build & deploy AI agents in production
+
+- **ServiceNow Configuration Agent (current):** led a small team to a **UAT-ready headless
+  agent in 2 months**, on the **Claude Agent SDK**, integrated via **A2A** in AI Agent Studio,
+  with an **MCP server** for safe validated deploys. Built for **150+ concurrent executions**
+  (~2M stories/year across 4,000 projects), **40+ story eval harness**, every turn under
+  ServiceNow's **5-min timeout**, **token use halved**, cost **$10 → $5 per story**.
+- **Driver Feedback (Amazon, in production):** architected the experience in Amazon's Customer
+  Service Agentic AI Stack → **75%+ fewer driver-related contacts**, **1M+ annual interactions
+  eliminated**.
+- Two-year agent-building breadth: **LangChain** (first agent), Amazon's customer-service
+  harness, **Bedrock**, **AgentCore/Strands**, **Claude Agent SDK**, **OpenAI Agent SDK**,
+  plus **MCP servers**, RAG, graphs, **Langfuse tracing**, and **custom evals**.
+
+### Quantified bench
+
+- TB-scale pipeline re-architecture: **$2.5M/year savings**, **98% fresher data** (24h→5m).
+- 25+ big-data analyses shaping 10+ A/B tests → **$100M+ forecasted revenue**.
+- Owned a Tier-1 Digital Fulfillment Service at **250+ TPS**. 13+ years across software, data, AI.
+
+### Honesty guardrails (carry into every draft)
+
+- ❌ "I've lived this exact role" → ✅ "At CognitiveScale I effectively did the director +
+  architect/sales-engineer work this role blends." (More than an SA, but not the title.)
+- ❌ "managed a team" (title) → ✅ "led through influence; did the substance of management."
+- ❌ ServiceNow agent "in production" → ✅ "UAT-ready, built to scale." (Driver Feedback is the
+  in-production agent.)
+- ❌ "GTM strategy" for the **Amazon** S-Team work → ✅ "design, experimentation, and launch
+  strategy" (internal rollout + experiment dial-up, not market-facing GTM). Reserve "GTM
+  strategy" for **CognitiveScale**.
+- **Use "influence" once.** Let team/stakeholder counts show it elsewhere.
+- **Agent-stack list:** keep only frameworks defensible in a screen with a real thing built.
+
+> An experiment dial-up plan (ramp %, guardrails, kill criteria) is **launch/rollout
+> strategy**, not **GTM strategy**. GTM is market-facing: positioning, pricing, channel,
+> sales/marketing motion. Keep the two straight.
+
+---
+
+## The message (drafts and lengths)
+
+> **Style rule: NO em dashes or en dashes anywhere** (they read as AI-written). Use periods,
+> commas, parentheses, and "and." Keep the voice human and in my real cadence.
+
+**Subject:** Interest and Fit for the Director of Deployed Engineering Role
+*(alternates: "Director, Deployed Engineering: a strong fit" / "...: GTM + hands-on agents")*
+
+### Version B — the one I sent (disclaimer-first, ~215 words)
+
+Hi Janani,
+
+I came across the Director of Deployed Engineering role at LangChain and it genuinely excited me! It's the kind of role I feel built for. I'm not sure whether you're the right person to connect with about it. If you are, great! If not, I'd appreciate a pointer to whoever is.
+
+In short, I bring a rare combination this role calls for: deep technical credibility, strong people and communication skills, and a track record of leading complex, cross-functional initiatives through influence across both startups and large organizations.
+
+At Amazon, I owned the design, experimentation, and launch strategy for an S-Team (C-suite) goal: bringing agentic customer-service support to a new line of business. I drove this effort by aligning engineering, product, and business across 12+ teams in 3 different orgs and more than 100 stakeholders.
+
+Earlier, across ~9 years in startups, I lived on the go-to-market side. At CognitiveScale, I invented our flagship feature and owned its end-to-end GTM strategy, driving alignment across sales, marketing, product, and the executive team (CEO, CTO, and Chief Designer). I also architected the solutions and customer POCs that proved its value, winning five Fortune 500 customers and expanding into follow-on deals.
+
+Currently, I'm leading a small team building an agent to accelerate delivery at ServiceNow from zero to market. In just two months, we've built the agent and already begun UAT. More broadly, over the past two years I've been hands-on building agentic systems in production, working with LangChain, the OpenAI Agent SDK, Amazon Bedrock offerings, the Strands SDK, and the Claude Agent SDK. I'm deeply technical and a builder at heart.
+
+I'm confident I could bring real value here. I'd love to connect and learn more.
+
+Best,
+Omar
+
+> **Post-send revision:** the version actually sent to Janani did not include the ServiceNow
+> "current role" paragraph above. This revised paragraph is for the next role, a follow-up, or
+> reuse. Honesty check: "from zero to market" is stated as the goal, then grounded truthfully
+> with "already begun UAT" (the agent is UAT-ready, not yet in production).
+
+### Version A — full case (~330 words, "if they engage" / cover-letter seed)
+
+Hi Janani,
+
+I came across LangChain's Director, Deployed Engineering (Central) role and wanted to reach out, though I'm not sure if you're the one staffing it. If not, I'd appreciate a pointer to whoever is.
+
+I think I'm a strong fit. This role is about building and leading a team of deployed engineers, and I bring three things it calls for.
+
+**Leadership and people.** I've been offered management and director roles several times, including a Director position at CognitiveScale to lead the very product I invented, and declined only for personal reasons, never for lack of capability or interest. Without the title, I've done the work: coaching and mentoring engineers, running a monthly forum that brought 40+ engineers across a large Amazon org together to improve the employee experience (with an anonymized, bidirectional feedback channel I built), escalating staffing and resourcing issues, owning RAID logs, and articulating impact on timelines. I directed a cross-functional team of 14 and set the technical bar through 50+ architecture reviews. I know what it takes to lead a team, and connecting with and growing people is the part I love most.
+
+**Owning strategy and the customer win.** At Amazon, I owned the launch and experimentation strategy for an S-Team (C-suite) goal: bringing agentic customer-service support to a new line of business, aligning 12+ teams and more than 100 stakeholders. Earlier, at CognitiveScale (an AI platform for building and deploying enterprise AI apps), I invented our flagship feature and owned its end-to-end GTM strategy, driving alignment across sales, marketing, product, and the executive team (CEO, CTO, and Chief Designer). I architected the solutions and customer POCs that proved its value, winning five Fortune 500 customers, expanding into follow-on deals, and earning the 2020 Customer Hero Award.
+
+**Deep agent depth.** Currently, I'm leading a small team building an agent to accelerate delivery at ServiceNow from zero to market; in just two months we've built it and already begun UAT. More broadly, over the past two years I've been hands-on building agentic systems in production, working with LangChain, the OpenAI Agent SDK, Amazon Bedrock offerings, the Strands SDK, and the Claude Agent SDK, plus MCP servers, RAG, and custom evals. I'm deeply technical and a builder at heart.
+
+Could you point me in the right direction?
+
+Best,
+Omar
+
+### Version C — connection-request note (≤300 chars)
+
+Hi Janani, the Director, Deployed Engineering (Central) role really excites me. Not sure you're the right person, but if not I'd love a pointer. The blend it needs is mine: I lead teams, shape tech strategy, and build agents (first one on LangChain, now on the Claude Agent SDK). Would love to connect either way.
+
+---
+
+## Final-pass checklist (run before sending any outreach)
+
+- **No em or en dashes** anywhere (the #1 AI tell). Periods, commas, parentheses, "and".
+- Avoid AI-register words: delve, tapestry, moreover, reflexive "not only... but also",
+  every list a tidy tricolon. Match my real cadence.
+- **Honesty:** de-facto vs titled; led-through-influence vs managed; UAT-ready vs in-production;
+  Amazon = launch/experimentation strategy, CognitiveScale = GTM strategy; only defensible stacks.
+- **Reframe the objection:** management-by-choice (offered the title, declined, did the substance).
+- **Structure:** the stated blend maps 1:1 to the body; excitement opens, conviction closes
+  (don't bookend the same phrase).
+- **Length:** short InMail target; connection note under 300 chars; no repeated phrases.
+- **Spelling/grammar pass.** Fill in the recipient's name. Confirm each named framework is
+  screen-defensible.


### PR DESCRIPTION
## What

Recovers a real, unshipped premium doc found during a branch-cleanup audit. The source never reached master (only stale `build/` HTML artifacts remained); it lived only on the 205-commits-behind `add-career-development-premium` branch, with further refinements sitting in a git stash.

- **`docs/journey/career-development/README.mdx`** + `_category_.json` — the section landing.
- **`langchain-director-deployed-engineering.mdx`** (~290 lines, `premium: true`) — a complete worked example of tailoring outreach for a Director, Deployed Engineering role at LangChain: the JD analysis, an evidence bank mapped to every pillar, honesty guardrails, and all message drafts (Version A/B/C + the version actually sent).

## How it was recovered
1. Base doc applied from the stale branch onto **current** master (not the old fork).
2. The stash's **career-doc refinement** (the Version B "current best" message + variants) applied on top.
3. All em-dashes converted to the repo convention (colons in headings, commas inline) so it passes the blocking em-dash hook.

Deliberately **excluded** from the stash: unfinished `ISSUES.md` placeholder rows (`_(set key)_` stubs) and an `MDXComponents` `SvgVariantGrid` registration (unrelated to this doc; needs its own verification).

## Verification
- `make check`: all 516 MDX files compile.
- Em-dash clean (both files).
- `premium: true` + `draft: false` (valid premium combo, not the mutually-exclusive premium+draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRtyLha5c6gN3VJ6cEqRPu